### PR TITLE
WIP: instrument net/http.ServeHTTP implementations

### DIFF
--- a/internal/injector/builtin/generated_deps.go
+++ b/internal/injector/builtin/generated_deps.go
@@ -13,7 +13,6 @@ import (
 	_ "context"
 	_ "fmt"
 	_ "github.com/DataDog/orchestrion/instrument"
-	_ "github.com/DataDog/orchestrion/instrument/event"
 	_ "github.com/DataDog/orchestrion/instrument/net/http"
 	_ "gopkg.in/DataDog/dd-trace-go.v1/appsec/events"
 	_ "gopkg.in/DataDog/dd-trace-go.v1/contrib/99designs/gqlgen"

--- a/internal/injector/builtin/testdata/server/chiv5.go.snap
+++ b/internal/injector/builtin/testdata/server/chiv5.go.snap
@@ -28,12 +28,15 @@ func chiV5Server() {
 			return mux
 		}()
 //line samples/server/chiv5.go:16
-	router.Get("/",
+	router.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("Hello World!\n"))
+	})
 //line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/chiv5.go:16
-			func(w http.ResponseWriter, _ *http.Request) {
-				w.Write([]byte("Hello World!\n"))
-			}))
-	http.ListenAndServe(":8080", router)
+//line samples/server/chiv5.go:19
+	http.ListenAndServe(":8080",
+//line <generated>
+		__orchestrion_instrument.MaybeWrapHandler(
+//line samples/server/chiv5.go:19
+			router),
+	)
 }

--- a/internal/injector/builtin/testdata/server/gorilla.go.snap
+++ b/internal/injector/builtin/testdata/server/gorilla.go.snap
@@ -18,16 +18,20 @@ import (
 //line samples/server/gorilla.go:15
 func gorillaMuxServer() {
 	r := mux.NewRouter()
-	ping :=
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/gorilla.go:17
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
+	ping := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
 
-				_, _ = io.WriteString(w, `{"message":"pong"}`)
-			})
+		_, _ = io.WriteString(w, `{"message":"pong"}`)
+	}
 	r.HandleFunc("/ping", ping).Methods("GET")
-	_ = http.ListenAndServe(":8080", r)
+	_ =
+//line <generated>
+//line samples/server/gorilla.go:24
+		http.ListenAndServe(":8080",
+//line <generated>
+			__orchestrion_instrument.MaybeWrapHandler(
+//line samples/server/gorilla.go:24
+				r),
+		)
 }

--- a/internal/injector/builtin/testdata/server/main.go.snap
+++ b/internal/injector/builtin/testdata/server/main.go.snap
@@ -30,7 +30,7 @@ func main() {
 		Handler:
 		//dd:startwrap
 //line <generated>
-		__orchestrion_instrument.WrapHandler(
+		__orchestrion_instrument.MaybeWrapHandler(
 //line samples/server/main.go:17
 			http.HandlerFunc(myHandler)),
 		//dd:endwrap

--- a/internal/injector/builtin/testdata/server/other_handlers.go.snap
+++ b/internal/injector/builtin/testdata/server/other_handlers.go.snap
@@ -28,20 +28,12 @@ func (f foo) fooHandler(rw http.ResponseWriter, req *http.Request) {
 }
 
 func buildHandlers() {
-	http.HandleFunc("/foo/bar",
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:26
-			func(writer http.ResponseWriter, request *http.Request) {
-				writer.Write([]byte("done!"))
-			}))
-	v :=
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:29
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte("another one!"))
-			})
+	http.HandleFunc("/foo/bar", func(writer http.ResponseWriter, request *http.Request) {
+		writer.Write([]byte("done!"))
+	})
+	v := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("another one!"))
+	}
 
 	fmt.Printf("%T\n", v)
 
@@ -50,54 +42,39 @@ func buildHandlers() {
 	}
 
 	x := holder{
-		f:
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:40
-			func(w http.ResponseWriter, request *http.Request) {
-				w.Write([]byte("asdf"))
-			}),
+		f: func(w http.ResponseWriter, request *http.Request) {
+			w.Write([]byte("asdf"))
+		},
 	}
 
 	fmt.Println(x)
 
 	// silly legal things
-//line <generated>
-	__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:48
-		func(w http.ResponseWriter, r *http.Request) {
-			client := &http.Client{
-				Timeout: time.Second,
-			}
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "localhost:8080", strings.NewReader(os.Args[1]))
-			if err != nil {
-				panic(err)
-			}
-			resp, err := client.Do(req)
-			if err != nil {
-				panic(err)
-			}
-			fmt.Println(resp.Status)
-			w.Write([]byte("expression!"))
-		})(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
+	func(w http.ResponseWriter, r *http.Request) {
+		client := &http.Client{
+			Timeout: time.Second,
+		}
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "localhost:8080", strings.NewReader(os.Args[1]))
+		if err != nil {
+			panic(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(resp.Status)
+		w.Write([]byte("expression!"))
+	}(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
 
 	for i := 0; i < 10; i++ {
-		go
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:65
-			func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte("goroutine!"))
-			})(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
+		go func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("goroutine!"))
+		}(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
 	}
 
