### PR TITLE
refactor: replace inject-source-file with inject-declarations

### DIFF
--- a/internal/injector/aspect/advice/code/template.go
+++ b/internal/injector/aspect/advice/code/template.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go/token"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,7 +34,18 @@ type Template struct {
 var wrapper = template.Must(template.New("code.Template").Funcs(template.FuncMap{
 	"Version": func() string { return version.Tag },
 }).Parse(
-	"{{define `_`}}package _\nfunc _() {\n{{template `code.Template` .}}\n}{{end}}",
+	`
+{{- define "_statements_" -}}
+package _
+func _() {
+	{{template "code.Template" .}}
+}
+{{- end -}}
+{{- define "_declarations_" -}}
+package _
+{{ template "code.Template" . }}
+{{- end -}}}
+	`,
 ))
 
 // NewTemplate creates a new Template using the provided template string and
@@ -67,6 +79,12 @@ func (t *Template) CompileBlock(ctx context.Context, node *node.Chain) (*dst.Blo
 	return &dst.BlockStmt{List: stmts}, nil
 }
 
+// CompileDeclarations generates new source based on this Template and extracts
+// all produced declarations.
+func (t *Template) CompileDeclarations(ctx context.Context, node *node.Chain) ([]dst.Decl, error) {
+	return t.compileTemplate(ctx, "_declarations_", node)
+}
+
 // CompileExpression generates new source based on this Template and extracts
 // the produced dst.Expr node. The provided context.Context and *dstutil.Cursor
 // are used to supply context information to the template functions. The
