### PR TITLE
docs: friendlier landing repo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 
 Automatic compile-time instrumentation of Go code
 
-![Orchestrion](https://upload.wikimedia.org/wikipedia/commons/5/55/Welteorchestrion1862.jpg)
-
 ## Overview
 
-Orchestrion processes Go source code at compilation time and automatically inserts instrumentation. This instrumentation
+[Orchestrion](https://en.wikipedia.org/wiki/Orchestrion) processes Go source code at compilation time and automatically inserts instrumentation. This instrumentation
 produces Datadog APM traces from the instrumented code and supports Datadog Application Security Management. Future work
 will include support for OpenTelemetry tracing as well.
 


### PR DESCRIPTION
The orchestrion image made the first look at our repo look and feel complex while it's not. So I removed it in favor of a more discreet wikipedia link in the first orchestrion word of the overview section.
