### PR TITLE
release: v0.7.4-rc.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions: read-all
 
 jobs:
   validate:
+    name: Validate Release
     runs-on: ubuntu-latest
     permissions:
       contents: write # To be able to create draft releases
@@ -29,7 +30,7 @@ jobs:
           set -euo pipefail
           # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string, with added v prefix.
           VERSION_TAG_REGEX='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
-          version=$(grep -E "${VERSION_TAG_REGEX}" <(go run . version))
+          version=$(grep -E "${VERSION_TAG_REGEX}" <(go run . version | cut -d' ' -f 2))
           echo "tag=${version}" >> "${GITHUB_OUTPUT}"
           if gh release view "${version}" --json isDraft; then
             echo "exists=true" >> "${GITHUB_OUTPUT}"

--- a/README.md
+++ b/README.md
@@ -174,19 +174,47 @@ func HandleRequest(name string, req *http.Request) {
 
 Orchestrion supports automatic tracing of the following libraries:
 
-- `net/http`
-- `database/sql`
-- `google.golang.org/grpc`
-- `github.com/gin-gonic/gin`
-- `github.com/labstack/echo/v4`
-- `github.com/go-chi/chi/v5`
-- `github.com/gorilla/mux`
-- `github.com/gofiber/fiber/v2`
+Library                             | Since    | Notes
+------------------------------------|:--------:|-----------------------------------------------
+`database/sql`                      | `v0.7.0` | [Aspect][db-sql]
+`github.com/gin-gonic/gin`          | `v0.7.0` | [Aspect][gin]
+`github.com/go-chi/chi/v5`          | `v0.7.0` | [Aspect][chi-v5]
+`github.com/go-chi/chi`             | `v0.7.0` | [Aspect][chi-v1]
+`github.com/go-redis/redis/v7`      | `v0.7.0` | [Aspect][go-redis-v7]
+`github.com/go-redis/redis/v8`      | `v0.7.0` | [Aspect][go-redis-v8]
+`github.com/gofiber/fiber/v2`       | `v0.7.0` | [Aspect][fiber-v2]
+`github.com/gomodule/redigo/redis`  | `v0.7.0` | [Aspect][redigo]
+`github.com/gorilla/mux`            | `v0.7.0` | [Aspect][gorilla]. Cannot be opted out of via `//dd:ignore`
+`github.com/jinzhu/gorm`            | `v0.7.0` | [Aspect][jinzhu-gorm]
+`github.com/labstack/echo/v4`       | `v0.7.0` | [Aspect][echo]
+`google.golang.org/grpc`            | `v0.7.0` | [Aspect][grpc]
+`gorm.io/gorm`                      | `v0.7.0` | [Aspect][gorm]
+`net/http`                          | `v0.7.0` | [Client][net-http.client] / [Server][net-http.server]
+`go.mongodb.org/mongo-driver/mongo` | `v0.7.3` | [Aspect][mongo]
+`k8s.io/client-go`                  | `v0.7.4` | [Aspect][k8s-client]
+`github.com/hashicorp/vault`        | `v0.7.4` | [Aspect][hashicorp-vault]
+
+[db-sql]: https://datadoghq.dev/orchestrion/docs/built-in/stdlib/database-sql/
+[gin]: https://datadoghq.dev/orchestrion/docs/built-in/http/gin/
+[chi-v5]: https://datadoghq.dev/orchestrion/docs/built-in/http/chi/#use-v5-tracer-middleware
+[chi-v1]: https://datadoghq.dev/orchestrion/docs/built-in/http/chi/#use-v1-tracer-middleware
+[go-redis-v7]: https://datadoghq.dev/orchestrion/docs/built-in/databases/go-redis/#wrap-v7-client
+[go-redis-v8]: https://datadoghq.dev/orchestrion/docs/built-in/databases/go-redis/#wrap-v8-client
+[fiber-v2]: https://datadoghq.dev/orchestrion/docs/built-in/http/fiber/
+[redigo]: https://datadoghq.dev/orchestrion/docs/built-in/databases/redigo/
+[gorilla]: https://datadoghq.dev/orchestrion/docs/built-in/http/gorilla/
+[jinzhu-gorm]: https://datadoghq.dev/orchestrion/docs/built-in/databases/gorm/#jinzhugorm
+[echo]: https://datadoghq.dev/orchestrion/docs/built-in/http/echo/
+[grpc]: https://datadoghq.dev/orchestrion/docs/built-in/grpc/
+[gorm]: https://datadoghq.dev/orchestrion/docs/built-in/databases/gorm/#gormiogorm
+[net-http.Client]: https://datadoghq.dev/orchestrion/docs/built-in/stdlib/net-http.client/
+[net-http.Server]: https://datadoghq.dev/orchestrion/docs/built-in/stdlib/net-http.server/
+[mongo]: https://datadoghq.dev/orchestrion/docs/built-in/databases/mongo/
+[k8s-client]: https://datadoghq.dev/orchestrion/docs/built-in/k8s-client/
+[hashicorp-vault]: https://datadoghq.dev/orchestrion/docs/built-in/api/vault/
 
 Calls to these libraries are instrumented with library-specific code adding tracing to them, including support for
 distributed traces.
-
-[1]: https://github.com/DataDog/go-sample-app
 
 ## Troubleshooting
 

--- a/_integration-tests/validator/trace/diff.go
+++ b/_integration-tests/validator/trace/diff.go
@@ -55,7 +55,6 @@ func (span *Span) matches(other *Span, diff treeprint.Tree) (matches bool) {
 		}
 	}
 	sort.Strings(keys)
