### PR TITLE
chore: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,282 +1,123 @@
 # Orchestrion
 
-Automatic instrumentation of Go code
+Automatic compile-time instrumentation of Go code
 
 ![Orchestrion](https://upload.wikimedia.org/wikipedia/commons/5/55/Welteorchestrion1862.jpg)
 
 ## Overview
 
-Orchestrion processes Go source code and automatically inserts instrumentation.
-This instrumentation creates Datadog APM traces for the instrumented code, but future work will include support for OpenTelemetry as well.
+Orchestrion processes Go source code at compilation time and automatically inserts instrumentation. This instrumentation
+produces Datadog APM traces from the instrumented code and supports Datadog Application Security Management. Future work
+will include support for OpenTelemetry tracing as well.
 
 ## Getting started
 
-Orchestrion automatically adds instrumentation to your source code. This process saves time that engineers would have to spend manually adding the tracer and integrations by replacing that process with a single command.
+Orchestrion is used as a standard Go toolchain `-toolexec` utility. It provides convenience subcommands to make using it
+as simple as it gets:
 
-There are a couple of ways to add instrumentation to your projects using Orchestrion. Orchestrion will also optionally (`-rm`) remove any instrumentation it has added, so this process is reversible.
+1. Add `github.com/datadog/orchestrion` to your tools dependencies:
+   ```go
+	 //go:build tools
+	 package tools
 
-### Instrument your code before check-in
+	 import (
+			_ "github.com/datadog/orchestrion"
+	 )
+	 ```
+2. Run `go mod tidy` to update your `go.mod` and `go.sum` files
+3. For added convenience, install Orchestrion in `$GOBIN` with `go install github.com/datadog/orchestrion`
+4. Prepend `orchestrion` to your `go build` (or `go test`, etc...) commands:
+   ```console
+	 $ orchestrion go build .
+	 $ orchestrion go test ./...
+	 ```
 
-The quickest way to instrument your code is to download and run Orchestrion on your development machine, and then check in the instrumented code. The executable(s) built with this instrumented code support tracing.
-
-
-1. Install Orchestrion.
-
-```sh
-go install github.com/datadog/orchestrion@latest
-```
-
-2. Run Orchestrion to scan and rewrite the codebase.
-
-```sh
-## Go to your project root
-cd ~/my_go_project
-
-## Run orchestrion on the root directory. This will recursively instrument everything in the directory and its subdirectories.
-orchestrion -w ./
-
-## Build your project like normal. If you get errors here, you may need to tidy your go.mod file (go mod tidy)
-go build <target>
-
-## Congrats! You have a program with tracing automatically installed.
-./<executable>
-```
-
-3. Check-in the modified code. You might need to run `go get github.com/datadog/orchestrion` and `go mod tidy` if it's the first time you add `orchestrion` to your Go project.
-
-4. Deploy your service.
-
-### Instrument your code at build time
-
-It is also possible to instrument your code at build time. Instead of running Orchestrion on your machine and then checking in the code, you run Orchestrion in your build pipeline right before `go build`. 
-
-1. Install Orchestrion in your build scripts/jobs.
-```sh
-go install github.com/datadog/orchestrion@latest
-```
-
-2. Run Orchestrion over your project before your compile step (`go build <target>`).
-```sh
-## This will recursively instrument everything in the directory (./) and its subdirectories.
-orchestrion -w ./
-
-go build <target>
-```
-
-3. Your build script should build a traced version of your project. You won't have to check in this code, so your codebase can remain untouched by tracing-specific code.
-
-**Note**: It's a known issue that adding instrumentation at build time can alter the line numbers in your instrumented files. As a result, the line numbers in stack traces may differ from those in the checked-in code in your version control system.
-
-## Example
-
-### Starting code
-
-Given a small `main.go` file, we can add instrumentation with one command.
-
-`main.go`:
-```go
-package main
-
-import (
-	"context"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-)
-
-func main() {
-	http.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
-		data, err := GetSomeData(request.Context())
-		if err != nil {
-			http.Error(writer, fmt.Sprintf("Failed to get data: %v", err), http.StatusInternalServerError)
-			return
-		}
-		writer.Write(data)
-	})
-
-	http.ListenAndServe(":8080", nil)
-}
-
-//dd:span my:tag
-func GetSomeData(ctx context.Context) ([]byte, error) {
-	client := &http.Client{
-		Timeout: time.Second,
-	}
-	req, err := http.NewRequestWithContext(ctx,
-		http.MethodPost, "http://example.com",
-		strings.NewReader("Hello, World!"))
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Println(resp.Status)
-	if resp.Body == nil {
-		return nil, nil
-	}
-	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
-}
-```
-
-### Adding instrumentation
-Run Orchestrion:
-```
-## in the directory with main.go
-orchestrion -w ./
-```
-
-### Results
-
-The `main.go` file has been modified with added instrumentation.
-
-`main.go`:
-```go
-package main
-
-import (
-	"context"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-
-	"github.com/datadog/orchestrion/instrument"
-	"github.com/datadog/orchestrion/instrument/event"
-)
-
-func main() {
-	//dd:startinstrument
-	defer instrument.Init()()
-	//dd:endinstrument
-	//dd:startwrap
-	http.HandleFunc("/", instrument.WrapHandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		data, err := GetSomeData(request.Context())
-		if err != nil {
-			http.Error(writer, fmt.Sprintf("Failed to get data: %v", err), http.StatusInternalServerError)
-			return
-		}
-		writer.Write(data)
-	}))
-	//dd:endwrap
-
-	http.ListenAndServe(":8080", nil)
-}
-
-//dd:span my:tag
-func GetSomeData(ctx context.Context) ([]byte, error) {
-	//dd:startinstrument
-	ctx = instrument.Report(ctx, event.EventStart, "function-name", "GetSomeData", "my", "tag")
-	defer instrument.Report(ctx, event.EventEnd, "function-name", "GetSomeData", "my", "tag")
-	//dd:endinstrument
-	//dd:startwrap
-	client := instrument.WrapHTTPClient(&http.Client{
-		Timeout: time.Second,
-	})
-	//dd:endwrap
-	req, err := http.NewRequestWithContext(ctx,
-		http.MethodPost, "http://example.com",
-		strings.NewReader("Hello, World!"))
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Println(resp.Status)
-	if resp.Body == nil {
-		return nil, nil
-	}
-	defer resp.Body.Close()
-	return io.ReadAll(resp.Body)
-}
-
-```
-
-### Building
-
-```
-## You may need to tidy the go.mod file:
-go mod tidy
-
-## Then it can be built normally
-go build main.go
-```
-
-And running it, we can see traces when the sample program receives requests.
-```
-./main
-2023/07/18 10:13:28 Datadog Tracer v1.53.0-rc.1 INFO: DATADOG TRACER CONFIGURATION ...
-```
-
-In another terminal:
-```
-curl http://localhost:8080/
-```
-
-In the UI:
-
-![A trace for the instrumented application](doc/trace.png)
-
-## Additional Examples
-
-For a more complete, downloadable example including distributed traces between multiple services, please see our sample application here: [DataDog/go-sample-app][1].
+It is also possible to use the standard `go build` command while specifying the `-toolexec "orchestrion toolexec"`
+argument (either directly on the command line, or via the `GOFLAGS` environment variable) yourself.
 
 ## How it works
 
-The source code package tree is scanned. For each source code file, `dave/dst` is used to build an AST of the source code in the file.
+The go toolchain's `-toolexec` feature invokes `orchestrion toolexec` with the complete list of arguments for each
+toolchain command invocation, allowing `orchestrion` to inspect and modify those before executing the actual command.
+This allows `orchestrion` to inspect all the go source files that contribute to the complete application, and to modify
+these to include instrumentation code where appropriate. Orchestrion uses [`dave/dst`][dave-dst] to parse and modify the
+go source code. Orchestrion adds `//line` directive comments in modified source files to make sure the stack trace
+information produced by the final application are not affected by additional code added during instrumentation.
 
-The AST is checked for package level functions or methods that have a `//dd:span` comment attached to them.
+Since the instrumentation may use packages not present in the original code, `orchestrion` also intercepts the standard
+go linker command invocations to make the relevant packages available to the linker.
 
-### dd:span magic comment
+[dave-dst]: https://github.com/dave/dst
 
-Use a `dd:span` comment before any function or method to create specific spans from your automatically instrumented code. Spans will include tags described as arguments in the `dd:span`.
+### Directive comments
 
-A function or method annotated with `//dd:span` must have a `context.Context` as its first parameter, or an `*http.Request` as any parameter in order for a span to be automatically inserted into the code.
+Directive comments are special single-line comments with no space between then `//` and the directive name. These allow
+influencing the behavior of Orchestrion in a declarative manner.
 
-The context or request is required for trace information to be passed through function calls in a Go program. If this condition is met, the `//dd:span` comment is scanned and code is inserted as the first lines of the function.
+#### `//dd:ignore`
 
-It's possible to add key-value pairs separated by `:` or arguments (including their fields) present in the function or method signature.
+The `//dd:ignore` directive instructs Orchestrion not to perform any code changes in Go code nested in the decorated
+scope: when applied to a statement, it prevents instrumentations from being added to any component of this statement,
+and when applied to a block, or function, it prevents instrumentation from being added anywhere in that block or
+function.
+
+This is useful when you specifically want to opt out of instrumenting certain parts of your code, either because it has
+already been instrumented manually, or because the tracing is undesirable (not useful, adds too much overhead in a
+performance-critical section, etc...).
+
+#### `//dd:span`
+
+Use a `//dd:span` comment before any function or method to create specific spans from your automatically instrumented
+code. Spans will include tags described as arguments in the `//dd:span`. In order for the directive to be recognized,
+the line-comment must be spelled out with no white space after the `//` comment start.
+
+A function or method annotated with `//dd:span` must receive an argument of type `context.Context` or `*http.Request`.
+The context or request is required for trace information to be passed through function calls in a Go program. If this
+condition is met, the `//dd:span` comment is scanned and code is inserted in the function preamble (before any other
+code).
+
+Span tags are specified as a space-delimited series of `name:value` pairs, or as simple expressions referring to
+argument names (or access to fields thereof). All `name:value` pairs are provided as strings, and expressions are
+expected to evaluate to strings as well.
 
 ```go
 //dd:span my:tag type:request name req.Method
 func HandleRequest(name string, req *http.Request) {
-	//dd:startinstrument
+	// ↓↓↓↓ Instrumentation added by Orchestrion ↓↓↓↓
 	req = req.WithContext(instrument.Report(req.Context(), event.EventStart, "function-name", "HandleRequest", "my", "tag", "type", "request", "name", name, "req.Method", req.Method))
 	defer instrument.Report(req.Context(), event.EventEnd, "function-name", "HandleRequest", "my", "tag", "type", "request", "name", name, "req.Method", req.Method)
-	//dd:endinstrument
-	
+	// ↑↑↑↑ End of added instrumentation ↑↑↑↑
+
 	// your code here
 }
 ```
-
-Note: key-value pairs will be passed as strings. Arguments' values are expected to be string too.
 
 ## Supported libraries
 
 Orchestrion supports automatic tracing of the following libraries:
 
-- [x] `net/http`
-- [x] `database/sql`
-- [x] `google.golang.org/grpc`
-- [x] `github.com/gin-gonic/gin`
-- [x] `github.com/labstack/echo/v4`
-- [x] `github.com/go-chi/chi/v5`
-- [x] `github.com/gorilla/mux`
-- [x] `github.com/gofiber/fiber/v2`
+- `net/http`
+- `database/sql`
+- `google.golang.org/grpc`
+- `github.com/gin-gonic/gin`
+- `github.com/labstack/echo/v4`
+- `github.com/go-chi/chi/v5`
+- `github.com/gorilla/mux`
+- `github.com/gofiber/fiber/v2`
 
-Calls to these libraries are instrumented with library-specific code adding tracing to them, including support for distributed traces.
-
-## Next steps
-
-- [ ] Support compile-time auto-instrumentation via `-toolexec`
-- [ ] Support auto-instrumenting more third-party libraries
-- [ ] Support for OpenTelemetry
+Calls to these libraries are instrumented with library-specific code adding tracing to them, including support for
+distributed traces.
 
 [1]: https://github.com/DataDog/go-sample-app
+
+## Troubleshooting
+
+If you run into issues when using `orchestrion` please make sure to collect all relevant details about your setup in
+order to help us identify (and ideally reproduce) the issue. The version of orchestrion (which can be obtained from
+`orchestrion version`) as well as of the go toolchain (from `go version`) are essential and must be provided with any
+bug report.
+
+You can inspect everything Orchestrion is doing by adding the `-work` argument to your `go build` command; when doing so
+the build will emit a `WORK=` line pointing to a working directory that is retained after the build is finished. The
+contents of this directory contains all updated source code Orchestrion produced and additional metadata that can help
+diagnosing issues.


### PR DESCRIPTION
Updates the `README.md` to match the `-toolexec` usage model.