### PR TITLE
feat: decorate output of `toolexec [...] -V=full`

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/datadog/orchestrion/internal/injector/builtin"
@@ -37,7 +38,9 @@ func main() {
 	case "go":
 		orchestrion, err := os.Executable()
 		if err != nil {
-			orchestrion = os.Args[0]
+			if orchestrion, err = filepath.Abs(os.Args[0]); err != nil {
+				orchestrion = os.Args[0]
+			}
 		}
 
 		if err := goproxy.Run(args, goproxy.WithToolexec(orchestrion, "toolexec")); err != nil {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
+	"github.com/datadog/orchestrion/internal/injector/builtin"
 	"github.com/datadog/orchestrion/internal/version"
 
 	"github.com/datadog/orchestrion/internal/goproxy"
@@ -32,14 +35,25 @@ func main() {
 		fmt.Println(version.Tag)
 		return
 	case "go":
-		err := goproxy.Run(args, goproxy.WithForceBuild(), goproxy.WithDifferentCache())
+		orchestrion, err := os.Executable()
 		if err != nil {
+			orchestrion = os.Args[0]
+		}
+
+		if err := goproxy.Run(args, goproxy.WithToolexec(orchestrion, "toolexec")); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v", err)
 			os.Exit(1)
 		}
 		return
 	case "toolexec":
 		proxyCmd := proxy.MustParseCommand(args)
+		if proxyCmd.ShowVersion() {
+			stdout := strings.Builder{}
+			proxy.MustRunCommand(proxyCmd, func(cmd *exec.Cmd) { cmd.Stdout = &stdout })
+			fmt.Printf("%s:orchestrion@%s+%s\n", strings.TrimSpace(stdout.String()), version.Tag, builtin.Checksum)
+			return
+		}
+
 		proxy.MustRunCommand(proxyCmd)
 		return
 	default:


### PR DESCRIPTION
The go build toolchain calls tooling with `-V=full` to compute the full build ID, allowing for invalidation of cached build artifacts when tooling changes.

The contract for this option is to print a single line of content, which will be embedded in the build ID. We are hence intercepting these in the `-toolexec` flow and appending the Orchestrion version and ruleset information to the output.

---

Additionally, this removes ability to force build (pass `-a`) and override the `GOCACHE`, since these measure ought to make these two features redundant.