-	format := fmt.Sprintf("%%-%ds = %%q", maxLen)
 	for _, tag := range keys {
 		expected := span.Tags[tag]
 		actual := other.Tags[tag]
@@ -65,7 +64,7 @@ func (span *Span) matches(other *Span, diff treeprint.Tree) (matches bool) {
 			branch.AddMetaNode("+", actual)
 			matches = false
 		} else {
-			diff.AddMetaNode("=", fmt.Sprintf(format, tag, expected))
+			diff.AddMetaNode("=", fmt.Sprintf("%-*s = %q", maxLen, tag, expected))
 		}
 	}
 
@@ -78,7 +77,6 @@ func (span *Span) matches(other *Span, diff treeprint.Tree) (matches bool) {
 		}
 	}
 	sort.Strings(keys)
-	format = fmt.Sprintf("%%-%ds = %%q", maxLen)
 	var metaNode treeprint.Tree
 	for _, key := range keys {
 		expected := span.Meta[key]
@@ -92,7 +90,7 @@ func (span *Span) matches(other *Span, diff treeprint.Tree) (matches bool) {
 			branch.AddMetaNode("+", actual)
 			matches = false
 		} else {
-			metaNode.AddMetaNode("=", fmt.Sprintf(format, key, expected))
+			metaNode.AddMetaNode("=", fmt.Sprintf("%-*s = %q", maxLen, key, expected))
 		}
 	}
 

--- a/_integration-tests/validator/trace/span.go
+++ b/_integration-tests/validator/trace/span.go
@@ -79,9 +79,8 @@ func (span *Span) into(tree treeprint.Tree) {
 		}
 	}
 	sort.Strings(keys)
-	format := fmt.Sprintf("%%-%ds = %%q", maxLen)
 	for _, tag := range keys {
-		tree.AddNode(fmt.Sprintf(format, tag, span.Tags[tag]))
+		tree.AddNode(fmt.Sprintf("%-*s = %q", maxLen, tag, span.Tags[tag]))
 	}
 
 	if len(span.Meta) > 0 {
@@ -94,10 +93,9 @@ func (span *Span) into(tree treeprint.Tree) {
 			}
 		}
 		sort.Strings(keys)
