### PR TITLE
fix: linker may fail to satisfy linkdeps unless imported by main

### DIFF
--- a/internal/toolexec/aspect/oncompile-main.go
+++ b/internal/toolexec/aspect/oncompile-main.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package aspect
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/datadog/orchestrion/internal/log"
+	"github.com/datadog/orchestrion/internal/toolexec/aspect/linkdeps"
+	"github.com/datadog/orchestrion/internal/toolexec/importcfg"
+	"github.com/datadog/orchestrion/internal/toolexec/proxy"
+	"github.com/dave/jennifer/jen"
+)
+
+// OnCompileMain only performs changes when compiling the "main" package, adding blank imports for
+// any linkdeps dependencies that are not yet satisfied by the importcfg file. This ensures that the
+// relevant packages' `init` (if any) are appropriately run, and that the linker automatically picks
+// up these dependencies when creating the full binary.
+func (w Weaver) OnCompileMain(cmd *proxy.CompileCommand) error {
+	if cmd.Flags.Package != "main" {
+		return nil
+	}
+
+	log.SetContext("PHASE", "compile(main)")
+	defer log.SetContext("PHASE", "")
+
+	reg, err := importcfg.ParseFile(cmd.Flags.ImportCfg)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %w", cmd.Flags.ImportCfg, err)
+	}
+
+	var addImports []string
+	for _, archive := range reg.PackageFile {
+		data, err := readArchiveData(archive, linkdeps.LinkDepsFilename)
+		if err != nil {
+			return fmt.Errorf("reading %s from %q: %w", linkdeps.LinkDepsFilename, archive, err)
+		} else if data == nil {
+			continue
+		}
+
+		log.Tracef("Found %s file in %q\n", linkdeps.LinkDepsFilename, archive)
+		linkDeps, err := linkdeps.Read(data)
+		if err != nil {
+			return fmt.Errorf("reading %s from %q: %w", linkdeps.LinkDepsFilename, archive, err)
+		}
+
+		for _, depPath := range linkDeps.Dependencies() {
+			if arch, found := reg.PackageFile[depPath]; found {
+				log.Debugf("Already satisfied %s dependency: %q => %q\n", linkdeps.LinkDepsFilename, depPath, arch)
+				continue
+			}
+
+			deps, err := resolvePackageFiles(depPath)
+			if err != nil {
+				return fmt.Errorf("resolving %q: %w", depPath, err)
+			}
+			for p, a := range deps {
+				if _, found := reg.PackageFile[p]; !found {
+					log.Debugf("Recording resolved %s dependency: %q => %q\n", linkdeps.LinkDepsFilename, p, a)
+					reg.PackageFile[p] = a
+				}
+			}
+			addImports = append(addImports, depPath)
+		}
+	}
+
+	if len(addImports) == 0 {
+		// Nothing was added, we're done!
+		return nil
+	}
+
+	// We back up the original ImportCfg file only if there's not already such a file (could have been created by OnCompile)
+	backupFile := cmd.Flags.ImportCfg + ".original"
+	if _, err := os.Stat(backupFile); errors.Is(err, os.ErrNotExist) {
+		log.Tracef("Backing up original %q\n", cmd.Flags.ImportCfg)
+		if err := os.Rename(cmd.Flags.ImportCfg, backupFile); err != nil {
+			return fmt.Errorf("renaming %q: %w", cmd.Flags.ImportCfg, err)
+		}
+	}
+	log.Tracef("Writing updated %q\n", cmd.Flags.ImportCfg)
+	if err := reg.WriteFile(cmd.Flags.ImportCfg); err != nil {
+		return fmt.Errorf("writing updated %q: %w", cmd.Flags.ImportCfg, err)
+	}
+
+	source := jen.NewFile("main")
+	for _, imp := range addImports {
+		source.Anon(imp)
+	}
+
+	genDir := filepath.Join(filepath.Dir(cmd.Flags.Output), "orchestrion", "src", "synthetic")
+	genFile := filepath.Join(genDir, "link_deps_imports.go")
+	log.Tracef("Writing new blank imports source file %q\n", genFile)
+	if err := os.MkdirAll(genDir, 0o755); err != nil {
+		return fmt.Errorf("creating directory %q: %w", genDir, err)
+	}
+	if err := source.Save(genFile); err != nil {
+		return fmt.Errorf("writing generated code to %q: %w", genFile, err)
+	}
+
+	log.Debugf("Adding synthetic source file to command: %q\n", genFile)
+	cmd.AddFiles([]string{genFile})
+
+	return nil
+}

