### PR TITLE
ci: setup reusable workflow for integration tests

### DIFF
--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -26,18 +26,13 @@ jobs:
         runs-on: [macos, ubuntu, windows]
         go-version: ['1.21', '1.22']
     runs-on: ${{ matrix.runs-on }}-latest
-    name: Integration tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
+    name: Integration tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }})
     steps:
       - name: Checkout orchestrion
         uses: actions/checkout@v4
         with:
+          path: orchestrion
           repository: DataDog/orchestrion
-      - name: Checkout dd-trace-go
-        uses: actions/checkout@v4
-        with:
-          path: dd-trace-go
-          repository: DataDog/dd-trace-go
-          ref: ${{ inputs.dd-trace-go-ref }}
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -48,17 +43,19 @@ jobs:
         with:
           python-version: '>=3.9 <3.13'
           cache: pip
-          cache-dependency-path: _integration-tests/utils/agent/requirements.txt
+          cache-dependency-path: orchestrion/_integration-tests/utils/agent/requirements.txt
       - name: Install python dependencies
-        run: pip install -r _integration-tests/utils/agent/requirements.txt
+        run: pip install -r orchestrion/_integration-tests/utils/agent/requirements.txt
       - name: Build orchestrion binary
-        run: go build -o="bin/orchestrion.exe" .
+        run: go -C orchestrion/ build -o="./_integration-tests/orchestrion.exe" .
       - name: Run Integration Tests
         shell: bash
         run: |-
-          bin/orchestrion.exe go -C=_integration-tests mod edit -replace=gopkg.in/DataDog/dd-trace-go.v1=../dd-trace-go
-          bin/orchestrion.exe go -C=_integration-tests mod tidy
-          bin/orchestrion.exe go -C=_integration-tests test -shuffle=on ./...
+          set -x
+          cd orchestrion/_integration-tests
+          ./orchestrion.exe go get gopkg.in/DataDog/dd-trace-go.v1@${{ inputs.dd-trace-go-ref }}
+          ./orchestrion.exe go mod tidy
+          ./orchestrion.exe go test -shuffle=on ./...
         env:
           GOFLAGS: -tags=integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
 

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -55,7 +55,7 @@ jobs:
           cd orchestrion/_integration-tests
           ./orchestrion.exe go get gopkg.in/DataDog/dd-trace-go.v1@${{ inputs.dd-trace-go-ref }}
           ./orchestrion.exe go mod tidy
-          ./orchestrion.exe go test -shuffle=on ./...
+          ./orchestrion.exe go test -v -shuffle=on ./...
         env:
           GOFLAGS: -tags=integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
 

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -1,0 +1,89 @@
+name: Integration Tests (Workflow Call)
+on:
+  workflow_dispatch:
+    inputs:
+      dd-trace-go-ref:
+        description: 'The ref to checkout dd-trace-go at'
+        required: false
+        type: string
+        default: main
+  workflow_call:
+    inputs:
+      dd-trace-go-ref:
+        type: string
+        required: true
+        description: 'The ref to checkout dd-trace-go at'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [macos, ubuntu, windows]
+        go-version: ['1.21', '1.22', '1.23.0-rc.1']
+        build-mode: [DRIVER]
+        include:
+          # Alternate build modes (only on ubuntu, latest go; to save CI time)
+          - runs-on: ubuntu
+            go-version: '1.22'
+            build-mode: TOOLEXEC
+          - runs-on: ubuntu
+            go-version: '1.22'
+            build-mode: GOFLAGS
+    runs-on: ${{ matrix.runs-on }}-latest
+    name: Integration tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
+    steps:
+      - name: Checkout orchestrion
+        uses: actions/checkout@v4
+        with:
+          repository: DataDog/orchestrion
+      - name: Checkout dd-trace-go
+        uses: actions/checkout@v4
+        with:
+          path: dd-trace-go
+          repository: DataDog/dd-trace-go
+          ref: ${{ inputs.dd-trace-go-ref }}
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: "**/*.sum"
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '>=3.9 <3.13'
+          cache: pip
+          cache-dependency-path: _integration-tests/utils/agent/requirements.txt
+      - name: Install python dependencies
+        run: pip install -r _integration-tests/utils/agent/requirements.txt
+      - name: Build orchestrion binary
+        run: go build -cover -covermode=atomic -coverpkg="./..." -o="bin/orchestrion.exe" .
+      - name: Run Integration Tests
+        shell: bash
+        run: |-
+          bin/orchestrion.exe go -C=_integration-tests mod edit -replace=gopkg.in/DataDog/dd-trace-go.v1=../dd-trace-go
+          bin/orchestrion.exe go -C=_integration-tests mod tidy
+          bin/orchestrion.exe go -C=_integration-tests test -shuffle=on ./...
+        env:
+          GOFLAGS: -tags=integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
+
+  # This is just a join point intended to simplify branch protection settings
+  complete:
+    runs-on: ubuntu-latest
+    needs:
+      - integration-tests
+    if: '!cancelled()'
+    steps:
+      - name: Done
+        if: needs.lint.result == 'success' && needs.unit-tests.result == 'success' && needs.integration-tests.result == 'success'
+        run: echo "OK"
+      - name: Done
+        if: needs.lint.result != 'success' || needs.unit-tests.result != 'success' || needs.integration-tests.result != 'success'
+        run: |-
+          echo "Failed!"
+          exit 1
+

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -23,23 +23,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos, ubuntu, windows]
-        go-version: ['1.21', '1.22']
+        runs-on: [ macos, ubuntu, windows ]
+        go-version: [ '1.21', '1.22' ]
     runs-on: ${{ matrix.runs-on }}-latest
     name: Integration tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }})
     steps:
       - name: Checkout orchestrion
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: orchestrion
           repository: DataDog/orchestrion
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: "**/*.sum"
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
         with:
           python-version: '>=3.9 <3.13'
           cache: pip
