### PR TITLE
feat: ensure version run matches go.mod requirements

### DIFF
--- a/internal/ensure/integration/main.go
+++ b/internal/ensure/integration/main.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/datadog/orchestrion/internal/ensure"
+)
+
+// main is the entry point of a command that is used by the `ensure` integration
+// test to verify the `ensure.RequiredVersion()` function behaves correctly in
+// real conditions.
+func main() {
+	if err := ensure.RequiredVersion(); err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println("This command has not respawned!")
+}

--- a/internal/ensure/integration_test.go
+++ b/internal/ensure/integration_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package ensure_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var ensureDir string
+
+func Test(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "ensure_test-*")
+	require.NoError(t, err, "failed to create temporary working directory")
+	defer os.RemoveAll(tmp)
+
+	testMain := path.Join(tmp, "bin", "test_main")
+
+	_, err = shell(ensureDir, "go", "build", "-o", testMain, "./integration")
+	require.NoError(t, err, "failed to build test_main helper")
+
+	type test struct {
+		// version is the orchestrion version to mention in the `go.mod` files' require directive. The
+		// test will run go mod tidy, so this version must be an existing release tag. We typically use
+		// `v0.6.0` for testing purposes, but you can specify another existing version if there is a
+		// reason to. If blank, no `require` directive will be added in `go.mod` to require orchestrion.
+		version string
+		// replaces causes the `go.mod` file to have a `replace` directive that redirects the
+		// Orchestrion package to the version that is currently being tested.
+		replaces bool
+		// output is the expected output from running the `test_main` command, which is created from
+		// compiling the `./integration` package.
+		output string
+		// fails is true when the `test_main` helper is expected to exit with a non-0 status code. When
+		// true, the value of `output` is not asserted against.
+		fails bool
+	}
+	for name, test := range map[string]test{
+		"v0.6.0":   {version: "v0.6.0", output: "v0.6.0"},
+		"replaced": {version: "v0.6.0", replaces: true, output: "This command has not respawned!"},
+		"none":     {fails: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			wd := path.Join(tmp, name)
+			require.NoError(t, os.Mkdir(wd, 0750), "failed to create test working directory")
+
+			goMod := []string{
+				"module integration_test_case",
+				"",
+				"go 1.20",
+				"",
+			}
+
+			if test.version != "" {
+				goMod = append(goMod, fmt.Sprintf("require github.com/datadog/orchestrion %s", test.version), "")
+
+				// So that "go mod tidy" does not remove the requirement...
+				require.NoError(t,
+					os.WriteFile(path.Join(wd, "tools.go"), []byte(strings.Join([]string{
+						"//go:build tools",
+						"package tools",
+						"",
+						"import _ \"github.com/datadog/orchestrion\"",
+					}, "\n")), 0o640),
+					"failed to write tools.go",
+				)
+			}
+			if test.replaces {
+				goMod = append(goMod, fmt.Sprintf("replace github.com/datadog/orchestrion => %s", path.Dir(path.Dir(ensureDir))), "")
+			}
+
+			require.NoError(t,
+				os.WriteFile(path.Join(wd, "go.mod"), []byte(strings.Join(goMod, "\n")), 0o640),
+				"failed to create go.mod file",
+			)
+
+			_, err := shell(wd, "go", "mod", "tidy")
+			require.NoError(t, err, "failed to 'go mod tidy'")
+
+			out, err := shell(wd, testMain, "-v")
+			if test.fails {
+				_, ok := err.(*exec.ExitError)
+				require.True(t, ok, "unexpected error while running test_main: %v", err)
+			} else {
+				require.NoError(t, err, "failed to run test_main helper")
+				require.Equal(t, test.output, out, "unexpected output from test_main helper")
+			}
+		})
+	}
+}
+
+func shell(dir, cmd string, args ...string) (string, error) {
+	var stdout bytes.Buffer
+
+	child := exec.Command(cmd, args...)
+	child.Dir = dir
+	child.Stdout = &stdout
+
+	err := child.Run()
+	return strings.TrimSpace(stdout.String()), err
+}
+
+func init() {
+	_, file, _, _ := runtime.Caller(0)
+	ensureDir = path.Dir(file)
+}

--- a/internal/ensure/requiredversion.go
+++ b/internal/ensure/requiredversion.go
@@ -40,7 +40,7 @@ func RequiredVersion() error {
 }
 
 // requiredVersion is the internal implementation of RequiredVersion, and takes the goModVersion and
