### PR TITLE
chore: workflow for automated release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 'Pull Request title must be "release: ${{ steps.version.outputs.tag }}"'
         if: "github.event_name == 'pull_request' && steps.version.outputs.exists == 'false' && github.event.pull_request.title != 'release: ${{ steps.version.outputs.tag }}'"
         run: |-
-          echo 'Please update the PR titlee to "release: ${{ steps.version.outputs.tag }}"'
+          echo 'Please update the PR title to "release: ${{ steps.version.outputs.tag }}"'
 
       # If the release does not yet exist, create a draft release targeting this commit.
       - name: Create draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
           else
             echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       # If this is a pull request, and the release does not yet exist, the PR title must be "release: <tag>"
       - name: 'Pull Request title must be "release: ${{ steps.version.outputs.tag }}"'
@@ -46,3 +48,5 @@ jobs:
         if: github.event_name == 'push' && steps.version.outputs.exists == 'false'
         run: |-
           gh release create --draft --generate-notes --target="${{ github.sha }}" --title="${{ steps.version.outputs.tag }}" ${{ contains(steps.version.outputs.tag, '-') && '--prerelease' || '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+on:
+  pull_request:
+    paths: ['internal/version.go']
+  push:
+    branches: ['main']
+    paths: ['internal/version.go']
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To be able to create draft releases
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          cache-dependency-path: '**/*.sum'
+
+      # Obtains the current configured version tag from source, and verifies it is a valid tag name.
+      # Also checks whether the tag already exists.
+      - name: Determine version
+        id: version
+        run: |-
+          set -euo pipefail
+          # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string, with added v prefix.
+          VERSION_TAG_REGEX='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+          version=$(grep -E "${VERSION_TAG_REGEX}" <(go run . version))
+          echo "tag=${version}" >> "${GITHUB_OUTPUT}"
+          if gh release view "${version}" --json isDraft; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      # If this is a pull request, and the release does not yet exist, the PR title must be "release: <tag>"
+      - name: 'Pull Request title must be "release: ${{ steps.version.outputs.tag }}"'
+        if: "github.event_name == 'pull_request' && steps.version.outputs.exists == 'false' && github.event.pull_request.title != 'release: ${{ steps.version.outputs.tag }}'"
+        run: |-
+          echo 'Please update the PR titlee to "release: ${{ steps.version.outputs.tag }}"'
+
+      # If the release does not yet exist, create a draft release targeting this commit.
+      - name: Create draft release
+        if: github.event_name == 'push' && steps.version.outputs.exists == 'false'
+        run: |-
+          gh release create --draft --generate-notes --target="${{ github.sha }}" --title="${{ steps.version.outputs.tag }}" ${{ contains(steps.version.outputs.tag, '-') && '--prerelease' || '' }}


### PR DESCRIPTION
Adds a new workflow that triggers on modifications to the `internal/version.go` file, and determines whether a new release should be created or not.

If the version tag does not match an existing release:
- on `pull_request`, requires the PR title be set to `release: <tag>`
- on `push`, automatically creates a _draft_ release with the corresponding tag

This allows automating release creation by simply merging a pull request that updates the `Tag` constant in `internal/version.go` and limits the risk of incorrectly cutting releases.