### PR TITLE
instrument: support middleware as selector expression

### DIFF
--- a/internal/instrument/chiv5.go
+++ b/internal/instrument/chiv5.go
@@ -10,30 +10,13 @@ import (
 )
 
 func instrumentChiV5(stmt *dst.AssignStmt) []dst.Stmt {
-	if !isChiV5(stmt) {
-		return nil
-	}
-	stmt.Decorations().Start.Prepend(dd_instrumented)
-	return []dst.Stmt{
-		stmt,
-		chiV5Middleware(stmt),
-	}
+	return instrumentMiddleware(stmt, isChiV5, "ChiV5Middleware")
 }
 
 func isChiV5(stmt *dst.AssignStmt) bool {
 	rhs := stmt.Rhs[0]
 	f, ok := funcIdent(rhs)
 	return ok && f.Path == "github.com/go-chi/chi/v5" && f.Name == "NewRouter"
-}
-
-func chiV5Middleware(got *dst.AssignStmt) dst.Stmt {
-	iden, ok := got.Lhs[0].(*dst.Ident)
-	if !ok {
-		return nil
-	}
-	stmt := useMiddleware(iden.Name, "ChiV5Middleware")
-	markAsInstrumented(stmt)
-	return stmt
 }
 
 // removeChiV5 returns whether a statement corresponds to orchestrion's Chi-middleware registration

