### PR TITLE
feat: allow command processors to return an error

### DIFF
--- a/internal/toolexec/examples/add-go-file.go
+++ b/internal/toolexec/examples/add-go-file.go
@@ -23,6 +23,7 @@ type goFilesAdder struct {
 	files []string
 }
 
-func (i goFilesAdder) ProcessCompile(cmd *proxy.CompileCommand) {
+func (i goFilesAdder) ProcessCompile(cmd *proxy.CompileCommand) error {
 	cmd.AddFiles(i.files)
+	return nil
 }

--- a/internal/toolexec/examples/list-go-files.go
+++ b/internal/toolexec/examples/list-go-files.go
@@ -20,8 +20,9 @@ func ExampleListGofiles() {
 	proxy.ProcessCommand(cmd, ProcessCompile)
 }
 
-func ProcessCompile(cmd *proxy.CompileCommand) {
+func ProcessCompile(cmd *proxy.CompileCommand) error {
 	for _, f := range cmd.GoFiles() {
 		log.Println(f)
 	}
+	return nil
 }

--- a/internal/toolexec/examples/replace-go-file.go
+++ b/internal/toolexec/examples/replace-go-file.go
@@ -23,8 +23,11 @@ type goFilesReplacer struct {
 	files map[string]string
 }
 
-func (i goFilesReplacer) ProcessCompile(cmd *proxy.CompileCommand) {
+func (i goFilesReplacer) ProcessCompile(cmd *proxy.CompileCommand) error {
 	for old, new := range i.files {
-		cmd.ReplaceParam(old, new)
+		if err := cmd.ReplaceParam(old, new); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/internal/toolexec/processors/fileswap.go
+++ b/internal/toolexec/processors/fileswap.go
@@ -6,6 +6,7 @@
 package processors
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/datadog/orchestrion/internal/toolexec/proxy"
@@ -23,14 +24,14 @@ func NewGoFileSwapper(swapMap map[string]string) GoFileSwapper {
 	}
 }
 
-func (s *GoFileSwapper) ProcessCompile(cmd *proxy.CompileCommand) {
+func (s *GoFileSwapper) ProcessCompile(cmd *proxy.CompileCommand) error {
 	log.Printf("[%s] Replacing Go files\n", cmd.Stage())
 
 	for old, new := range s.swapMap {
 		if err := cmd.ReplaceParam(old, new); err != nil {
-			log.Printf("couldn't replace param: %v\n", err)
-		} else {
-			log.Printf("====> Replacing %s by %s\n", old, new)
+			return fmt.Errorf("replacing %q with %q: %w", old, new, err)
 		}
+		log.Printf("====> Replaced %s with %s\n", old, new)
 	}
+	return nil
 }


### PR DESCRIPTION
This makes it easier to manage errors in `-toolexec` processors, and also provides a clean and easy way to report that a given command should be skipped instead of being run.