@@ -58,4 +58,3 @@ jobs:
           ./orchestrion.exe go test -v -shuffle=on ./...
         env:
           GOFLAGS: -tags=integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
-

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     name: Integration Smoke Tests
     steps:
       - name: Checkout orchestrion

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -24,16 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [macos, ubuntu, windows]
-        go-version: ['1.21', '1.22', '1.23.0-rc.1']
-        build-mode: [DRIVER]
-        include:
-          # Alternate build modes (only on ubuntu, latest go; to save CI time)
-          - runs-on: ubuntu
-            go-version: '1.22'
-            build-mode: TOOLEXEC
-          - runs-on: ubuntu
-            go-version: '1.22'
-            build-mode: GOFLAGS
+        go-version: ['1.21', '1.22']
     runs-on: ${{ matrix.runs-on }}-latest
     name: Integration tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
     steps:
@@ -61,7 +52,7 @@ jobs:
       - name: Install python dependencies
         run: pip install -r _integration-tests/utils/agent/requirements.txt
       - name: Build orchestrion binary
-        run: go build -cover -covermode=atomic -coverpkg="./..." -o="bin/orchestrion.exe" .
+        run: go build -o="bin/orchestrion.exe" .
       - name: Run Integration Tests
         shell: bash
         run: |-
@@ -70,20 +61,4 @@ jobs:
           bin/orchestrion.exe go -C=_integration-tests test -shuffle=on ./...
         env:
           GOFLAGS: -tags=integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
-
-  # This is just a join point intended to simplify branch protection settings
-  complete:
-    runs-on: ubuntu-latest
-    needs:
-      - integration-tests
-    if: '!cancelled()'
-    steps:
-      - name: Done
-        if: needs.lint.result == 'success' && needs.unit-tests.result == 'success' && needs.integration-tests.result == 'success'
-        run: echo "OK"
-      - name: Done
-        if: needs.lint.result != 'success' || needs.unit-tests.result != 'success' || needs.integration-tests.result != 'success'
-        run: |-
-          echo "Failed!"
-          exit 1
 

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -15,28 +15,29 @@ on:
         description: 'The ref to checkout dd-trace-go at'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.dd-trace-go-ref }}
   cancel-in-progress: true
 
 jobs:
   integration-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ macos, ubuntu, windows ]
-        go-version: [ '1.21', '1.22' ]
-    runs-on: ${{ matrix.runs-on }}-latest
-    name: Integration tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }})
+    runs-on: ubuntu-latest
+    name: Integration Smoke Tests
     steps:
       - name: Checkout orchestrion
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: orchestrion
           repository: DataDog/orchestrion
+      - name: Checkout dd-trace-go
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          path: dd-trace-go
+          repository: DataDog/dd-trace-go
+          ref: ${{ inputs.dd-trace-go-ref }}
       - name: Setup go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: '1.21'
           cache-dependency-path: "**/*.sum"
       - name: Setup python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
@@ -53,8 +54,6 @@ jobs:
         run: |-
           set -x
           cd orchestrion/_integration-tests
-          ./orchestrion.exe go get gopkg.in/DataDog/dd-trace-go.v1@${{ inputs.dd-trace-go-ref }}
+          ./orchestrion.exe go mod edit -replace=gopkg.in/DataDog/dd-trace-go.v1=../../dd-trace-go
           ./orchestrion.exe go mod tidy
-          ./orchestrion.exe go test -v -shuffle=on ./...
-        env:
-          GOFLAGS: -tags=integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
+          ./orchestrion.exe go test -v -tags=integration,buildtag -shuffle=on ./...

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -14,6 +14,8 @@ on:
         required: true
         description: 'The ref to checkout dd-trace-go at'
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.dd-trace-go-ref }}
   cancel-in-progress: true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

This PR creates a new workflow because we can't use the codecov workflow in dd-trace-go. Even if we are not technically using it because the `if` condition would have evaluated to false. cf. [this job](https://github.com/DataDog/dd-trace-go/actions/runs/9892772923)

### Motivation

Add a CI connection dd-trace-go and orchestrion to make sure we don't break orchestrion features when changing dd-trace-go