### PR TITLE
chore: test on go1.23-rc.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       go-version: ['1.21', '1.22']
+       go-version: ['1.21', '1.22', '1.23-rc.1']
     name: Unit tests (go${{ matrix.go-version }})
     steps:
       - name: Checkout
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [macos, ubuntu, windows]
-        go-version: ['1.21', '1.22']
+        go-version: ['1.21', '1.22', '1.23-rc.1']
         include:
           # Alternate build modes (only on ubuntu, latest go; to save CI time)
           - runs-on: ubuntu


### PR DESCRIPTION
Ensure we don't have any unpleasant surprises with 1.23 ahead of it being released in a few weeks.