### PR TITLE
fix: Missing argument to fmt.Printf

### DIFF
--- a/_integration-tests/validator/validator.go
+++ b/_integration-tests/validator/validator.go
@@ -142,7 +142,7 @@ func main() {
 
 	f, err := os.Open(*vfile)
 	if err != nil {
-		fmt.Printf("Failed to open validation file '%s': %v\n", err)
+		fmt.Printf("Failed to open validation file %q: %v\n", *vfile, err)
 		os.Exit(1)
 	}
 	defer f.Close()
@@ -152,7 +152,7 @@ func main() {
 	var v Validation
 	err = d.Decode(&v)
 	if err != nil {
-		fmt.Printf("Failed to decode validation from '%s': %v\n", err)
+		fmt.Printf("Failed to decode validation from %q: %v\n", *vfile, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fixes an error in calls to `fmt.Printf` where there were not as many arguments provided as `%` placeholders in the format string.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [X] Changed code has unit tests for its functionality.
