### PR TITLE
all: shift linting in CI to lint job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52.2
+      - name: make-lint
+        run: make lint
   unit-tests:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ build-only:
 build-linux-x64: generate test
 	GOOS=linux GOARCH=amd64 go build -o ./bin/orchestrion ./
 
-test: generate fmt vet verify-licenses verify-dd-headers
+test: generate 
 	go test ./... -cover
+
+lint: fmt vet verify-licenses verify-dd-headers
 
 vet:
 	go vet ./...


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR moves the linting (vet, fmt, licenses, etc.) into the lint job rather than the unit test job.
### Motivation

fmt/vet/etc. checks were causing the unit test job to fail before running the tests.
These checks should run in the lint job rather than the unit test job.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
