### PR TITLE
fix: broken documentation site

### DIFF
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -29,7 +29,10 @@ jobs:
       - name: Run go generate (builtin)
         run: go generate ./internal/injector/builtin
       - name: Build Site
-        run: go -C ./docs run github.com/gohugoio/hugo --minify --enableGitInfo
+        # Set environment to anything other than "production", as the theme we use adds SRI attributes to all CSS files,
+        # but datadoghq.dev is behind CloudFlare with auto-minify enabled; which breaks SRI if its minification is not
+        # identical to hugo's.
+        run: go -C ./docs run github.com/gohugoio/hugo --minify --enableGitInfo --environment=gh-pages
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The datadoghq.dev site is served with CloudFlare auto-minification, which breaks SRI attributes if the minification performed by Hugo is not identical to that of CloudFlare.

In order to avoid this issue, disable SRI output in the website build by setting the environment to something other than `production`.