--- a/internal/instrument/chiv5_test.go
+++ b/internal/instrument/chiv5_test.go
@@ -50,6 +50,7 @@ func register() {
 		{pkg: `"github.com/go-chi/chi/v5"`, stmt: `r := chi.NewRouter()`, want: `r.Use(instrument.ChiV5Middleware())`, tmpl: wantTpl},
 		{pkg: `chi "github.com/go-chi/chi/v5"`, stmt: `r := chi.NewRouter()`, want: `r.Use(instrument.ChiV5Middleware())`, tmpl: wantTpl},
 		{pkg: `chiv5 "github.com/go-chi/chi/v5"`, stmt: `r := chiv5.NewRouter()`, want: `r.Use(instrument.ChiV5Middleware())`, tmpl: wantTpl},
+		{pkg: `"github.com/go-chi/chi/v5"`, stmt: `api.server = chi.NewRouter()`, want: `api.server.Use(instrument.ChiV5Middleware())`, tmpl: wantTpl},
 	}
 
 	for i, tc := range tests {

--- a/internal/instrument/echov4.go
+++ b/internal/instrument/echov4.go
@@ -8,30 +8,13 @@ package instrument
 import "github.com/dave/dst"
 
 func instrumentEchoV4(stmt *dst.AssignStmt) []dst.Stmt {
-	if !isEchoV4(stmt) {
-		return nil
-	}
-	stmt.Decorations().Start.Prepend(dd_instrumented)
-	return []dst.Stmt{
-		stmt,
-		echoV4Middleware(stmt),
-	}
+	return instrumentMiddleware(stmt, isEchoV4, "EchoV4Middleware")
 }
 
 func isEchoV4(stmt *dst.AssignStmt) bool {
 	rhs := stmt.Rhs[0]
 	f, ok := funcIdent(rhs)
 	return ok && f.Path == "github.com/labstack/echo/v4" && f.Name == "New"
-}
-
-func echoV4Middleware(got *dst.AssignStmt) dst.Stmt {
-	iden, ok := got.Lhs[0].(*dst.Ident)
-	if !ok {
-		return nil
-	}
-	stmt := useMiddleware(iden.Name, "EchoV4Middleware")
-	markAsInstrumented(stmt)
-	return stmt
 }
 
 // removeEchoV4 returns whether a statement corresponds to orchestrion's Echo-middleware registration

--- a/internal/instrument/echov4_test.go
+++ b/internal/instrument/echov4_test.go
@@ -50,6 +50,7 @@ func register() {
 		{pkg: `"github.com/labstack/echo/v4"`, stmt: `r := echo.New()`, want: `r.Use(instrument.EchoV4Middleware())`, tmpl: wantTpl},
 		{pkg: `echo "github.com/labstack/echo/v4"`, stmt: `r := echo.New()`, want: `r.Use(instrument.EchoV4Middleware())`, tmpl: wantTpl},
 		{pkg: `echov4 "github.com/labstack/echo/v4"`, stmt: `r := echov4.New()`, want: `r.Use(instrument.EchoV4Middleware())`, tmpl: wantTpl},
+		{pkg: `"github.com/labstack/echo/v4"`, stmt: `api.server = echo.New()`, want: `api.server.Use(instrument.EchoV4Middleware())`, tmpl: wantTpl},
 	}
 
 	for i, tc := range tests {

--- a/internal/instrument/gin.go
+++ b/internal/instrument/gin.go
@@ -8,30 +8,13 @@ package instrument
 import "github.com/dave/dst"
 
 func instrumentGin(stmt *dst.AssignStmt) []dst.Stmt {
-	if !isGin(stmt) {
-		return nil
-	}
-	stmt.Decorations().Start.Prepend(dd_instrumented)
-	return []dst.Stmt{
-		stmt,
-		ginMiddleware(stmt),
-	}
+	return instrumentMiddleware(stmt, isGin, "GinMiddleware")
 }
 
 func isGin(stmt *dst.AssignStmt) bool {
 	rhs := stmt.Rhs[0]
 	f, ok := funcIdent(rhs)
 	return ok && f.Path == "github.com/gin-gonic/gin" && (f.Name == "New" || f.Name == "Default")
-}
-
-func ginMiddleware(got *dst.AssignStmt) dst.Stmt {
-	iden, ok := got.Lhs[0].(*dst.Ident)
-	if !ok {
-		return nil
-	}
-	stmt := useMiddleware(iden.Name, "GinMiddleware")
-	markAsInstrumented(stmt)
-	return stmt
 }
 
 // removeGin returns whether a statement corresponds to orchestrion's Gin-middleware registration

--- a/internal/instrument/gin_test.go
+++ b/internal/instrument/gin_test.go
@@ -48,6 +48,7 @@ func register() {
 	}{
 		{in: `g := gin.New()`, want: `g.Use(instrument.GinMiddleware())`, tmpl: wantTpl},
 		{in: `g := gin.Default()`, want: `g.Use(instrument.GinMiddleware())`, tmpl: wantTpl},
+		{in: `api.server = gin.Default()`, want: `api.server.Use(instrument.GinMiddleware())`, tmpl: wantTpl},
 	}
 
 	for i, tc := range tests {

--- a/internal/instrument/instrument.go
+++ b/internal/instrument/instrument.go
@@ -584,7 +584,7 @@ func useMiddleware(expr dst.Expr, middleware string) (*dst.ExprStmt, error) {
 		//dd:instrumented
 		api.server = echo.New()
 		//dd:startinstrument
-		api.serverr.Use(instrument.EchoV4Middleware())
+		api.server.Use(instrument.EchoV4Middleware())
 		//dd:endinstrument
 	*/
 	var stmt *dst.ExprStmt

--- a/samples/server/echov4.go
+++ b/samples/server/echov4.go
@@ -20,3 +20,17 @@ func echoV4Server() {
 	})
 	_ = r.Start(":8080")
 }
+
+type api struct {
+	srv *echo.Echo
+}
+
+func (a *api) echoV4Server() {
+	a.srv = echo.New()
+	a.srv.GET("/ping", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]any{
+			"message": "pong",
+		})
+	})
+	_ = a.srv.Start(":8888")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Add support for using middlewares when the server is a struct field. Before this fix, Orchestrion would inject a nil statement which causes a panic in `ast.Walk`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

fixes #51 

This commit has also been tested against https://github.com/gotenberg/gotenberg as mentioned in the issue.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality.
