### PR TITLE
chore: improve OpenSSF Score

### DIFF
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches: [main]
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches: ['main']
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -96,4 +98,6 @@ jobs:
         run: |-
           git add .
           git commit -s -m "chore: update generated files"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin HEAD:${EVENT_PR_HEAD_REF}
+        env:
+          EVENT_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
     branches: ['main']
     paths: ['internal/version/version.go']
 
+permissions: read-all
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -41,8 +43,10 @@ jobs:
       - name: 'Pull Request title must be "release: ${{ steps.version.outputs.tag }}"'
         if: "github.event_name == 'pull_request' && !fromJSON(steps.version.outputs.exists) && format('release: {0}', steps.version.outputs.tag) != github.event.pull_request.title"
         run: |-
-          echo 'Please update the PR title to "release: ${{ steps.version.outputs.tag }}" (instead of ${{ toJSON(github.event.pull_request.title) }})'
+          echo "Please update the PR title to \"release: ${{ steps.version.outputs.tag }}\" (instead of ${EVENT_PR_TITLE})"
           exit 1
+        env:
+          EVENT_PR_TITLE: ${{ toJSON(github.event.pull_request.title) }}
 
       # Release must not already exist (if the PR title suggests this is intended to be a release)
       - name: Release ${{ steps.version.outputs.tag }} already exists

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation](https://img.shields.io/badge/documentation-datadoghq.dev/orchestrion-blue.svg?style=flat)](https://datadoghq.dev/orchestrion)
 ![Latest Release](https://img.shields.io/github/v/release/DataDog/orchestrion?display_name=tag&label=Latest%20Release)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/datadog/orchestrion)
-
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/DataDog/orchestrion/badge)](https://scorecard.dev/viewer/?uri=github.com/DataDog/orchestrion)
 
 Automatic compile-time instrumentation of Go code.
 


### PR DESCRIPTION
Reduce vulnerable surface of the repository by enacting recommendations from the OpenSSD Scorecard:

- Set default read-only permissions at the top-level of all GitHub workflows;
- Avoid possible shell injection via event inputs by indirecting values through environment variables.