### PR TITLE
fix: propagate --log-level and --log-file to child processes

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,6 +168,7 @@ func main() {
 var logLevelSet bool
 
 func actionSetLogLevel(_ *cli.Context, level string) error {
+	os.Setenv(envVarOrchestrionLogLevel, level)
 	if level, valid := log.LevelNamed(level); valid {
 		logLevelSet = true
 		log.SetLevel(level)
@@ -180,9 +181,9 @@ func actionSetLogFile(_ *cli.Context, path string) error {
 	if !filepath.IsAbs(path) {
 		if wd, err := os.Getwd(); err == nil {
 			path = filepath.Join(wd, path)
-			os.Setenv(envVarOrchestrionLogFile, path)
 		}
 	}
+	os.Setenv(envVarOrchestrionLogFile, path)
 	filename := os.Expand(path, func(name string) string {
 		switch name {
 		case "PID":


### PR DESCRIPTION
### What does this PR do?

If the log level is set via `--log-level`, set the corresponding environment
variables so that the child processes will get it. This was done for
`--log-file` already, but only if it was originally a relative path. Propagate
it always.

### Motivation

I noticed this when investigating #223. I was setting the log level to "trace"
via the command line and didn't see much output. It took me a bit to realize
that the setting wasn't picked up by all the workers. I set the env var
instead, but ideally the command line argument works the
same way :)

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality.
