### PR TITLE
feat: add profiling of Orchestrion

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,9 +6,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
+	"runtime/trace"
 	"strconv"
 
 	"github.com/datadog/orchestrion/internal/cmd"
@@ -22,7 +26,17 @@ const (
 	envVarOrchestrionLogFile  = "ORCHESTRION_LOG_FILE"
 	envVarOrchestrionLogLevel = "ORCHESTRION_LOG_LEVEL"
 	envVarToolexecImportPath  = "TOOLEXEC_IMPORTPATH"
+	envVarCPUProfiling        = "CPU_PROFILING"
+	envVarHeapProfiling       = "HEAP_PROFILING"
+	envVarExecutionTracing    = "EXECUTION_TRACING"
+	envVarProfilePrefix       = "PROFILE_PREFIX"
 )
+
+var profilePrefix string
+
+type ctxKeyCPUProfiling struct{}
+type ctxKeyHeapProfiling struct{}
+type ctxKeyExecutionTracing struct{}
 
 func main() {
 	// Setup the logger
@@ -67,6 +81,44 @@ func main() {
 				Usage:    "Send logging output to a file instead of STDERR. Unless --log-level is also specified, the default log level changed to WARN.",
 				Action:   actionSetLogFile,
 			},
+			&cli.StringFlag{
+				Category:    "Profiling",
+				Name:        "profile-prefix",
+				EnvVars:     []string{envVarProfilePrefix},
+				Usage:       "Path prefix for profiling data",
+				Value:       "",
+				Destination: &profilePrefix,
+				Action: func(ctx *cli.Context, s string) error {
+					// Set the env var so child processes get it
+					os.Setenv(envVarProfilePrefix, s)
+					return nil
+				},
+				Hidden: true,
+			},
+			&cli.BoolFlag{
+				Category: "Profiling",
+				Name:     "cpu-profiling",
+				EnvVars:  []string{envVarCPUProfiling},
+				Usage:    "Enable the CPU profiler. Profiles are recorded to file \"orchestrion-cpu-${pid}.pprof\"",
+				Action:   actionCPUProfiling,
+				Hidden:   true,
+			},
+			&cli.BoolFlag{
+				Category: "Profiling",
+				Name:     "heap-profiling",
+				EnvVars:  []string{envVarHeapProfiling},
+				Usage:    "Enable the heap profiler. Profiles are recorded to file \"orchestrion-heap-${pid}.pprof\"",
+				Action:   actionHeapProfiling,
+				Hidden:   true,
+			},
+			&cli.BoolFlag{
+				Category: "Profiling",
+				Name:     "execution-tracing",
+				EnvVars:  []string{envVarExecutionTracing},
+				Usage:    "Enable the execution tracer. Traces are recorded to file \"orchestrion-${pid}.trace\"",
+				Action:   actionExecutionTracing,
+				Hidden:   true,
+			},
 		},
 		Commands: []*cli.Command{
 			cmd.Go,
@@ -74,6 +126,28 @@ func main() {
 			cmd.Toolexec,
 			cmd.Version,
 			cmd.Server,
+		},
+		After: func(ctx *cli.Context) error {
+			// Stop profiling, execution tracing, if they were started
+			if f := ctx.Context.Value(ctxKeyCPUProfiling{}); f != nil {
+				pprof.StopCPUProfile()
+				f.(*os.File).Close()
+			}
+			if f := ctx.Context.Value(ctxKeyExecutionTracing{}); f != nil {
+				trace.Stop()
+				f.(*os.File).Close()
+			}
+			if filename := ctx.Context.Value(ctxKeyHeapProfiling{}); filename != nil {
+				filename := filename.(string)
+				f, err := profileToFile(filename, func(w io.Writer) error {
+					return pprof.Lookup("heap").WriteTo(w, 0)
+				})
+				if err != nil {
+					return fmt.Errorf("writing heap profile: %w", err)
+				}
+				f.Close()
+			}
+			return nil
 		},
 	}
 	// Run the CLI application
