### PR TITLE
internal/version/version.go: release v0.4.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,4 +6,4 @@
 package version
 
 // Tag specifies the current release tag. It needs to be manually updated.
-const Tag = "v0.4.0-dev"
+const Tag = "v0.5.0-dev"


### PR DESCRIPTION
### What does this PR do?

Updates to `v0.5.0-dev` because of `v0.4.0` release.

### Motivation

Pending fixes blocking TEE tests.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality.
