### PR TITLE
docs: fix broken pkg.go.dev links

### DIFF
--- a/docs/layouts/shortcodes/godoc.html
+++ b/docs/layouts/shortcodes/godoc.html
@@ -1,4 +1,4 @@
-<a href='https://pkg.go.dev/{{ or (.Get 0) "builtin" }}{{ with .Get 1 }}#{{ . }}{{ end }}" target="_blank" rel="noopener'><code>
+<a href='https://pkg.go.dev/{{ or (.Get 0) "builtin" }}{{ with .Get 1 }}#{{ . }}{{ end }}' target='_blank' rel='noopener'><code>
     {{- with .Get 2 -}}{{ . }}{{- end -}}
     {{- if .Get 0 -}}
       {{- .Get 0 -}}


### PR DESCRIPTION
The links to pkg.go.dev were broken due to mismatched quotation marks,
mixing single and double quotes. This lead to the "target" and "rel"
attributes getting added to the actual URL, like

	https://pkg.go.dev/net/http#Server" target="_blank" rel="noopener

See, for example, the link to the `net/http.Server` docs on
https://datadoghq.dev/orchestrion/docs/built-in/stdlib/net-http.server/:

<img width="754" alt="Screenshot 2024-07-23 at 15 04 31" src="https://github.com/user-attachments/assets/69671897-2a0f-4a28-b35a-d515185a9618">

