### PR TITLE
instrument/http: add span.kind & component tags to WrapHandlerFunc

### DIFF
--- a/_integration-tests/tests/net_http/validation.json
+++ b/_integration-tests/tests/net_http/validation.json
@@ -5,6 +5,10 @@
 	    "name": "http.request",
 	    "service": "net_http",
 	    "resource": "GET /",
-	    "type": "web"
+	    "type": "web",
+		"meta": {
+			"component": "net/http",
+			"span.kind": "server"
+		}
 	}]
 }

--- a/instrument/http.go
+++ b/instrument/http.go
@@ -10,8 +10,12 @@ import (
 	"net/http"
 
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
+
+const componentName = "net/http"
 
 // if a function meets the handlerfunc type, insert code to:
 // get the header from the request and look for the trace id
@@ -101,6 +105,10 @@ func WrapHandlerFunc(handlerFunc http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		httptrace.TraceAndServe(handlerFunc, w, r, &httptrace.ServeConfig{
 			Resource: resourceNamer(r),
+			SpanOpts: []ddtrace.StartSpanOption{
+				tracer.Tag(ext.SpanKind, ext.SpanKindServer),
+				tracer.Tag(ext.Component, componentName),
+			},
 		})
 	}
 	// TODO: We'll reintroduce this later when we stop hard-coding dd-trace-go as above.


### PR DESCRIPTION
### What does this PR do?

Adds missing tags `span.kind` and `component` for `net/http` autoinstrumentation using `instrument.WrapHandlerFunc`.

The root cause is that it uses `httptrace.TraceAndServe` under the hood, that assumes these tags are added by the caller (like `httptrace.WrapHandler`).

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality.
