### PR TITLE
chore: collect coverage when running generators

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,6 +4,8 @@ on:
     branches: ['**']
   merge_group:
     branches: ['main']
+  push:
+    branches: ['main']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -23,22 +25,43 @@ jobs:
           go-version: '1.21'
           cache-dependency-path: '**/*.sum'
       - name: Run 'go generate ./...'
-        run: go generate ./...
+        run: |-
+          mkdir -p ${GOCOVERDIR}
+          go generate ./...
+        env:
+          GOFLAGS: -covermode=atomic -coverpkg=github.com/datadog/orchestrion/...
+          GOCOVERDIR: ${{ github.workspace }}/coverage
+      - name: Consolidate coverage report
+        if: always() && github.event_name != 'merge_group'
+        run: go tool covdata textfmt -i ./coverage -o ./coverage/generator.out
+      - name: Upload coverage report
+        # We want this even if the tests failed
+        if: always() && github.event_name != 'merge_group'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ runner.os }},${{ runner.arch }},generator
+          file: ./coverage/generator.out
+          name: Generators
       - name: Run 'go mod tidy'
+        # Don't run for push, it's not necessary
+        if: github.event_name != 'push'
         run: find . -iname go.mod -execdir go mod tidy \;
       - name: Check if working tree is dirty
+        # Don't run for push, it's not necessary
+        if: github.event_name != 'push'
         id: is-tree-dirty
         run: |-
           git add .
           git diff --staged --patch --exit-code > .repo.patch || echo "result=true" >> ${GITHUB_OUTPUT}
       - name: Upload patch
-        if: steps.is-tree-dirty.outputs.result == 'true'
+        if: github.event_name != 'push' && steps.is-tree-dirty.outputs.result == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: repo.patch
           path: .repo.patch
       - name: Fail build if working tree is dirty
-        if: steps.is-tree-dirty.outputs.result == 'true'
+        if: github.event_name == 'push' && steps.is-tree-dirty.outputs.result == 'true'
         run: |-
           echo "::error::Files have been modified by 'go generate ./...' (see logs)."
           cat .repo.patch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,11 @@
 name: Tests
 on:
   pull_request:
-    branches: ["**"]
+    branches: ['**']
   merge_group:
     branches: ['main']
   push:
-    branches: ["main"]
+    branches: ['main']
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -56,12 +56,13 @@ jobs:
           go test -cover -covermode=atomic -coverpkg=./... -coverprofile=coverage/unit.out -race ./...
       - name: Upload coverage report
         # We want this even if the tests failed
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: go${{ matrix.go-version }},${{ runner.os }},${{ runner.arch }},unit
           file: ./coverage/unit.out
+          name: Unit Tests (go${{ matrix.go-version }})
 
   integration-tests:
     strategy:
@@ -96,18 +97,19 @@ jobs:
         env:
           TESTCASE_BUILD_MODE: ${{ matrix.build-mode || 'DRIVER' }}
       - name: Consolidate coverage report
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         run: |-
           mkdir ./coverage
           go tool covdata textfmt -i ./_integration-tests/outputs/coverage -o ./coverage/integration.out
       - name: Upload coverage report
         # We want this even if the tests failed
-        if: always()
+        if: always() && github.event_name != 'merge_group'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: go${{ matrix.go-version }},${{ runner.os }},${{ runner.arch }},integration
           file: ./coverage/integration.out
+          name: Integration Tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode || 'DRIVER' }})
       - name: Upload artifact
         # We want this even if the tests failed
         if: always()

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,7 @@ coverage:
         informational: true
 
 comment:
+  after_n_builds: 9 # Generators + Unit Tests (2 entries) + Integration Tests (6 entries)
   require_changes: true
 
 component_management:


### PR DESCRIPTION
This will help get a better visibility on the real code coverage, granted a number of code paths only exist for generators to use.