### PR TITLE
Feature: Add options to SQL auto tracing library (and add comment pattern for supporting options in other libs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,26 @@ Orchestrion supports automatic tracing of the following libraries:
 
 Calls to these libraries are instrumented with library-specific code adding tracing to them, including support for distributed traces.
 
+### Adding tracer options for supported libraries [WIP]
+To add your own tracer options, simply add the magic `//dd:options` comment above the function call where you initialize the service. For example,
+```go
+package main
+
+import "database/sql"
+
+func main() {
+	//dd:options service:test-name tag:my_key:my_val
+	db, err := sql.Open("driver", "connectionString")
+}
+```
+#### Current libraries that support custom options, with supported options
+
+  | Library  | Option Name | Decorator Format |
+  | ------------- | ------------- | ---- |
+  | `database/sql` | Service Name | `service:{name}` |
+  | `database/sql` | Custom Tag | `tag:{name}:{value}` |
+
+
 ## Next steps
 
 - [ ] Support compile-time auto-instrumentation via `-toolexec`

--- a/instrument/sql.go
+++ b/instrument/sql.go
@@ -12,10 +12,18 @@ import (
 	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 )
 
-func Open(driverName, dataSourceName string) (*sql.DB, error) {
-	return sqltrace.Open(driverName, dataSourceName)
+func Open(driverName, dataSourceName string, opts ...sqltrace.Option) (*sql.DB, error) {
+	return sqltrace.Open(driverName, dataSourceName, opts...)
 }
 
-func OpenDB(c driver.Connector) *sql.DB {
-	return sqltrace.OpenDB(c)
+func OpenDB(c driver.Connector, opts ...sqltrace.Option) *sql.DB {
+	return sqltrace.OpenDB(c, opts...)
+}
+
+func SqlWithServiceName(name string) sqltrace.Option {
+	return sqltrace.WithServiceName(name)
+}
+
+func SqlWithCustomTag(key string, value interface{}) sqltrace.Option {
+	return sqltrace.WithCustomTag(key, value)
 }

--- a/internal/instrument/instrument.go
+++ b/internal/instrument/instrument.go
@@ -428,6 +428,7 @@ const (
 	dd_instrumented    = "//dd:instrumented"
 	dd_span            = "//dd:span"
 	dd_ignore          = "//dd:ignore"
+	dd_options         = "//dd:options"
 )
 
 func hasLabel(label string, decs []string) bool {

--- a/internal/instrument/sql.go
+++ b/internal/instrument/sql.go
@@ -76,7 +76,11 @@ func wrapSqlCall(call *dst.CallExpr, startDeco dst.Decorations) bool {
 			for _, opt := range optList {
 				optSections := strings.Split(opt, ":")
 				if len(optSections) > 1 {
-					args = append(args, mapOptionToCall(optSections[0], optSections[1:]...))
+					optionCall := mapOptionToCall(optSections[0], optSections[1:]...)
+					if optionCall != nil {
+						args = append(args, optionCall)
+					}
+
 				}
 			}
 		}

--- a/internal/instrument/sql_test.go
+++ b/internal/instrument/sql_test.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package instrument
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/datadog/orchestrion/internal/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSql(t *testing.T) {
+	var codeTpl = `package main
+
+import %s
+
+func register() {
+	%s
+}
+`
+	var wantTpl = `package main
+
+import "github.com/datadog/orchestrion/instrument"
+
+func register() {
+	//dd:startwrap
+	%s
+	//dd:endwrap
+}
+`
+
+	tests := []struct {
+		pkg  string
+		stmt string
+		want string
+		tmpl string
+	}{
+		{pkg: `"database/sql"`, stmt: `r, err := sql.Open("driver", "connString")`, want: `r, err := instrument.Open("driver", "connString")`, tmpl: wantTpl},
+		{pkg: `"database/sql"`, stmt: `db := sql.OpenDB(mssql.NewConnectorConfig(msdsn.Config{}))`, want: `db := instrument.OpenDB(mssql.NewConnectorConfig(msdsn.Config{}))`, tmpl: wantTpl},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("tc-%d", i), func(t *testing.T) {
+			code := fmt.Sprintf(codeTpl, tc.pkg, tc.stmt)
+			reader, err := InstrumentFile("test", strings.NewReader(code), config.Config{})
+			require.Nil(t, err)
+			got, err := io.ReadAll(reader)
+			require.Nil(t, err)
+			want := fmt.Sprintf(tc.tmpl, tc.want)
+			require.Equal(t, want, string(got))
+
+			reader, err = UninstrumentFile("test", strings.NewReader(want), config.Config{})
+			require.Nil(t, err)
+			orig, err := io.ReadAll(reader)
+			require.Nil(t, err)
+			require.Equal(t, code, string(orig))
+		})
+	}
+}
+
+func TestSqlWithOptions(t *testing.T) {
+	var codeTpl = `package main
+
+import %s
+
+func register() {
+	//dd:options service:test-name tag:my:value
+	%s
+}
+`
+	var wantTpl = `package main
+
+import "github.com/datadog/orchestrion/instrument"
+
+func register() {
+	//dd:options service:test-name tag:my:value
+	//dd:startwrap
+	%s
+	//dd:endwrap
+}
+`
+
+	tests := []struct {
+		pkg  string
+		stmt string
+		want string
+		tmpl string
+	}{
+		{pkg: `"database/sql"`, stmt: `r, err := sql.Open("driver", "connString")`, want: `r, err := instrument.Open("driver", "connString", instrument.SqlWithServiceName("test-name"), instrument.SqlWithCustomTag("my", "value"))`, tmpl: wantTpl},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("tc-%d", i), func(t *testing.T) {
+			code := fmt.Sprintf(codeTpl, tc.pkg, tc.stmt)
+			reader, err := InstrumentFile("test", strings.NewReader(code), config.Config{})
+			require.Nil(t, err)
+			got, err := io.ReadAll(reader)
+			require.Nil(t, err)
+			want := fmt.Sprintf(tc.tmpl, tc.want)
+			require.Equal(t, want, string(got))
+
+			reader, err = UninstrumentFile("test", strings.NewReader(want), config.Config{})
+			require.Nil(t, err)
+			orig, err := io.ReadAll(reader)
+			require.Nil(t, err)
+			require.Equal(t, code, string(orig))
+		})
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?
This PR defines a pattern to add supported options to the tracer initializations for automatic tracing libraries.

Specifically, this PR wires it up for `database/sql` with support for the [service name](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1@v1.58.0/contrib/database/sql#WithServiceName) and [custom tag](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1@v1.58.0/contrib/database/sql#WithCustomTag) options.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Internally, this PR adds a parser in the sql instrumentation that looks for a comment/decorator that starts with `//dd:options`, and then parses all options as specified in the comment, then adds an appropriate option in the `instrument.Open` or `instrument.OpenDB` call, only if it's supported. It also modifies the exported instrumentation methods for sql to include 0 or many options, and adds methods to generate the methods

### Motivation
I don't like that I can't pass options to the libraries that auto-wire. I wanted this option!
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [x] Changed code has unit tests for its functionality.
