### PR TITLE
chore: republish docsite on all `main` pushes

### DIFF
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches: [main]
     paths: [docs/**]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Filtering on the `paths` does not work all too well with merge queues, as the filter only looks at the top-most commit being pushed, instead of the superposition of all new commits.