### PR TITLE
Wrap mux handlers

### DIFF
--- a/cmd/samples/server/other_handlers.go
+++ b/cmd/samples/server/other_handlers.go
@@ -86,6 +86,23 @@ func MyFunc3(name string) {
 
 func registerHandlers() {
 	handler := http.HandlerFunc(myHandler)
+	http.Handle("/handle-1", handler)
+	http.Handle("/hundle-2", http.HandlerFunc(myHandler))
+	http.Handle("/hundle-3", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	http.HandleFunc("/handlefunc-1", handler)
+	http.HandleFunc("/handlefunc-2", http.HandlerFunc(myHandler))
+	http.HandleFunc("/handlefunc-3", func(w http.ResponseWriter, r *http.Request) {})
+	s := http.NewServeMux()
+	s.Handle("/handle-mux", handler)
+	s.Handle("/handle-mux", http.HandlerFunc(myHandler))
+	s.Handle("/handle-mux", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	s.HandleFunc("/handlefunc-1", handler)
+	s.HandleFunc("/handlefunc-2", http.HandlerFunc(myHandler))
+	s.HandleFunc("/handlefunc-3", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func instrumentedRegisterHandlers() {
+	handler := http.HandlerFunc(myHandler)
 	//dd:startinstrument
 	http.Handle("/handle-1", orchestrion.WrapHandler(handler))
 	//dd:endinstrument
@@ -103,5 +120,24 @@ func registerHandlers() {
 	//dd:endinstrument
 	//dd:startinstrument
 	http.HandleFunc("/handlefunc-3", orchestrion.WrapHandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	//dd:endinstrument
+	s := http.NewServeMux()
+	//dd:startinstrument
+	s.Handle("/handle-mux", orchestrion.WrapHandler(handler))
+	//dd:endinstrument
+	//dd:startinstrument
+	s.Handle("/handle-mux", orchestrion.WrapHandler(http.HandlerFunc(myHandler)))
+	//dd:endinstrument
+	//dd:startinstrument
+	s.Handle("/handle-mux", orchestrion.WrapHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
+	//dd:endinstrument
+	//dd:startinstrument
+	s.HandleFunc("/handlefunc-1", orchestrion.WrapHandlerFunc(handler))
+	//dd:endinstrument
+	//dd:startinstrument
+	s.HandleFunc("/handlefunc-2", orchestrion.WrapHandlerFunc(http.HandlerFunc(myHandler)))
+	//dd:endinstrument
+	//dd:startinstrument
+	s.HandleFunc("/handlefunc-3", orchestrion.WrapHandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	//dd:endinstrument
 }

--- a/dst_test.go
+++ b/dst_test.go
@@ -16,6 +16,8 @@ import (
 	"net/http"
 )
 
+var s http.ServeMux
+
 func register() {
 	%s
 }
@@ -27,6 +29,8 @@ import (
 
 	"github.com/datadog/orchestrion"
 )
+
+var s http.ServeMux
 
 func register() {
 	//dd:startinstrument
@@ -44,6 +48,12 @@ func register() {
 		{in: `http.HandleFunc("/handle", handler)`, want: `http.HandleFunc("/handle", orchestrion.WrapHandlerFunc(handler))`},
 		{in: `http.HandleFunc("/handle", http.HandlerFunc(myHandler))`, want: `http.HandleFunc("/handle", orchestrion.WrapHandlerFunc(http.HandlerFunc(myHandler)))`},
 		{in: `http.HandleFunc("/handle", func(w http.ResponseWriter, r *http.Request) {})`, want: `http.HandleFunc("/handle", orchestrion.WrapHandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))`},
+		{in: `s.Handle("/handle", handler)`, want: `s.Handle("/handle", orchestrion.WrapHandler(handler))`},
+		{in: `s.Handle("/handle", http.HandlerFunc(myHandler))`, want: `s.Handle("/handle", orchestrion.WrapHandler(http.HandlerFunc(myHandler)))`},
+		{in: `s.Handle("/handle",http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))`, want: `s.Handle("/handle", orchestrion.WrapHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))`},
+		{in: `s.HandleFunc("/handle", handler)`, want: `s.HandleFunc("/handle", orchestrion.WrapHandlerFunc(handler))`},
+		{in: `s.HandleFunc("/handle", http.HandlerFunc(myHandler))`, want: `s.HandleFunc("/handle", orchestrion.WrapHandlerFunc(http.HandlerFunc(myHandler)))`},
+		{in: `s.HandleFunc("/handle", func(w http.ResponseWriter, r *http.Request) {})`, want: `s.HandleFunc("/handle", orchestrion.WrapHandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))`},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This commit extends the handlers wrapping logic and supports detecting and wrapping the handler passed to the mux `Handle` and `HandleFunc` methods.