-// syscall.Exec functions as arguments to allow for easier testing.
+// syscall.Exec functions as arguments to allow for easier testing. Panics if `osArgs` is 0-length.
 func requiredVersion(
 	goModVersion func() (string, error),
 	osGetenv func(string) string,
@@ -83,6 +83,10 @@ func requiredVersion(
 	goBin, err := exec.LookPath("go")
 	if err != nil {
 		return fmt.Errorf("failed to resolve go from PATH: %w", err)
+	}
+
+	if len(osArgs) == 0 {
+		panic("received 0-length osArgs, which is not supposed to happen")
 	}
 
 	args := make([]string, len(osArgs)+2)

--- a/internal/ensure/requiredversion.go
+++ b/internal/ensure/requiredversion.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package ensure
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+
+	"github.com/datadog/orchestrion/internal/version"
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	orchestrionPkgPath = "github.com/datadog/orchestrion"
+	envVarRespawned    = "DD_ORCHESTRION_RESPAWNED_FOR"
+	envValRespawnLocal = "<local>"
+)
+
+// EnsureRequiredVersion makes sure the version of the tool currently running is the same as the one
+// required in the current working directory's "go.mod" file by calling `syscall.Exec` with the
+// relevant `go run` command if necessary to replace the current process with one using the required
+// version.
+//
+// If this returns `nil`, the current process is running the correct version of the tool and can
+// proceed with it's intended purpose. If it returns an error, that should be presented to the user
+// before exiting with a non-0 status code. If the process was correctly substituted, this function
+// never returns control to its caller (as the process has been replaced).
+func RequiredVersion() error {
+	required, err := goModVersion()
+	if err != nil {
+		return fmt.Errorf("failed to determine go.mod requirement for %q: %w", orchestrionPkgPath, err)
+	}
+
+	if required == version.Tag {
+		// This is the correct version or no specific version could be determined (indicating a dev/replaced package is in
+		// use), so we can proceed without further ado.
+		return nil
+	}
+
+	if respawn := os.Getenv(envVarRespawned); respawn != "" && respawn != envValRespawnLocal {
+		// We're already re-spawning for a non-local version, so we should not be re-spawning again...
+		// If that were the case, we'd likely end up in an infinite loop of re-spawning, which is very
+		// much undesirable.
+		return fmt.Errorf(
+			"re-spawn loop detected (wanted %s, got %s, already respawning for %s)",
+			required,
+			version.Tag,
+			respawn,
+		)
+	}
+
+	if required == "" {
+		// If there is no required version, it means a local version is used instead, either because we
+		// are in Orchestrion's own development tree, or because the user has introduced a "replace"
+		// directive for orchestion. In such cases, we unconditionally exec `go run` exactly once.
+		required = envValRespawnLocal
+	}
+
+	log.Printf("Re-starting with '%s@%s' (this is %s)\n", orchestrionPkgPath, required, version.Tag)
+
+	args := make([]string, len(os.Args)+1)
+	args[0] = "run"
+	args[1] = orchestrionPkgPath
+	copy(args[2:], os.Args[1:])
+
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("%s=%s", envVarRespawned, required))
+
+	err = syscall.Exec("go", args, env)
+	return fmt.Errorf("failed to exec `go run %s ...`: %w", orchestrionPkgPath, err)
+}
+
+// goModVersion returns the version of the "github.com/datadog/orchestrion" module that is required
+// in the current working directory's "go.mod" file. The versions may be blank, indicating a replace
+// directive redirects the package to a local source tree.
+func goModVersion() (string, error) {
+	cfg := &packages.Config{Mode: packages.NeedModule}
+	pkgs, err := packages.Load(cfg, orchestrionPkgPath)
+	if err != nil {
+		return "", err
+	}
+
+	pkg := pkgs[0]
+	if len(pkg.Errors) > 0 {
+		errs := make([]error, len(pkg.Errors))
+		for i, e := range pkg.Errors {
+			errs[i] = errors.New(e.Error())
+		}
+		return "", errors.Join(errs...)
+	}
+
+	return pkg.Module.Version, nil
+}

--- a/internal/ensure/requiredversion_test.go
+++ b/internal/ensure/requiredversion_test.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package ensure
+
+import (
+	"errors"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+
+	"github.com/datadog/orchestrion/internal/version"
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	require.NoError(t, err, "could not resolve go command path")
+
+	testError := errors.New("simulated failure")
+	osArgs := []string{"/path/to/go/compile", "-a", "./..."}
+
+	type goModVersionResult struct {
+		version string
+		err     error
+	}
+	type expectedOutcome struct {
+		err      error
+		respawns bool
+	}
+	type testCase struct {
+		goModVersion    goModVersionResult
+		envVarRespawned string
+		expected        expectedOutcome
+	}
+
+	for name, tc := range map[string]testCase{
+		"happy path": {
+			goModVersion: goModVersionResult{version: version.Tag},
+			expected:     expectedOutcome{err: nil, respawns: false},
+		},
+		"go.mod failure": {
+			goModVersion: goModVersionResult{err: testError},
+			expected:     expectedOutcome{err: testError},
+		},
+		"respawn needed (requires different version)": {
+			goModVersion: goModVersionResult{version: "v1337.42.0-phony.0"},
+			expected:     expectedOutcome{respawns: true},
+		},
+		"respawn needed (blank required version)": {
+			goModVersion: goModVersionResult{version: ""},
+			expected:     expectedOutcome{respawns: true},
+		},
+		"respawn loop": {
+			goModVersion:    goModVersionResult{version: "v1337.42.0-phony.0"},
+			envVarRespawned: "v1.2.3-example.1",
+			expected:        expectedOutcome{err: errRespawnLoop},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockGoVersion := func() (string, error) {
+				return tc.goModVersion.version, tc.goModVersion.err
+			}
+			mockGetenv := func(name string) string {
+				require.Equal(t, name, envVarRespawned)
+				return tc.envVarRespawned
+			}
+			var syscallExecCalled atomic.Bool
+			mockSyscallExec := func(arg0 string, args []string, env []string) error {
+				t.Helper()
+				syscallExecCalled.Store(true)
+
+				require.Equal(t, goBin, arg0)
+				require.GreaterOrEqual(t, len(args), 3)
+				require.Equal(t, []string{goBin, "run", orchestrionPkgPath}, args[:3])
+				require.Equal(t, osArgs[1:], args[3:])
+
+				return nil
+			}
+
+			err := requiredVersion(mockGoVersion, mockGetenv, mockSyscallExec, osArgs)
+
+			if tc.expected.err != nil {
+				require.ErrorIs(t, err, tc.expected.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expected.respawns, syscallExecCalled.Load())
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces a feature that'd allow replacing the current process with a new one that runs from `go run github.com/datadog/orchestrion` so that it uses the same version as is declared in `go.mod`, allowing `orchestrion` to be installed using `go install` while still enforcing reproductible builds via `go.mod` locking.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
