### PR TITLE
report http writer and request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .DS_Store
 *.iml
+orchestrion

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 .PHONY: build generate vet test clean fmt
 
-build: generate test
+build: generate test build-only
+
+build-only:
 	go build ./cmd/orchestrion
 
 build-linux-x64: generate test

--- a/cmd/samples/client/main.go
+++ b/cmd/samples/client/main.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/datadog/orchestrion"
 )
 
 func main() {
@@ -17,9 +19,16 @@ func main() {
 	client := &http.Client{
 		Timeout: time.Second,
 	}
+	//dd:instrumented
 	req, err := http.NewRequestWithContext(context.Background(),
 		http.MethodPost, "http://localhost:8080",
 		strings.NewReader(os.Args[1]))
+	//dd:startinstrument
+	if req != nil {
+		orchestrion.ReportHTTPCall(req, orchestrion.EventCall, "name", req.URL, "verb", req.Method)
+		defer orchestrion.ReportHTTPCall(req, orchestrion.EventReturn, "name", req.URL, "verb", req.Method)
+	}
+	//dd:endinstrument
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/samples/server/main.go
+++ b/cmd/samples/server/main.go
@@ -18,6 +18,10 @@ func main() {
 
 // myHandler comment on function
 func myHandler(w http.ResponseWriter, r *http.Request) {
+	//dd:startinstrument
+	orchestrion.ReportHTTPServe(w, r, orchestrion.EventStart, "name", "myHandler", "verb", r.Method)
+	defer orchestrion.ReportHTTPServe(w, r, orchestrion.EventEnd, "name", "myHandler", "verb", r.Method)
+	//dd:endinstrument
 	b, err := io.ReadAll(r.Body)
 	// test comment in function
 	if err != nil {
@@ -32,9 +36,8 @@ func myHandler(w http.ResponseWriter, r *http.Request) {
 
 func instrumentedHandler(w http.ResponseWriter, r *http.Request) {
 	//dd:startinstrument
-	r = orchestrion.HandleHeader(r)
-	orchestrion.Report(r.Context(), orchestrion.EventStart, "name", "instrumentedHandler", "verb", r.Method)
-	defer orchestrion.Report(r.Context(), orchestrion.EventEnd, "name", "instrumentedHandler", "verb", r.Method)
+	orchestrion.ReportHTTPServe(w, r, orchestrion.EventStart, "name", "instrumentedHandler", "verb", r.Method)
+	defer orchestrion.ReportHTTPServe(w, r, orchestrion.EventEnd, "name", "instrumentedHandler", "verb", r.Method)
 	//dd:endinstrument
 	b, err := io.ReadAll(r.Body)
 	// test comment in function

--- a/cmd/samples/server/other_handlers.go
+++ b/cmd/samples/server/other_handlers.go
@@ -8,20 +8,34 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/datadog/orchestrion"
 )
 
 type Foo struct{}
 
 func (f Foo) FooHandler(rw http.ResponseWriter, req *http.Request) {
+	//dd:startinstrument
+	orchestrion.ReportHTTPServe(rw, req, orchestrion.EventStart, "name", "FooHandler", "verb", req.Method)
+	defer orchestrion.ReportHTTPServe(rw, req, orchestrion.EventEnd, "name", "FooHandler", "verb", req.Method)
+	//dd:endinstrument
 	rw.WriteHeader(http.StatusOK)
 	rw.Write([]byte("Foo!"))
 }
 
 func buildHandlers() {
 	http.HandleFunc("/foo/bar", func(writer http.ResponseWriter, request *http.Request) {
+		//dd:startinstrument
+		orchestrion.ReportHTTPServe(writer, request, orchestrion.EventStart, "name", "/foo/bar", "verb", request.Method)
+		defer orchestrion.ReportHTTPServe(writer, request, orchestrion.EventEnd, "name", "/foo/bar", "verb", request.Method)
+		//dd:endinstrument
 		writer.Write([]byte("done!"))
 	})
 	v := func(w http.ResponseWriter, r *http.Request) {
+		//dd:startinstrument
+		orchestrion.ReportHTTPServe(w, r, orchestrion.EventStart, "name", "v", "verb", r.Method)
+		defer orchestrion.ReportHTTPServe(w, r, orchestrion.EventEnd, "name", "v", "verb", r.Method)
+		//dd:endinstrument
 		w.Write([]byte("another one!"))
 	}
 
@@ -33,6 +47,10 @@ func buildHandlers() {
 
 	x := holder{
 		f: func(w http.ResponseWriter, request *http.Request) {
+			//dd:startinstrument
+			orchestrion.ReportHTTPServe(w, request, orchestrion.EventStart, "name", "f", "verb", request.Method)
+			defer orchestrion.ReportHTTPServe(w, request, orchestrion.EventEnd, "name", "f", "verb", request.Method)
+			//dd:endinstrument
 			w.Write([]byte("asdf"))
 		},
 	}
@@ -41,10 +59,21 @@ func buildHandlers() {
 
 	// silly legal things
 	func(w http.ResponseWriter, r *http.Request) {
+		//dd:startinstrument
+		orchestrion.ReportHTTPServe(w, r, orchestrion.EventStart, "name", "anon", "verb", r.Method)
+		defer orchestrion.ReportHTTPServe(w, r, orchestrion.EventEnd, "name", "anon", "verb", r.Method)
+		//dd:endinstrument
 		client := &http.Client{
 			Timeout: time.Second,
 		}
+		//dd:instrumented
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "localhost:8080", strings.NewReader(os.Args[1]))
+		//dd:startinstrument
+		if req != nil {
+			orchestrion.ReportHTTPCall(req, orchestrion.EventCall, "name", req.URL, "verb", req.Method)
+			defer orchestrion.ReportHTTPCall(req, orchestrion.EventReturn, "name", req.URL, "verb", req.Method)
+		}
+		//dd:endinstrument
 		if err != nil {
 			panic(err)
 		}
@@ -58,22 +87,38 @@ func buildHandlers() {
 
 	for i := 0; i < 10; i++ {
 		go func(w http.ResponseWriter, r *http.Request) {
+			//dd:startinstrument
+			orchestrion.ReportHTTPServe(w, r, orchestrion.EventStart, "name", "anon", "verb", r.Method)
+			defer orchestrion.ReportHTTPServe(w, r, orchestrion.EventEnd, "name", "anon", "verb", r.Method)
+			//dd:endinstrument
 			w.Write([]byte("goroutine!"))
 		}(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
 	}
 
 	defer func(w http.ResponseWriter, r *http.Request) {
+		//dd:startinstrument
+		orchestrion.ReportHTTPServe(w, r, orchestrion.EventStart, "name", "anon", "verb", r.Method)
+		defer orchestrion.ReportHTTPServe(w, r, orchestrion.EventEnd, "name", "anon", "verb", r.Method)
+		//dd:endinstrument
 		w.Write([]byte("goroutine!"))
 	}(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
 }
 
 //dd:span foo:bar type:potato
 func MyFunc(ctx context.Context, name string) {
+	//dd:startinstrument
+	orchestrion.Report(ctx, orchestrion.EventStart, "name", "MyFunc", "foo", "bar", "type", "potato")
+	defer orchestrion.Report(ctx, orchestrion.EventEnd, "name", "MyFunc", "foo", "bar", "type", "potato")
+	//dd:endinstrument
 	fmt.Println(name)
 }
 
 //dd:span foo2:bar2 type:request
 func MyFunc2(name string, req *http.Request) {
+	//dd:startinstrument
+	orchestrion.Report(req.Context(), orchestrion.EventStart, "name", "MyFunc2", "foo2", "bar2", "type", "request")
+	defer orchestrion.Report(req.Context(), orchestrion.EventEnd, "name", "MyFunc2", "foo2", "bar2", "type", "request")
+	//dd:endinstrument
 	fmt.Println(name)
 }
 


### PR DESCRIPTION
Report enough HTTP data to integrate with dd-trace-go

Motivation: AIT-6942
- Server-side tracing requires both the response writer and the request objects ([here](https://github.com/DataDog/dd-trace-go/blob/d3d375c80cb4304088da96fec29699dfa7e4710f/contrib/net/http/trace.go#L55-L61))
- Client-side tracing requires the request object ([here](https://github.com/DataDog/dd-trace-go/blob/d3d375c80cb4304088da96fec29699dfa7e4710f/contrib/net/http/roundtripper.go#L29-L51))