### PR TITLE
chore: improve GitHub Workflows a bit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,25 +13,25 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "stable"
           cache: true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'DataDog/orchestrion'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.52.2
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'DataDog/orchestrion'
       - name: Checkout Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "stable"
       - name: Run unit tests
@@ -50,10 +50,10 @@ jobs:
           TRACE_LANGUAGE: golang
           ENABLED_CHECKS: trace_stall,trace_count_header,trace_peer_service,trace_dd_service
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'DataDog/orchestrion'
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "stable"
       - name: Run Integration Tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,11 +1,11 @@
 name: Tests
 on:
   pull_request:
-    branches:
-      - "**"
+    branches: ["**"]
+  merge_group:
+    branches: ["main"]
   push:
-    branches:
-      - "main"
+    branches: ["main"]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -58,3 +58,14 @@ jobs:
           go-version: "stable"
       - name: Run Integration Tests
         run: make integration-tests
+
+  # This is just a join point intended to simplify branch protection settings
+  complete:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - unit-tests
+      - integration-tests
+    steps:
+      - name: Done
+        run: echo "OK"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,13 +13,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'DataDog/orchestrion'
       - uses: actions/setup-go@v5
         with:
           go-version: "stable"
           cache: true
-      - uses: actions/checkout@v4
-        with:
-          repository: 'DataDog/orchestrion'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "stable"
-          cache: true
+          cache-dependency-path: "**/*.sum"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
+          cache-dependency-path: "**/*.sum"
       - name: Run unit tests
         run: make test
   integration-tests:
@@ -56,6 +57,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "stable"
+          cache-dependency-path: "**/*.sum"
       - name: Run Integration Tests
         run: make integration-tests
 


### PR DESCRIPTION
### What does this PR do?

- Updates gitHub Actions to current latest majors, in order to stop using deprecated Node release.
- Makes the `test.yaml` workflow compatible with GitHub merge queues
- Add a "complete" job that serves as a join point for all tests so branch protection can be easily configured to require all tests to have passed
- Correctly order `actions/checkout` and `actions/setup-go` so that the go module cache can actually be retrieved from GitHub Actions Cache 
- Make `actions/setup-go` cache configuration me mondful of there possibly being multiple `go.sum` files in the repository
