### PR TITLE
fix: `append-args` breaks on ellipsis

### DIFF
--- a/internal/injector/aspect/advice/call.go
+++ b/internal/injector/aspect/advice/call.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 
 	"github.com/datadog/orchestrion/internal/injector/aspect/advice/code"
+	"github.com/datadog/orchestrion/internal/injector/aspect/join"
 	"github.com/datadog/orchestrion/internal/injector/node"
+	"github.com/datadog/orchestrion/internal/injector/typed"
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
 	"github.com/dave/jennifer/jen"
@@ -18,11 +20,14 @@ import (
 )
 
 type appendArgs struct {
+	typeName  join.TypeName
 	templates []code.Template
 }
 
-func AppendArgs(templates ...code.Template) *appendArgs {
-	return &appendArgs{templates}
+// AppendArgs appends arguments of a given type to the end of a function call. All arguments must be
+// of the same type, as they may be appended at the tail end of a variadic call.
+func AppendArgs(typeName join.TypeName, templates ...code.Template) *appendArgs {
+	return &appendArgs{typeName, templates}
 }
 
 func (a *appendArgs) Apply(ctx context.Context, chain *node.Chain, csor *dstutil.Cursor) (bool, error) {
@@ -40,13 +45,65 @@ func (a *appendArgs) Apply(ctx context.Context, chain *node.Chain, csor *dstutil
 		}
 	}
 
-	call.Args = append(call.Args, newArgs...)
+	if !call.Ellipsis {
+		call.Args = append(call.Args, newArgs...)
+		return true, nil
+	}
+
+	// The function call has an ellipsis, so we need to append our new arguments to the last argument,
+	// which is a slice. To do so, we need to provision a new slice of the right type and size, append
+	// all the relevant data in there, and then replace the last argument with the new slice.
+	lastIdx := len(call.Args) - 1
+	call.Args[lastIdx] = &dst.CallExpr{
+		Fun: &dst.FuncLit{
+			Type: &dst.FuncType{
+				Params: &dst.FieldList{
+					List: []*dst.Field{{
+						Names: []*dst.Ident{dst.NewIdent("opts")},
+						Type:  &dst.Ellipsis{Elt: a.typeName.AsNode()},
+					}},
+				},
+				Results: &dst.FieldList{
+					List: []*dst.Field{{
+						Type: &dst.ArrayType{Elt: a.typeName.AsNode()},
+					}},
+				},
+			},
+			Body: &dst.BlockStmt{
+				List: []dst.Stmt{
+					&dst.ReturnStmt{Results: []dst.Expr{
+						&dst.CallExpr{
+							Fun: dst.NewIdent("append"),
+							Args: append(
+								append(
+									make([]dst.Expr, 0, len(newArgs)+1),
+									dst.NewIdent("opts"),
+								),
+								newArgs...,
+							),
+						},
+					}},
+				},
+			},
+		},
+		Args:     []dst.Expr{call.Args[lastIdx]},
+		Ellipsis: true,
+	}
+
+	if importPath := a.typeName.ImportPath(); importPath != "" {
+		if file, ok := typed.ContextValue[*dst.File](ctx); ok {
+			if refMap, ok := typed.ContextValue[*typed.ReferenceMap](ctx); ok {
+				refMap.AddImport(file, importPath)
+			}
+		}
+	}
 
 	return true, nil
 }
 
 func (a *appendArgs) AsCode() jen.Code {
 	return jen.Qual(pkgPath, "AppendArgs").CallFunc(func(group *jen.Group) {
+		group.Line().Add(a.typeName.AsCode())
 		for _, t := range a.templates {
 			group.Line().Add(t.AsCode())
 		}
@@ -56,10 +113,20 @@ func (a *appendArgs) AsCode() jen.Code {
 
 func init() {
 	unmarshalers["append-args"] = func(node *yaml.Node) (Advice, error) {
-		var templates []code.Template
-		if err := node.Decode(&templates); err != nil {
+		var args struct {
+			TypeName string          `yaml:"type"`
+			Values   []code.Template `yaml:"values"`
+		}
+
+		if err := node.Decode(&args); err != nil {
 			return nil, err
 		}
-		return AppendArgs(templates...), nil
+
+		tn, err := join.NewTypeName(args.TypeName)
+		if err != nil {
+			return nil, err
+		}
+
+		return AppendArgs(tn, args.Values...), nil
 	}
 }

--- a/internal/injector/aspect/join/join.go
+++ b/internal/injector/aspect/join/join.go
@@ -41,7 +41,7 @@ type TypeName struct {
 	pointer bool
 }
 
-var typeNameRe = regexp.MustCompile(`\A(\*)?(?:([A-Za-z_][A-Za-z0-9_]+(?:/[A-Za-z_][A-Za-z0-9_]+)*)\.)?([A-Za-z_][A-Za-z0-9_]*)\z`)
+var typeNameRe = regexp.MustCompile(`\A(\*)?\s*(?:([A-Za-z_][A-Za-z0-9_.-]+(?:/[A-Za-z_.-][A-Za-z0-9_.-]+)*)\.)?([A-Za-z_][A-Za-z0-9_]*)\z`)
 
 func NewTypeName(n string) (tn TypeName, err error) {
 	matches := typeNameRe.FindStringSubmatch(n)
@@ -63,6 +63,12 @@ func MustTypeName(n string) (tn TypeName) {
 		panic(err)
 	}
 	return
+}
+
+// ImportPath returns the import path for this type name, or a blank string if
+// this refers to a local or built-in type.
+func (n *TypeName) ImportPath() string {
+	return n.path
 }
 
 func (n *TypeName) Matches(node dst.Expr) bool {

--- a/internal/injector/builtin/generated.go
+++ b/internal/injector/builtin/generated.go
@@ -175,6 +175,7 @@ var Aspects = [...]aspect.Aspect{
 		JoinPoint: join.FunctionCall("google.golang.org/grpc.Dial"),
 		Advice: []advice.Advice{
 			advice.AppendArgs(
+				join.MustTypeName("google.golang.org/grpc.DialOption"),
 				code.MustTemplate(
 					"grpc.WithStreamInterceptor(grpctrace.StreamClientInterceptor())",
 					map[string]string{
@@ -196,6 +197,7 @@ var Aspects = [...]aspect.Aspect{
 		JoinPoint: join.FunctionCall("google.golang.org/grpc.NewServer"),
 		Advice: []advice.Advice{
 			advice.AppendArgs(
+				join.MustTypeName("google.golang.org/grpc.ServerOption"),
 				code.MustTemplate(
 					"grpc.StreamInterceptor(grpctrace.StreamServerInterceptor())",
 					map[string]string{
@@ -311,4 +313,4 @@ var RestorerMap = map[string]string{
 }
 
 // Checksum is a checksum of the built-in configuration which can be used to invalidate caches.
-const Checksum = "sha512:5pCLu294ZbGQAdwTIA3paSIdPLNtvYIVGyn09oYlEXSutfRHvgUHuYzcFSfbe7hWEoX8ovTnoxMaBupR+j1A4A=="
+const Checksum = "sha512:K7Wx44EoT37GaznSSDHXAR6eaC+/xX8MucoH5IqZb+TPM5JyMPKMe573l9jI9B9GVkY2sEULLqwqcGsH013BGQ=="

--- a/internal/injector/builtin/yaml/grpc.yml
+++ b/internal/injector/builtin/yaml/grpc.yml
@@ -9,19 +9,23 @@
     function-call: google.golang.org/grpc.Dial
   advice:
     - append-args:
-        - imports: &imports
-            grpc: google.golang.org/grpc
-            grpctrace: gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc
-          template: grpc.WithStreamInterceptor(grpctrace.StreamClientInterceptor())
-        - imports: *imports
-          template: grpc.WithUnaryInterceptor(grpctrace.UnaryClientInterceptor())
+        type: google.golang.org/grpc.DialOption
+        values:
+          - imports: &imports
+              grpc: google.golang.org/grpc
+              grpctrace: gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc
+            template: grpc.WithStreamInterceptor(grpctrace.StreamClientInterceptor())
+          - imports: *imports
+            template: grpc.WithUnaryInterceptor(grpctrace.UnaryClientInterceptor())
 
 # Server Instrumentation
 - join-point:
     function-call: google.golang.org/grpc.NewServer
   advice:
     - append-args:
-        - imports: *imports
-          template: grpc.StreamInterceptor(grpctrace.StreamServerInterceptor())
-        - imports: *imports
-          template: grpc.UnaryInterceptor(grpctrace.UnaryServerInterceptor())
+        type: google.golang.org/grpc.ServerOption
+        values:
+          - imports: *imports
+            template: grpc.StreamInterceptor(grpctrace.StreamServerInterceptor())
+          - imports: *imports
+            template: grpc.UnaryInterceptor(grpctrace.UnaryServerInterceptor())

--- a/internal/injector/testdata/injector.yml
+++ b/internal/injector/testdata/injector.yml
@@ -729,19 +729,23 @@ grpc-client:
           function-call: google.golang.org/grpc.Dial
         advice:
           - append-args:
-              - imports: &imports
-                  instrument: github.com/datadog/orchestrion/instrument
-                template: instrument.GRPCStreamClientInterceptor()
-              - imports: *imports
-                template: instrument.GRPCUnaryClientInterceptor()
+              type: google.golang.org/grpc.DialOption
+              values:
+                - imports: &imports
+                    instrument: github.com/datadog/orchestrion/instrument
+                  template: instrument.GRPCStreamClientInterceptor()
+                - imports: *imports
+                  template: instrument.GRPCUnaryClientInterceptor()
       - join-point:
           function-call: google.golang.org/grpc.NewServer
         advice:
           - append-args:
-              - imports: *imports
-                template: instrument.GRPCStreamServerInterceptor()
-              - imports: *imports
-                template: instrument.GRPCUnaryServerInterceptor()
+              type: google.golang.org/grpc.ServerOption
+              values:
+                - imports: *imports
+                  template: instrument.GRPCStreamServerInterceptor()
+                - imports: *imports
+                  template: instrument.GRPCUnaryServerInterceptor()
 
   source: |
     package main
@@ -754,7 +758,8 @@ grpc-client:
     )
 
     func grpcClient() {
-      conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure())
+      dialOpts := []grpc.DialOption{grpc.WithInsecure()}
+      conn, err := grpc.Dial("localhost:50051", dialOpts...)
       if err != nil {
         log.Fatal(err)
       }
@@ -790,10 +795,15 @@ grpc-client:
 
       //line input.go:10
       func grpcClient() {
-        conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure(),
+        dialOpts := []grpc.DialOption{grpc.WithInsecure()}
+        conn, err := grpc.Dial("localhost:50051",
       //line <generated>:1
-          instrument.GRPCStreamClientInterceptor(), instrument.GRPCUnaryClientInterceptor())
+          func(opts ...grpc.DialOption) []grpc.DialOption {
+            return append(opts, instrument.GRPCStreamClientInterceptor(), instrument.GRPCUnaryClientInterceptor())
+          }(
       //line input.go:12
+            dialOpts...)...)
+      //line input.go:13
         if err != nil {
           log.Fatal(err)
         }
@@ -809,7 +819,7 @@ grpc-client:
         s := grpc.NewServer(grpc.EmptyServerOption{},
       //line <generated>:1
           instrument.GRPCStreamServerInterceptor(), instrument.GRPCUnaryServerInterceptor())
-      //line input.go:25
+      //line input.go:26
         if err := s.Serve(ln); err != nil {
           log.Fatalf("failed to serve: %v", err)
         }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,4 +6,4 @@
 package version
 
 // Tag specifies the current release tag. It needs to be manually updated.
-const Tag = "v0.7.0-dev.1"
+const Tag = "v0.7.0-dev.2"


### PR DESCRIPTION
When an ellipsis is used on a call that is targeted by an `append-args` advice, the new arguments were simply added to the list of values, which resulted in invalid code.

To address this, the `append-args` advice now injects an IIFE that correctly generates a new slice with the additional arguments injected in. The use of an IIFE allows removing problems if the variadic argument is provided as a function call (calling that multiple times could result in duplicated side-effects, etc...).

Fixes #88
