### PR TITLE
Seperate the http instrumentation techniques via a httpmode flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,25 @@
+package orchestrion
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Config holds the instrumentation config
+type Config struct {
+	// HTTPMode controls the technique used for HTTP instrumentation
+	// The possible values are "wrap", "report"
+	HTTPMode string
+}
+
+var defaultConf = Config{HTTPMode: "wrap"}
+
+func (c *Config) Validate() error {
+	c.HTTPMode = strings.ToLower(c.HTTPMode)
+	switch c.HTTPMode {
+	case "wrap", "report":
+		return nil
+	default:
+		return fmt.Errorf("invalid httpmode %q, the supported values are wrap or report", c.HTTPMode)
+	}
+}

--- a/orchestrion_test.go
+++ b/orchestrion_test.go
@@ -12,7 +12,7 @@ func TestScanPackageDST(t *testing.T) {
 	output := func(fullName string, out io.Reader) {
 		io.ReadAll(out)
 	}
-	ProcessPackage("./cmd/samples", InstrumentFile, output)
+	ProcessPackage("./cmd/samples", InstrumentFile, output, defaultConf)
 }
 
 func TestReport(t *testing.T) {

--- a/testdata/http_in.go
+++ b/testdata/http_in.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	s := http.NewServeMux()
+	s.HandleFunc("/handle", myHandler)
+}
+
+func myHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	defer r.Body.Close()
+	w.WriteHeader(http.StatusOK)
+	w.Write(b)
+}
+
+func myClient() {
+	client := &http.Client{
+		Timeout: time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, "http://localhost:8080",
+		strings.NewReader(os.Args[1]))
+	if err != nil {
+		panic(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+}

--- a/testdata/http_reported.go
+++ b/testdata/http_reported.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/datadog/orchestrion"
+)
+
+func main() {
+	//dd:startinstrument
+	defer orchestrion.Init()()
+	//dd:endinstrument
+	s := http.NewServeMux()
+	s.HandleFunc("/handle", myHandler)
+}
+
+func myHandler(w http.ResponseWriter, r *http.Request) {
+	//dd:startinstrument
+	r = r.WithContext(orchestrion.Report(r.Context(), orchestrion.EventStart, "name", "myHandler", "verb", r.Method))
+	defer orchestrion.Report(r.Context(), orchestrion.EventEnd, "name", "myHandler", "verb", r.Method)
+	//dd:endinstrument
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	defer r.Body.Close()
+	w.WriteHeader(http.StatusOK)
+	w.Write(b)
+}
+
+func myClient() {
+	client := &http.Client{
+		Timeout: time.Second,
+	}
+	//dd:instrumented
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, "http://localhost:8080",
+		strings.NewReader(os.Args[1]))
+	//dd:startinstrument
+	if req != nil {
+		req = orchestrion.InsertHeader(req)
+		req = req.WithContext(orchestrion.Report(req.Context(), orchestrion.EventCall, "name", req.URL, "verb", req.Method))
+		defer orchestrion.Report(req.Context(), orchestrion.EventReturn, "name", req.URL, "verb", req.Method)
+	}
+	//dd:endinstrument
+	if err != nil {
+		panic(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+}

--- a/testdata/http_wrapped.go
+++ b/testdata/http_wrapped.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/datadog/orchestrion"
+)
+
+func main() {
+	//dd:startinstrument
+	defer orchestrion.Init()()
+	//dd:endinstrument
+	s := http.NewServeMux()
+	//dd:startwrap
+	s.HandleFunc("/handle", orchestrion.WrapHandlerFunc(myHandler))
+	//dd:endwrap
+}
+
+func myHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	defer r.Body.Close()
+	w.WriteHeader(http.StatusOK)
+	w.Write(b)
+}
+
+func myClient() {
+	//dd:startwrap
+	client := orchestrion.WrapHTTPClient(&http.Client{
+		Timeout: time.Second,
+	})
+	//dd:endwrap
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, "http://localhost:8080",
+		strings.NewReader(os.Args[1]))
+	if err != nil {
+		panic(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	if resp.Body == nil {
+		return
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+}

--- a/uninstrument.go
+++ b/uninstrument.go
@@ -19,7 +19,7 @@ var unwrappers = []func(n dst.Node) bool{
 	unwrapHandlerAssign,
 }
 
-func UninstrumentFile(name string, r io.Reader) (io.Reader, error) {
+func UninstrumentFile(name string, r io.Reader, conf Config) (io.Reader, error) {
 	fset := token.NewFileSet()
 	d := decorator.NewDecoratorWithImports(fset, name, goast.New())
 	f, err := d.Parse(r)


### PR DESCRIPTION
Right now we use two techniques to instrument net/http (Wrapping vs Report). The 2 techniques are mutually exclusive, this PR put the Report technique behind a flag `-httpmode`.