### PR TITLE
fix: error message shows useless expectation

### DIFF
--- a/internal/injector/aspect/advice/block.go
+++ b/internal/injector/aspect/advice/block.go
@@ -31,7 +31,7 @@ func PrependStmts(template code.Template) *blockStmts {
 func (a *blockStmts) Apply(ctx context.Context, node *node.Chain, csor *dstutil.Cursor) (bool, error) {
 	block, ok := node.Node.(*dst.BlockStmt)
 	if !ok {
-		return false, fmt.Errorf("expected *dst.BlockStmt, got %T", node)
+		return false, fmt.Errorf("expected *dst.BlockStmt, got %T", node.Node)
 	}
 
 	stmts, err := a.template.CompileBlock(ctx, node)


### PR DESCRIPTION
The error message produced in case when an advice is used on an incompatible join-point output the type name `*node.Chain` instead of the actual underlying node type name... This fixes that issue to make the error message more useful.