@@ -98,6 +116,15 @@ func (t *Template) CompileExpression(ctx context.Context, node *node.Chain) (dst
 // compile generates new source based on this Template and returns a cloned
 // version of minimally post-processed dst.Stmt nodes this produced.
 func (t *Template) compile(ctx context.Context, chain *node.Chain) ([]dst.Stmt, error) {
+	decls, err := t.compileTemplate(ctx, "_statements_", chain)
+	if err != nil {
+		return nil, err
+	}
+
+	return decls[0].(*dst.FuncDecl).Body.List, nil
+}
+
+func (t *Template) compileTemplate(ctx context.Context, name string, chain *node.Chain) ([]dst.Decl, error) {
 	ctxFile, found := node.Find[*dst.File](chain)
 	if !found {
 		return nil, errors.New("no *dst.File was found in the node chain")
@@ -107,7 +134,7 @@ func (t *Template) compile(ctx context.Context, chain *node.Chain) ([]dst.Stmt, 
 
 	buf := bytes.NewBuffer(nil)
 	dot := &dot{node: chain}
-	if err := tmpl.ExecuteTemplate(buf, "_", dot); err != nil {
+	if err := tmpl.ExecuteTemplate(buf, name, dot); err != nil {
 		return nil, fmt.Errorf("while executing template: %w", err)
 	}
 
@@ -117,18 +144,22 @@ func (t *Template) compile(ctx context.Context, chain *node.Chain) ([]dst.Stmt, 
 	}
 	file, err := dec.Parse(buf.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("while parsing generated code: %w\n%q", err, numberLines(buf.String()))
+		return nil, fmt.Errorf("while parsing generated code: %w\n%s", err, numberLines(buf.String()))
 	}
 
-	body := file.Decls[0].(*dst.FuncDecl).Body
-	dot.placeholders.replaceAllIn(body)
-
-	list := body.List
-	stmts := make([]dst.Stmt, len(list))
-	for i, node := range list {
-		stmts[i] = t.processImports(ctx, ctxFile, node).(dst.Stmt)
+	decls := make([]dst.Decl, 0, len(file.Decls))
+	for _, decl := range file.Decls {
+		if decl, ok := decl.(*dst.GenDecl); ok && decl.Tok == token.IMPORT {
+			return nil, errors.New("code templates must not contain import declarations, use the imports map instead")
+		}
+		decls = append(decls, dot.placeholders.replaceAllIn(decl).(dst.Decl))
 	}
-	return stmts, nil
+
+	for i := range decls {
+		decls[i] = t.processImports(ctx, ctxFile, decls[i]).(dst.Decl)
+	}
+
+	return decls, nil
 }
 
 // processImports replaces all *dst.SelectorExpr based on one of the names
@@ -201,6 +232,7 @@ func (t *Template) UnmarshalYAML(node *yaml.Node) (err error) {
 	var cfg struct {
 		Template string
 		Imports  map[string]string
+		Links    []string
 	}
 	if err = node.Decode(&cfg); err != nil {
 		return
@@ -213,7 +245,7 @@ func (t *Template) UnmarshalYAML(node *yaml.Node) (err error) {
 func numberLines(text string) string {
 	lines := strings.Split(text, "\n")
 	width := len(strconv.FormatInt(int64(len(lines)), 10))
-	format := fmt.Sprintf("%% %dd | %%s", width)
+	format := fmt.Sprintf("%% %dd | %%s", width+1)
 
 	for i, line := range lines {
 		lines[i] = fmt.Sprintf(format, i+1, line)

--- a/internal/injector/aspect/advice/import.go
+++ b/internal/injector/aspect/advice/import.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package advice provides implementations of the injector.Action interface for
+// common AST changes.
+package advice
+
+import (
+	"context"
+	"errors"
+
+	"github.com/datadog/orchestrion/internal/injector/node"
+	"github.com/datadog/orchestrion/internal/injector/typed"
+	"github.com/dave/dst"
+	"github.com/dave/dst/dstutil"
+	"github.com/dave/jennifer/jen"
+	"gopkg.in/yaml.v3"
+)
+
+type addBlankImport string
+
+func AddBlankImport(path string) addBlankImport {
+	return addBlankImport(path)
+}
+
+func (a addBlankImport) Apply(ctx context.Context, chain *node.Chain, _ *dstutil.Cursor) (bool, error) {
+	file, hasFile := node.Find[*dst.File](chain)
+	if !hasFile {
+		return false, errors.New("cannot add import: no *dst.File found in node.Chain")
+	}
+
+	refMap, hasMap := typed.ContextValue[*typed.ReferenceMap](ctx)
+	if !hasMap {
+		return false, errors.New("cannot add import: no *typed.ReferenceMap found in context")
+	}
+
+	refMap.AddImport(file, string(a))
+	return true, nil
+}
+
+func (a addBlankImport) AsCode() jen.Code {
+	return jen.Qual(pkgPath, "AddBlankImport").Call(jen.Lit(string(a)))
+}
+
+func (a addBlankImport) AddedImports() []string {
+	return []string{string(a)}
+}
+
+func init() {
+	unmarshalers["add-blank-import"] = func(node *yaml.Node) (Advice, error) {
+		var path string
+		if err := node.Decode(&path); err != nil {
+			return nil, err
+		}
+		return AddBlankImport(path), nil
+	}
+}

--- a/internal/injector/aspect/advice/inject.go
+++ b/internal/injector/aspect/advice/inject.go
@@ -8,32 +8,32 @@ package advice
 import (
 	"context"
 	"errors"
-	"fmt"
-	"go/parser"
-	"go/token"
+	"sort"
 
-	"github.com/datadog/orchestrion/internal/injector/basiclit"
+	"github.com/datadog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/datadog/orchestrion/internal/injector/node"
 	"github.com/datadog/orchestrion/internal/injector/typed"
 	"github.com/dave/dst"
-	"github.com/dave/dst/decorator"
 	"github.com/dave/dst/dstutil"
 	"github.com/dave/jennifer/jen"
 	"gopkg.in/yaml.v3"
 )
 
-type injectSourceFile []byte
-
-// InjectSourceFile merges all declarations in the provided source file into the current file. The package name of both
-// original & injected files must match.
-func InjectSourceFile(text string) injectSourceFile {
-	return injectSourceFile(text)
+type injectDeclarations struct {
+	template code.Template
+	links    []string
 }
 
-func (a injectSourceFile) Apply(ctx context.Context, chain *node.Chain, _ *dstutil.Cursor) (bool, error) {
-	dec, found := typed.ContextValue[*decorator.Decorator](ctx)
-	if !found {
-		return false, errors.New("cannot inject source file: no *decorator.Decorator in context")
+// InjectDeclarations merges all declarations in the provided source file into the current file. The package name of both
+// original & injected files must match.
+func InjectDeclarations(template code.Template, links []string) injectDeclarations {
+	return injectDeclarations{template, links}
+}
+
+func (a injectDeclarations) Apply(ctx context.Context, chain *node.Chain, _ *dstutil.Cursor) (bool, error) {
+	decls, err := a.template.CompileDeclarations(ctx, chain)
+	if err != nil {
+		return false, err
 	}
 
 	file, ok := node.Find[*dst.File](chain)
@@ -41,61 +41,49 @@ func (a injectSourceFile) Apply(ctx context.Context, chain *node.Chain, _ *dstut
 		return false, errors.New("cannot inject source file: no *dst.File in context")
 	}
 
-	newFile, err := dec.ParseFile("<generated>", []byte(a), parser.ParseComments)
-	if err != nil {
-		return false, fmt.Errorf("injecting new source file: %w", err)
-	}
+	file.Decls = append(file.Decls, decls...)
 
-	if file.Name.Name != newFile.Name.Name {
-		return false, fmt.Errorf("cannot inject source file: package names do not match (%s != %s)", file.Name.Name, newFile.Name.Name)
-	}
-
-	refMap, _ := typed.ContextValue[*typed.ReferenceMap](ctx)
-	if refMap == nil {
-		return false, fmt.Errorf("cannot inject source file: no *typed.ReferenceMap in context")
-	}
-
-	for _, decl := range newFile.Decls {
-		file.Decls, err = mergeDeclaration(file, refMap, file.Decls, decl)
-		if err != nil {
-			return false, err
+	if len(a.links) > 0 {
+		refMap, found := typed.ContextValue[*typed.ReferenceMap](ctx)
+		if !found {
+			return true, errors.New("unable to register link requirements, no *typed.ReferenceMap in context")
+		}
+		refMap.AddImport(file, "unsafe") // We use go:linkname so we have an implicit dependency on unsafe.
+		for _, link := range a.links {
+			refMap.AddLink(file, link)
 		}
 	}
 
 	return true, nil
 }
 
-func mergeDeclaration(file *dst.File, refs *typed.ReferenceMap, decls []dst.Decl, newDecl dst.Decl) ([]dst.Decl, error) {
-	if gen, ok := newDecl.(*dst.GenDecl); ok && gen.Tok == token.IMPORT {
-		for _, spec := range gen.Specs {
-			if imp, ok := spec.(*dst.ImportSpec); ok {
-				importPath, err := basiclit.String(imp.Path)
-				if err != nil {
-					return decls, err
-				}
-				refs.AddImport(file, importPath)
+func (a injectDeclarations) AsCode() jen.Code {
+	return jen.Qual(pkgPath, "InjectDeclarations").Call(
+		a.template.AsCode(),
+		jen.Index().String().ValuesFunc(func(g *jen.Group) {
+			sort.Strings(a.links)
+			for _, link := range a.links {
+				g.Line().Lit(link)
 			}
-		}
-		return decls, nil
-	}
-	return append(decls, newDecl), nil
+			g.Line()
+		}),
+	)
 }
 
-func (a injectSourceFile) AsCode() jen.Code {
-	return jen.Qual(pkgPath, "InjectSourceFile").Call(jen.Lit(string(a)))
-}
-
-func (a injectSourceFile) AddedImports() []string {
-	return nil
+func (a injectDeclarations) AddedImports() []string {
+	return a.links
 }
 
 func init() {
-	unmarshalers["inject-source-file"] = func(node *yaml.Node) (Advice, error) {
-		var text string
-		if err := node.Decode(&text); err != nil {
+	unmarshalers["inject-declarations"] = func(node *yaml.Node) (Advice, error) {
+		var config struct {
+			Template code.Template `yaml:",inline"`
+			Links    []string
+		}
+		if err := node.Decode(&config); err != nil {
 			return nil, err
 		}
 
-		return InjectSourceFile(text), nil
+		return InjectDeclarations(config.Template, config.Links), nil
 	}
 }

--- a/internal/injector/aspect/aspect.go
+++ b/internal/injector/aspect/aspect.go
@@ -37,7 +37,8 @@ func (a *Aspect) AsCode() (jp, adv jen.Code) {
 }
 
 func (a *Aspect) AddedImports() (imports []string) {
-	implied := make(map[string]struct{})
+	// "unsafe" is always implied, because it's special-cased in the go toolchain, and is not a "normal" module.
+	implied := map[string]struct{}{"unsafe": {}}
 	for _, path := range a.JoinPoint.ImpliesImported() {
 		implied[path] = struct{}{}
 	}

--- a/internal/injector/builtin/generated.go
+++ b/internal/injector/builtin/generated.go
@@ -369,7 +369,11 @@ var Aspects = [...]aspect.Aspect{
 		JoinPoint: join.StructDefinition(join.MustTypeName("runtime.g")),
 		Advice: []advice.Advice{
 			advice.AddStructField("__dd_gls", join.MustTypeName("any")),
-			advice.InjectSourceFile("package runtime\n\nimport (\n  _ \"unsafe\" // for go:linkname\n)\n\n//go:linkname __dd_orchestrion_gls_get __dd_orchestrion_gls_get\nfunc __dd_orchestrion_gls_get() any {\n  return getg().m.curg.__dd_gls\n}\n\n//go:linkname __dd_orchestrion_gls_set __dd_orchestrion_gls_set\nfunc __dd_orchestrion_gls_set(val any) {\n  getg().m.curg.__dd_gls = val\n}"),
+			advice.AddBlankImport("unsafe"),
+			advice.InjectDeclarations(code.MustTemplate(
+				"//go:linkname __dd_orchestrion_gls_get __dd_orchestrion_gls_get\nfunc __dd_orchestrion_gls_get() any {\n  return getg().m.curg.__dd_gls\n}\n\n//go:linkname __dd_orchestrion_gls_set __dd_orchestrion_gls_set\nfunc __dd_orchestrion_gls_set(val any) {\n  getg().m.curg.__dd_gls = val\n}",
+				map[string]string{},
+			), []string{}),
 		},
 	},
 }
@@ -421,4 +425,4 @@ var InjectedPaths = [...]string{
 }
 
 // Checksum is a checksum of the built-in configuration which can be used to invalidate caches.
-const Checksum = "sha512:oKkHjIFTKd1xA+1tAuFezR2trEwqRt+npSBK1L/VVIq8xcJi/zDeQJaalE/Gk+iO+g2ZxnujiXZduqDpEcUXdg=="
+const Checksum = "sha512:EsbLG0HdCZydc/Mb4pR+QP1xTyEBtVYWX6R/GY6S0inz1LD+F/X7W31mg1GkCWy3khcC1/XqJ7BgU6TFIp0cDA=="

--- a/internal/injector/builtin/yaml/stdlib/runtime.yml
+++ b/internal/injector/builtin/yaml/stdlib/runtime.yml
@@ -11,19 +11,15 @@
     - add-struct-field:
         name: __dd_gls
         type: any
-    - inject-source-file: |-
-        package runtime
+    - add-blank-import: unsafe # Needed for go:linkname
+    - inject-declarations:
+        template: |-
+          //go:linkname __dd_orchestrion_gls_get __dd_orchestrion_gls_get
+          func __dd_orchestrion_gls_get() any {
+            return getg().m.curg.__dd_gls
+          }
 
-        import (
-          _ "unsafe" // for go:linkname
-        )
-
-        //go:linkname __dd_orchestrion_gls_get __dd_orchestrion_gls_get
-        func __dd_orchestrion_gls_get() any {
-          return getg().m.curg.__dd_gls
-        }
-
-        //go:linkname __dd_orchestrion_gls_set __dd_orchestrion_gls_set
-        func __dd_orchestrion_gls_set(val any) {
-          getg().m.curg.__dd_gls = val
-        }
+          //go:linkname __dd_orchestrion_gls_set __dd_orchestrion_gls_set
+          func __dd_orchestrion_gls_set(val any) {
+            getg().m.curg.__dd_gls = val
+          }

--- a/internal/injector/typed/refmap.go
+++ b/internal/injector/typed/refmap.go
@@ -34,21 +34,37 @@ const (
 // available within the specified file. Returns true if that is the case. False if the import path
 // is already available within the file.
 func (r *ReferenceMap) AddImport(file *dst.File, path string) bool {
-	// Browse the current file to see if the import already exists...
-	for _, spec := range file.Imports {
-		specPath, err := basiclit.String(spec.Path)
-		if err != nil {
-			continue
-		}
-		if specPath == path {
-			return false
-		}
+	if hasImport(file, path) {
+		return false
 	}
 
 	// Register in this ReferenceMap
 	r.add(path, ImportStatement)
 
 	return true
+}
+
+func hasImport(file *dst.File, path string) bool {
+	for _, spec := range file.Imports {
+		specPath, err := basiclit.String(spec.Path)
+		if err != nil {
+			continue
+		}
+		if specPath == path {
+			return true
+		}
+	}
+	return false
+}
+
+// AddLink registers the provided path as a relocation target resolution source. If this path is
+// already registered as an import, this method does nothing and returns false.
+func (r *ReferenceMap) AddLink(file *dst.File, path string) bool {
+	if hasImport(file, path) {
+		return false
+	}
+
+	return r.add(path, RelocationTarget)
 }
 
 // AddSyntheticImports adds the registered imports to the provided *dst.File. This is not safe to
@@ -63,7 +79,7 @@ func (r *ReferenceMap) AddSyntheticImports(file *dst.File) bool {
 		if kind != ImportStatement {
 			continue
 		}
-		toAdd = append(toAdd, &dst.ImportSpec{Path: &dst.BasicLit{Kind: token.STRING, Value: fmt.Sprintf("%q", path)}})
+		toAdd = append(toAdd, &dst.ImportSpec{Path: &dst.BasicLit{Kind: token.STRING, Value: fmt.Sprintf("%q", path)}, Name: dst.NewIdent("_")})
 	}
 
 	if len(toAdd) == 0 {
@@ -110,14 +126,17 @@ func (r *ReferenceMap) Merge(other ReferenceMap) {
 	}
 }
 
-func (r *ReferenceMap) add(path string, kind ReferenceKind) {
+func (r *ReferenceMap) add(path string, kind ReferenceKind) bool {
 	if *r == nil {
 		*r = ReferenceMap{path: kind}
+		return true
 	} else if old, found := (*r)[path]; !found || old != ImportStatement {
 		// If it was already in as an ImportStatement, we don't do anything, since that is the strongest
 		// kind of reference (imported implies relocatable, the reverse is not true).
 		(*r)[path] = kind
+		return true
 	}
+	return false
 }
 
 func (k ReferenceKind) String() string {


### PR DESCRIPTION
After discovering it is extremely painful to track down & properly handle porting imports from the injected source file into the modified file; and realizing we have full featured support in the `code.Template` object, replaced the `inject-source-file` advice with a new `inject-declarations` version, which accepts a template, which is strictly more flexible.

It also supports specifying a list of `links`, which is packages that need to be linked against to resolve any `//go:linkname` directive within the injected declarations; and specifying any import path in there implies `unsafe` needs to be imported.