### PR TITLE
instrument: support gorilla/mux

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,8 @@ Orchestrion also supports automatic tracing of the following libraries:
 - [x] `google.golang.org/grpc`
 - [x] `github.com/gin-gonic/gin`
 - [x] `github.com/labstack/echo/v4`
-- [x] `https://github.com/go-chi/chi/v5`
+- [x] `github.com/go-chi/chi/v5`
+- [x] `github.com/gorilla/mux`
 
 Calls to these libraries are instrumented with library-specific code adding tracing to them, including support for distributed traces.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-chi/chi/v5 v5.0.0
+	github.com/gorilla/mux v1.8.0
 	github.com/labstack/echo/v4 v4.11.1
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.54.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/pprof v0.0.0-20230509042627-b1315fad0c5a h1:PEOGDI1kkyW37YqPWHLHc+D20D9+87Wt12TCcfTUo5Q=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/instrument/gorilla.go
+++ b/instrument/gorilla.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package instrument
+
+import (
+	"github.com/gorilla/mux"
+
+	muxtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
+)
+
+func WrapGorillaMuxRouter(r *mux.Router) *muxtrace.Router {
+	return muxtrace.WrapRouter(r)
+}

--- a/internal/instrument/gorilla.go
+++ b/internal/instrument/gorilla.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package instrument
+
+import "github.com/dave/dst"
+
+func wrapGorillaMux(stmt *dst.AssignStmt) {
+	rhs := stmt.Rhs[0]
+	f, ok := funcIdent(rhs)
+	if !ok {
+		return
+	}
+	if !(f.Path == "github.com/gorilla/mux" && f.Name == "NewRouter") {
+		return
+	}
+	wrap(stmt)
+	call := rhs.(*dst.CallExpr)
+	call.Args = []dst.Expr{
+		&dst.CallExpr{
+			Fun: &dst.Ident{
+				Name: f.Name,
+				Path: f.Path,
+			},
+		},
+	}
+	f.Path = "github.com/datadog/orchestrion/instrument"
+	f.Name = "WrapGorillaMuxRouter"
+}
+
+func unwrapGorillaMux(n dst.Node) bool {
+	stmt, ok := n.(*dst.AssignStmt)
+	if !ok {
+		return true
+	}
+	rhs := stmt.Rhs[0]
+	f, ok := funcIdent(rhs)
+	if !ok {
+		return true
+	}
+	if !(f.Path == "github.com/datadog/orchestrion/instrument" && f.Name == "WrapGorillaMuxRouter") {
+		return true
+	}
+	call := rhs.(*dst.CallExpr)
+	call.Args = nil
+	f.Path = "github.com/gorilla/mux"
+	f.Name = "NewRouter"
+	return true
+}

--- a/internal/instrument/gorilla_test.go
+++ b/internal/instrument/gorilla_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package instrument
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/datadog/orchestrion/internal/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGorillaMux(t *testing.T) {
+	var codeTpl = `package main
+
+import "github.com/gorilla/mux"
+
+func register() {
+	%s
+}
+`
+	var wantTpl = `package main
+
+import (
+	"github.com/datadog/orchestrion/instrument"
+	"github.com/gorilla/mux"
+)
+
+func register() {
+	//dd:startwrap
+	%s
+	//dd:endwrap
+}
+`
+
+	tests := []struct {
+		in   string
+		want string
+		tmpl string
+	}{
+		{in: `r := mux.NewRouter()`, want: `r := instrument.WrapGorillaMuxRouter(mux.NewRouter())`, tmpl: wantTpl},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("tc-%d", i), func(t *testing.T) {
+			code := fmt.Sprintf(codeTpl, tc.in)
+			reader, err := InstrumentFile("test", strings.NewReader(code), config.Config{})
+			require.Nil(t, err)
+			got, err := io.ReadAll(reader)
+			require.Nil(t, err)
+			want := fmt.Sprintf(tc.tmpl, tc.want)
+			require.Equal(t, want, string(got))
+
+			reader, err = UninstrumentFile("test", strings.NewReader(want), config.Config{})
+			require.Nil(t, err)
+			orig, err := io.ReadAll(reader)
+			require.Nil(t, err)
+			require.Equal(t, code, string(orig))
+		})
+	}
+}

--- a/internal/instrument/instrument.go
+++ b/internal/instrument/instrument.go
@@ -298,6 +298,7 @@ func addInFunctionCode(list []dst.Stmt, tc *typechecker.TypeChecker, conf config
 			}
 			wrapSqlOpenFromAssign(stmt)
 			wrapGRPC(stmt)
+			wrapGorillaMux(stmt)
 			if isGin(stmt) {
 				out = append(out, stmt)
 				appendStmt = false

--- a/internal/instrument/uninstrument.go
+++ b/internal/instrument/uninstrument.go
@@ -29,6 +29,7 @@ var unwrappers = []func(n dst.Node) bool{
 	unwrapSqlAssign,
 	unwrapSqlReturn,
 	unwrapGRPC,
+	unwrapGorillaMux,
 }
 
 // removers contains the list of helpers responsible for

--- a/samples/server/gorilla.go
+++ b/samples/server/gorilla.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package main
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func gorillaMuxServer() {
+	r := mux.NewRouter()
+	ping := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, _ = io.WriteString(w, `{"message":"pong"}`)
+	}
+	r.HandleFunc("/ping", ping).Methods("GET")
+	_ = http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.
-->
### What does this PR do?

Support `github.com/gorilla/mux` by detecting the instantiation of `mux.NewRouter` and replacing it with the Gorilla wrapper from `dd-trace-go`.

![image](https://github.com/DataDog/orchestrion/assets/163009/31631699-c8e3-4a6b-b5bc-5f7397fad1fb)

[Trace in DDev](https://dddev.datadoghq.com/apm/trace/4173493714106437496?colorBy=service&env=dario.castane&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=4173493714106437496&spanViewType=metadata&timeHint=1692870785780.177)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