--- a/internal/toolexec/aspect/oncompile-main.go
+++ b/internal/toolexec/aspect/oncompile-main.go
@@ -19,9 +19,11 @@ import (
 )
 
 // OnCompileMain only performs changes when compiling the "main" package, adding blank imports for
-// any linkdeps dependencies that are not yet satisfied by the importcfg file. This ensures that the
-// relevant packages' `init` (if any) are appropriately run, and that the linker automatically picks
-// up these dependencies when creating the full binary.
+// any linkdeps dependencies that are not yet satisfied by the importcfg file (this is the case for
+// link-time dependencies implied by use of the go:linkname directive, which are used to avoid
+// creating circular import dependencies).
+// This ensures that the relevant packages' `init` (if any) are appropriately run, and that the
+// linker automatically picks up these dependencies when creating the full binary.
 func (w Weaver) OnCompileMain(cmd *proxy.CompileCommand) error {
 	if cmd.Flags.Package != "main" {
 		return nil

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -93,7 +93,7 @@ func (w Weaver) OnCompile(cmd *proxy.CompileCommand) error {
 		regUpdated bool
 	)
 	for depImportPath, kind := range references {
-		if _, ok := reg.PackageFile[depImportPath]; ok {
+		if _, ok := reg.PackageFile[depImportPath]; ok || depImportPath == "unsafe" {
 			// Already part of natural dependencies, nothing to do...
 			continue
 		}

--- a/internal/toolexec/proxy/compile.go
+++ b/internal/toolexec/proxy/compile.go
@@ -45,8 +45,8 @@ func (cmd *CompileCommand) GoFiles() []string {
 // AddFiles adds the provided go files paths to the list of Go files passed
 // as arguments to cmd
 func (cmd *CompileCommand) AddFiles(files []string) {
-	paramIdx := len(cmd.paramPos)
-
+	paramIdx := len(cmd.args)
+	cmd.args = append(cmd.args, files...)
 	for i, f := range files {
 		cmd.paramPos[f] = paramIdx + i
 	}

--- a/main.go
+++ b/main.go
@@ -140,6 +140,13 @@ func main() {
 			}
 			utils.ExitIfError(err)
 		}
+		if err := proxy.ProcessCommand(proxyCmd, weaver.OnCompileMain); err != nil {
+			if errors.Is(err, proxy.ErrSkipCommand) {
+				log.Infof("SKIP: %q\n", proxyCmd.Args())
+				return
+			}
+			utils.ExitIfError(err)
+		}
 		if err := proxy.ProcessCommand(proxyCmd, weaver.OnLink); err != nil {
 			if errors.Is(err, proxy.ErrSkipCommand) {
 				log.Infof("SKIP: %q\n", proxyCmd.Args())


### PR DESCRIPTION
Go's `linker` does not bring in all objects from the `importcfg` file unconditionally, instead it only loads objects (transitively) **imported** by the `main` module. This means that _linkDeps_ introduced to satisfy `//go:linkname` directives may not be satisfied by the linker (resulting in undefined symbol errors) unless those dependencies are imported.

This change adds an `OnCompileMain` transformer to the `Weaver` that adds a new synthetic source file that contains blank imports of any yet-to-be-satisfied _linkDeps_ entry, ensuring the linker later satisfies them. It also has the benefit of making sure the compiler correctly registers any `init` function from these dependencies on the start-up stack.

This ought to be safe to do in `main`, since this cannot possibly introduce circular dependencies (and is generally considered good practice if you're using `//go:linkname` anyway).

---

NB - This was discovered as it broke #108, which will hence contribute to creating testing coverage for this change.