-	defer
-//line <generated>
-	__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:70
-		func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("goroutine!"))
-		})(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
+	defer func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("goroutine!"))
+	}(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/asfd", nil))
 }
 
 //dd:span foo:bar type:potato
@@ -162,39 +139,23 @@ func registerHandlers() {
 	handler := http.HandlerFunc(myHandler)
 	http.Handle("/handle-1", handler)
 	http.Handle("/hundle-2", http.HandlerFunc(myHandler))
-	http.Handle("/hundle-3", http.HandlerFunc(
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:95
-			func(w http.ResponseWriter, r *http.Request) {})))
+	http.Handle("/hundle-3", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	http.HandleFunc("/handlefunc-1", handler)
 	http.HandleFunc("/handlefunc-2", http.HandlerFunc(myHandler))
-	http.HandleFunc("/handlefunc-3",
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:98
-			func(w http.ResponseWriter, r *http.Request) {}))
+	http.HandleFunc("/handlefunc-3", func(w http.ResponseWriter, r *http.Request) {})
 	s := http.NewServeMux()
 	s.Handle("/handle-mux", handler)
 	s.Handle("/handle-mux", http.HandlerFunc(myHandler))
-	s.Handle("/handle-mux", http.HandlerFunc(
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:102
-			func(w http.ResponseWriter, r *http.Request) {})))
+	s.Handle("/handle-mux", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	s.HandleFunc("/handlefunc-1", handler)
 	s.HandleFunc("/handlefunc-2", http.HandlerFunc(myHandler))
-	s.HandleFunc("/handlefunc-3",
-//line <generated>
-		__orchestrion_instrument.WrapHandlerFunc(
-//line samples/server/other_handlers.go:105
-			func(w http.ResponseWriter, r *http.Request) {}))
+	s.HandleFunc("/handlefunc-3", func(w http.ResponseWriter, r *http.Request) {})
 	_ = &http.Server{
 		Addr: ":8080",
 		Handler:
 		//dd:startwrap
 //line <generated>
-		__orchestrion_instrument.WrapHandler(
+		__orchestrion_instrument.MaybeWrapHandler(
 //line samples/server/other_handlers.go:108
 			handler),
 		//dd:endwrap

--- a/internal/injector/builtin/yaml/stdlib/net-http.server.yml
+++ b/internal/injector/builtin/yaml/stdlib/net-http.server.yml
@@ -9,12 +9,9 @@ meta:
   description: HTTP server implementation.
   icon: at-symbol
 aspects:
-  # When httpmode is "wrap"
   - id: Wrap http.Server.Handler
     join-point:
       all-of:
-        - configuration:
-            httpmode: wrap
         - struct-literal:
             type: net/http.Server
             field: Handler
@@ -30,74 +27,35 @@ aspects:
             instrument: github.com/DataDog/orchestrion/instrument
           template: |-
             //dd:startwrap
-            instrument.WrapHandler({{.}})
+            instrument.MaybeWrapHandler({{.}})
             //dd:endwrap
-  - id: Wrap http.HandlerFunc
+  - id: "Wrap starting a server - part 1 - TODO: this description sucks"
     join-point:
-      all-of:
-        - configuration:
-            httpmode: wrap
-        - function:
-            - name: '' # This filters only *dst.FuncLit
-            - signature:
-                args: [net/http.ResponseWriter, '*net/http.Request']
-        # No instrumenting github.com/go-chi/chi/v5 as this causes a circular dependency.
-        - not:
-            one-of:
-              - import-path: github.com/go-chi/chi/v5
-              - import-path: github.com/go-chi/chi/v5/middleware
-              # No instrumenting golang.org/x/net as it causes a circular dependency via GRPC
-              - import-path: golang.org/x/net/http2
+      one-of:
+        - function-call: net/http.ListenAndServe
+        - function-call: net/http.Serve
     advice:
       - wrap-expression:
           imports:
             instrument: "github.com/DataDog/orchestrion/instrument"
           template: |-
-            instrument.WrapHandlerFunc({{.}})
-
-  # When httpmode is "report"
-  - id: Report http.HandlerFunc calls
+            {{.AST.Fun}}(
+              {{ index .AST.Args 0}},
+              instrument.MaybeWrapHandler({{ index .AST.Args 1 }}),
+            )
+  - id: "Wrap starting a server - part 2 - TODO: this description sucks"
     join-point:
-      all-of:
-        - configuration:
-            httpmode: report
-        - function-body:
-            function:
-              - signature:
-                  args: [net/http.ResponseWriter, '*net/http.Request']
-        # No instrumenting github.com/go-chi/chi/v5 as this causes a circular in wrap mode, and we
-        # don't want the behavior to be significantly different between wrap and report modes.
-        - not:
-            one-of:
-              - import-path: github.com/go-chi/chi/v5
-              - import-path: github.com/go-chi/chi/v5/middleware
-              # No instrumenting golang.org/x/net as it causes a circular dependency via GRPC
-              - import-path: golang.org/x/net/http2
+      one-of:
+        - function-call: net/http.ListenAndServeTLS
+        - function-call: net/http.ServeTLS
     advice:
-      - prepend-statements:
+      - wrap-expression:
           imports:
-            event: github.com/DataDog/orchestrion/instrument/event
-            instrument: github.com/DataDog/orchestrion/instrument
+            instrument: "github.com/DataDog/orchestrion/instrument"
           template: |-
-            {{- $arg := .Function.Argument 1 -}}
-            {{- $name := .Function.Name -}}
-            {{$arg}} = {{$arg}}.WithContext(instrument.Report(
-              {{$arg}}.Context(),
-              event.EventStart,
-              {{with $name}}"function-name", {{printf "%q" .}},{{end}}
-              "span.kind", "server",
-              "http.method", {{$arg}}.Method,
-              "http.url", {{$arg}}.URL,
-              "http.useragent", {{$arg}}.Header.Get("User-Agent"),
-              {{ range .DirectiveArgs "dd:span" -}}{{printf "%q, %q,\n" .Key .Value}}{{ end }}
-            ))
-            defer instrument.Report(
-              {{$arg}}.Context(),
-              event.EventEnd,
-              {{with $name}}"function-name", {{printf "%q" .}},{{end}}
-              "span.kind", "server",
-              "http.method", {{$arg}}.Method,
-              "http.url", {{$arg}}.URL,
-              "http.useragent", {{$arg}}.Header.Get("User-Agent"),
-              {{ range .DirectiveArgs "dd:span" -}}{{printf "%q, %q," .Key .Value}}{{- end }}
+            {{.AST.Fun}}(
+              {{ index .AST.Args 0}},
+              {{ index .AST.Args 1}},
+              {{ index .AST.Args 2}},
+              instrument.MaybeWrapHandler({{ index .AST.Args 3 }}),
             )


### PR DESCRIPTION
### What does this PR do?

TODO - tests

Makes sure we instrument `net/http` handlers and servers.

#### Background

There are two general ways to start an HTTP server with `net/http`:

- Package-level functions:
  - `http.ListenAndServe`
  - `http.ListenAndServeTLS`
  - `http.Serve`
  - `http.ServeTLS`
- Via the `net/http.Server` methods:
  - `http.(*Server).ListenAndServe`
  - `http.(*Server).ListenAndServeTLS`
  - `http.(*Server).Serve`
  - `http.(*Server).ServeTLS`
 
The package-level functions create a `Server` and dispatch to the matching methods.

All of these work with the `http.Handler` interface, which defines the "application" logic for handling an HTTP request. The `Server` type has a `Handler` field, and all of the package-level functions take an `http.Handler` argument. Many packages, like `github.com/gorilla/mux`, provide `http.Handler` implementations.

The `net/http` package has two `http.Handler` implementations: `net/http.ServeMux`, and `net/http.HandlerFunc`.

#### What this PR actually does

Before, we instrumented the `Handler` field of `Server` literals, and function literals cast to `http.HandlerFunc`. But this could lead to redundant instrumentation, and also didn't cover common patterns. For example, this doesn't get instrumented today:

```go
package main

import "net/http"

type Handler struct{}

func (Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}

func main() {
	mu := http.NewServeMux()
	mu.Handle("/foo", Handler{})
	http.ListenAndServe(":8080", mu)
}
```

For another example, we get redundant instrumentation for [this](https://github.com/DataDog/orchestrion/blob/0acfd197a7a60487e92ad646cca9a143fe839aec/_integration-tests/tests/mux/mux.go#L31C1-L42C19) `github.com/gorilla/mux` example:

```go
mux := mux.NewRouter()
tc.Server = &http.Server{
	Addr:    "127.0.0.1:" + utils.GetFreePort(t),
	Handler: mux,
}

mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
	w.Header().Set("Content-Type", "application/json")
	w.WriteHeader(http.StatusOK)
	_, err := io.WriteString(w, `{"message": "pong"}`)
	assert.NoError(t, err)
}).Methods("GET")
```

The `Handler` field of the `Server` literal gets instrumented, _and_ the `http.HandlerFunc` literal is instrumented, _and_ the router returned via `mux.NewRouter` is instrumented. We have at least one too many layers of instrumentation.

So this PR takes this approach:
- We define a new `MaybeWrapHandler` function. It takes an `http.Handler` and returns an `http.Handler`. If the input handler is one of the `net/http` handler types, we wrap it with tracing instrumentation. Otherwise we pass it on unchanged under the assumption it is already instrumented.
- We use this function to _maybe_ wrap the `http.Handler` passed to the package-level functions.
- We also use this function to _maybe_ wrap the `Handler` field of a `Server` literal, similar to what we did before.

This doesn't provide complete coverage. For example, the user could do something like `s := new(http.Server); s.Handler = foo` and we wouldn't catch it. But this hopefully improves our coverage significantly and avoids _some_ redundant instrumentation.

### Motivation

Fixes #173

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality.