@@ -123,5 +197,64 @@ func actionSetLogFile(_ *cli.Context, path string) error {
 		log.SetLevel(log.LevelWarn)
 	}
 
+	return nil
+}
+
+func profilePath(nameFormat string) string {
+	filename := fmt.Sprintf(nameFormat, os.Getpid())
+	if profilePrefix != "" {
+		filename = filepath.Join(profilePrefix, filename)
+	}
+	return filename
+}
+
+func profileToFile(filename string, collect func(io.Writer) error) (*os.File, error) {
+	f, err := os.Create(filename)
+	if err != nil {
+		return nil, fmt.Errorf("creating file %s: %w", filename, err)
+	}
+	if err := collect(f); err != nil {
+		f.Close()
+		os.Remove(filename)
+		return nil, fmt.Errorf("starting collection: %w", err)
+	}
+	return f, nil
+}
+
+func actionCPUProfiling(ctx *cli.Context, enabled bool) error {
+	if !enabled {
+		return nil
+	}
+	filename := profilePath("orchestrion-cpu-%d.pprof")
+	f, err := profileToFile(filename, pprof.StartCPUProfile)
+	if err != nil {
+		return fmt.Errorf("starting CPU profiling: %w", err)
+	}
+	ctx.Context = context.WithValue(ctx.Context, ctxKeyCPUProfiling{}, f)
+	os.Setenv(envVarCPUProfiling, "true")
+	return nil
+}
+
+func actionHeapProfiling(ctx *cli.Context, enabled bool) error {
+	if !enabled {
+		return nil
+	}
+	filename := profilePath("orchestrion-heap-%d.pprof")
+	ctx.Context = context.WithValue(ctx.Context, ctxKeyHeapProfiling{}, filename)
+	os.Setenv(envVarHeapProfiling, "true")
+	return nil
+}
+
+func actionExecutionTracing(ctx *cli.Context, enabled bool) error {
+	if !enabled {
+		return nil
+	}
+	filename := profilePath("orchestrion-%d.trace")
+	f, err := profileToFile(filename, trace.Start)
+	if err != nil {
+		return fmt.Errorf("starting execution tracing: %w", err)
+	}
+	ctx.Context = context.WithValue(ctx.Context, ctxKeyExecutionTracing{}, f)
+	os.Setenv(envVarExecutionTracing, "true")
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -101,6 +101,11 @@ func main() {
 			cmd.Server,
 		},
 		Before: func(ctx *cli.Context) error {
+			profiles := ctx.StringSlice("profile")
+			if len(profiles) == 0 {
+				return nil
+			}
+
 			profilePath, err := filepath.Abs(ctx.String("profile-path"))
 			if err != nil {
 				return err
@@ -109,8 +114,6 @@ func main() {
 				return err
 			}
 			os.Setenv(envVarProfilePath, profilePath)
-
-			profiles := ctx.StringSlice("profile")
 			for _, p := range profiles {
 				var err error
 				switch p {


### PR DESCRIPTION
### What does this PR do?

Add hidden flags to enable profiling Orchestrion. Options for writing
CPU and heap profiler, as well as execution traces, with a configurable
path prefix. Enabling the profiler for the parent enables it for the
children. There is one of each enabled profile type per process, and
each file gets the PID in its name.

Note that CPU profiling adds a ~200ms delay at the end of the app to
stop profiling. This might matter more for Orchestrion since there are
many normally short-lived processes.

Execution tracing should be enabled with caution since traces can be
quite large. Even the other profile types can produce significant
amounts of data. The profiles will have redundant symbol data. The CPU
and heap profiles can be combined into a single profile to eliminate the
redundancy.

Example usage:

```
$ mkdir profiles
$ orchestrion --profile-prefix=${PWD}/profiles --cpu-profiling=true go build
# To combine the profiles:
$ go tool pprof -proto profiles/*.pprof > cpu.pprof
# To view:
$ go tool pprof -http=localhost:6060 cpu.pprof
```

### Motivation

Looking for hot spots & bottlenecks in Orchestrion

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality.
