### PR TITLE
release: v0.7.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
 on:
   pull_request:
-    paths: ['internal/version.go']
+    paths: ['internal/version/version.go']
   push:
     branches: ['main']
-    paths: ['internal/version.go']
+    paths: ['internal/version/version.go']
 
 jobs:
   validate:
@@ -39,9 +39,17 @@ jobs:
 
       # If this is a pull request, and the release does not yet exist, the PR title must be "release: <tag>"
       - name: 'Pull Request title must be "release: ${{ steps.version.outputs.tag }}"'
-        if: "github.event_name == 'pull_request' && steps.version.outputs.exists == 'false' && github.event.pull_request.title != 'release: ${{ steps.version.outputs.tag }}'"
+        if: "github.event_name == 'pull_request' && !fromJSON(steps.version.outputs.exists) && format('release: {0}', steps.version.outputs.tag) != github.event.pull_request.title"
         run: |-
-          echo 'Please update the PR title to "release: ${{ steps.version.outputs.tag }}"'
+          echo 'Please update the PR title to "release: ${{ steps.version.outputs.tag }}" (instead of ${{ toJSON(github.event.pull_request.title) }})'
+          exit 1
+
+      # Release must not already exist (if the PR title suggests this is intended to be a release)
+      - name: Release ${{ steps.version.outputs.tag }} already exists
+        if: github.event_name == 'pull_request' && fromJSON(steps.version.outputs.exists) && startsWith(github.event.pull_request.title, 'release:')
+        run: |-
+          echo 'A release already exists for tag ${{ steps.version.outputs.tag }}. Please update to another version.'
+          exit 1
 
       # If the release does not yet exist, create a draft release targeting this commit.
       - name: Create draft release

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,4 +6,4 @@
 package version
 
 // Tag specifies the current release tag. It needs to be manually updated.
-const Tag = "v0.7.1"
+const Tag = "v0.7.2"

--- a/pin_test.go
+++ b/pin_test.go
@@ -38,6 +38,9 @@ func TestPin(t *testing.T) {
 }
 
 func scaffold(dir string) error {
+	_, thisFile, _, _ := runtime.Caller(0)
+	thisDir := filepath.Dir(thisFile)
+
 	goMod, err := os.Create(filepath.Join(dir, "go.mod"))
 	if err != nil {
 		return err
@@ -50,7 +53,13 @@ func scaffold(dir string) error {
 	if _, err := fmt.Fprintln(goMod); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(goMod, "go %s", runtime.Version()[2:6]); err != nil {
+	if _, err := fmt.Fprintf(goMod, "go %s\n", runtime.Version()[2:6]); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(goMod); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(goMod, "replace github.com/datadog/orchestrion %s => %s\n", version.Tag, thisDir); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Release `v0.7.2`.

Additionally, fixes:
- Some issues with the release automation (fixing the PR title comparison, fixing the `version.go` file path)
- An issue with the `pin`/`autoPin` test that causes it to fail because the current release tag does not _yet_ exist
- Checking for existing release when appropriate to catch user error early