-		format = fmt.Sprintf("%%-%ds = %%q", maxLen)
 		meta := tree.AddBranch("meta")
 		for _, key := range keys {
-			meta.AddNode(fmt.Sprintf(format, key, span.Meta[key]))
+			meta.AddNode(fmt.Sprintf("%-*s = %q", maxLen, key, span.Meta[key]))
 		}
 	}
 	if len(span.Children) > 0 {

--- a/internal/injector/aspect/advice/code/template.go
+++ b/internal/injector/aspect/advice/code/template.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"go/token"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -247,10 +248,9 @@ func (t *Template) UnmarshalYAML(node *yaml.Node) (err error) {
 func numberLines(text string) string {
 	lines := strings.Split(text, "\n")
 	width := len(strconv.FormatInt(int64(len(lines)), 10))
-	format := fmt.Sprintf("%% %dd | %%s", width+1)
 
 	for i, line := range lines {
-		lines[i] = fmt.Sprintf(format, i+1, line)
+		lines[i] = fmt.Sprintf("% *d | %s", width+1, i+1, line)
 	}
 
 	return strings.Join(lines, "\n")
@@ -261,8 +261,12 @@ func (t *Template) RenderHTML() string {
 
 	if len(t.imports) > 0 {
 		keys := make([]string, 0, len(t.imports))
+		nameLen := 0
 		for name := range t.imports {
 			keys = append(keys, name)
+			if l := len(name); l > nameLen {
+				nameLen = l
+			}
 		}
 		sort.Strings(keys)
 
@@ -270,14 +274,16 @@ func (t *Template) RenderHTML() string {
 		buf.WriteString("// Using the following synthetic imports:\n")
 		buf.WriteString("import (\n")
 		for _, name := range keys {
-			fmt.Fprintf(&buf, "\t%s %q\n", name, t.imports[name])
+			fmt.Fprintf(&buf, "\t%-*s %q\n", nameLen, name, t.imports[name])
 		}
 		buf.WriteString(")\n```")
 	}
 
 	buf.WriteString("\n\n```go-template\n")
 	// Render with tabs so it's more go-esque!
-	buf.WriteString(strings.ReplaceAll(t.source, "  ", "\t"))
+	buf.WriteString(regexp.MustCompile(`(?m)^(?:  )+`).ReplaceAllStringFunc(t.source, func(orig string) string {
+		return strings.Repeat("\t", len(orig)/2)
+	}))
 	buf.WriteString("\n```\n")
 
 	return buf.String()

--- a/internal/injector/aspect/advice/code/template_test.go
+++ b/internal/injector/aspect/advice/code/template_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package code_test
+
+import (
+	"context"
+	"go/token"
+	"testing"
+
+	"github.com/datadog/orchestrion/internal/injector/aspect/advice/code"
+	"github.com/datadog/orchestrion/internal/injector/node"
+	"github.com/datadog/orchestrion/internal/injector/typed"
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/golden"
+)
+
+func TestTemplate(t *testing.T) {
+	ctx := context.Background()
+	ctx = typed.ContextWithValue(ctx, decorator.NewDecorator(token.NewFileSet()))
+
+	t.Run("ParseError", func(t *testing.T) {
+		tmpl := code.MustTemplate(`this.IsNotValidGo("because it's missing a closing parenthesis"`, nil)
+		stmt, err := tmpl.CompileBlock(ctx, &node.Chain{Node: &dst.File{}})
+		require.Nil(t, stmt)
+		require.Error(t, err)
+		golden.Assert(t, err.Error(), "parse_error.txt")
+	})
+}

--- a/internal/injector/aspect/advice/code/testdata/parse_error.txt
+++ b/internal/injector/aspect/advice/code/testdata/parse_error.txt
@@ -1,0 +1,5 @@
+while parsing generated code: 3:64: missing ',' before newline in argument list (and 1 more errors)
+ 1 | package _
+ 2 | func _() {
+ 3 | 	this.IsNotValidGo("because it's missing a closing parenthesis"
+ 4 | }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,4 +6,4 @@
 package version
 
 // Tag specifies the current release tag. It needs to be manually updated.
-const Tag = "v0.7.4-rc.1"
+const Tag = "v0.7.4-rc.2"


### PR DESCRIPTION
Contains a small set of misc. fixes:

- Adjusted the `release.yml` workflow to account for the new output format of `orchestrion version`
- Updated `README.md` to mention supported contribs with minimum Orchestrion version (note that it intentionally does not include prerelease identifiers in the versions)
- Change all cases of length-adjusted format strings to use `%-*s`/`% *d` instead of previously using `fmt.Sprintf` to craft the format string; which is probably quite a bit safer
  - Added a test case that leverages the `numberLines` function in `code.Template` as it was previously uncovered by tests & this change touched it
- Fix tab-indentation replacement in the `code.Template` doc-gen to only replace two-space indents with tabs at line start (previously anywhere on the line)