### PR TITLE
chore: collect & upload code coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: ${{ matrix.go-version }},unit
+          flags: go${{ matrix.go-version }},${{ runner.os }}-${{ runner.arch }},unit,unit.${{ runner.os }}-${{ runner.arch }}
           files: coverage/report.out
 
   integration-tests:
@@ -86,7 +86,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: ${{ matrix.go-version }},integration
+          flags: go${{ matrix.go-version }},${{ runner.os }}-${{ runner.arch }},integration,integration.${{ runner.os }}-${{ runner.arch }}
           files: _integration-tests/outputs/coverage/*
       - name: Upload artifact
         # We want this even if the tests failed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,12 @@ jobs:
           python-version: '>=3.9 <3.13'
       - name: Run Integration Tests
         run: ./integration-tests.ps1
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ matrix.go-version }},integration
+          files: _integration-tests/outputs/coverage/*
       - name: Upload artifact
         # We want this even if the tests failed
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,15 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: "**/*.sum"
       - name: Run unit tests
-        run: go test -cover -covermode=atomic -race ./...
+        run: |-
+          mkdir -p coverage
+          go test -cover -covermode=atomic -coverpkg=./... -coverprofile=coverage/report.out -race ./...
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ matrix.go-version }},unit
+          files: coverage/report.out
 
   integration-tests:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /errors
 *.swp
 orchestrion
+coverage/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 ---
+ignore:
+  - '**/generator/main.go' # Generators are not actually part of the product
+  - 'samples/**' # This is sample code for instrumentable things
+  - 'tools/**' # Repository maintenance tooling
+
 coverage:
   status:
     project:
@@ -13,19 +18,23 @@ coverage:
 comment:
   require_changes: true
 
-individual_components:
-  - component_id: instruments
-    name: Instruments
-    paths: [instrument/**]
-  - component_id: go-driver
-    name: Go Driver
-    paths: [internal/go*/**]
-  - component_id: toolexec-driver
-    name: Toolexec Driver
-    paths: [internal/toolexec/**]
-  - component_id: aspects
-    name: Aspects
-    paths: [internal/injector/aspect/**]
-  - component_id: injector
-    name: Injector
-    paths: [internal/injector/**]
+component_management:
+  individual_components:
+    - component_id: instruments
+      name: Instruments
+      paths: [instrument/**]
+    - component_id: go-driver
+      name: Go Driver
+      paths: [internal/go*/**]
+    - component_id: toolexec-driver
+      name: Toolexec Driver
+      paths: [internal/toolexec/**]
+    - component_id: aspects
+      name: Aspects
+      paths: [internal/injector/aspect/**]
+    - component_id: injector
+      name: Injector
+      paths: [internal/injector/**]
+    - component_id: test-harness
+      name: Test Harness
+      paths: [_integration-tests/**]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+---
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: auto
+        informational: true
+
+comment:
+  require_changes: true
+
+individual_components:
+  - component_id: instruments
+    name: Instruments
+    paths: [instrument/**]
+  - component_id: go-driver
+    name: Go Driver
+    paths: [internal/go*/**]
+  - component_id: toolexec-driver
+    name: Toolexec Driver
+    paths: [internal/toolexec/**]
+  - component_id: aspects
+    name: Aspects
+    paths: [internal/injector/aspect/**]
+  - component_id: injector
+    name: Injector
+    paths: [internal/injector/**]

--- a/integration-tests.ps1
+++ b/integration-tests.ps1
@@ -51,11 +51,14 @@ $null = New-Item -ItemType Directory -Path $outputs
 # Build orchestrion
 Write-Progress -Activity "Preparation" -Status "Building orchestrion" -PercentComplete 0
 $orchestrion = Join-Path $outputs "orchestrion$($BinExt)"
-go build -o $orchestrion .
+go build -cover -covermode=atomic -coverpkg ./... -o $orchestrion .
 if ($LastExitCode -ne 0)
 {
   throw "Failed to build orchestrion"
 }
+
+$Env:GOCOVERDIR = Join-Path $outputs "coverage"
+$null = New-Item -ItemType Directory -Path $Env:GOCOVERDIR -Force
 
 # Warm up orchestrion
 Write-Progress -Activity "Preparation" -Status "Warming up" -PercentComplete 50


### PR DESCRIPTION
Keep an eye on code coverage to ensure consistent quality standard.

Coverage samples are sent to codecov, and tagged by:
- OS
- Test type (unit / integration)
- Go version
