### PR TITLE
internal/instrument: add support for //dd:ignore

### DIFF
--- a/internal/instrument/instrument.go
+++ b/internal/instrument/instrument.go
@@ -484,6 +484,9 @@ func wrapHandlerFromAssign(stmt *dst.AssignStmt, tc *typechecker.TypeChecker) bo
 				return false
 			}
 			for _, e := range x.Elts {
+				if hasLabel(dd_startwrap, e.Decorations().Start.All()) {
+					return false
+				}
 				if kve, ok := e.(*dst.KeyValueExpr); ok {
 					k, ok := kve.Key.(*dst.Ident)
 					if !(ok && k.Name == "Handler" && tc.OfType(k, "net/http.Handler")) {


### PR DESCRIPTION
This commit adds support for the //dd:ignore label on functions and statements. It causes orchestrion to ignore any functions or statements that are decorated with //dd:ignore, and not apply any instrumentation to them.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
