### PR TITLE
fix: blank import `./instruments` in `tools.go`

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -13,6 +13,7 @@ import (
 	_ "golang.org/x/tools/cmd/stringer"
 
 	// Instrumentation packages
+	_ "github.com/datadog/orchestrion/instrument"
 	_ "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 	_ "gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin"
 	_ "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5"


### PR DESCRIPTION
In order to better inter-operate with `go mod vendor`, add a blank import on `github.com/datadog/orchestrion/instrument` so that package (and its dependencies) is not pruned by `go mod vendor` for not being explicitly required.
