### PR TITLE
chore: use oldstable and stable for running workflows

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: stable # Minimum supported go release
-          cache-dependency-path: '**/*.sum'
+          cache-dependency-path: '**/go.mod'
 
       # Select the latest available version of gopkg.in/DataDog/dd-trace-go.v1, while ignoring all
       # the `v1.999.*` versions, which are experimental pre-releases.

--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          cache-dependency-path: '**/*.sum'
+          cache-dependency-path: '**/go.mod'
       - name: Run go generate (builtin)
         run: go generate ./internal/injector/builtin
       - name: Build Site

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: 'stable'
-          cache-dependency-path: '**/*.sum'
+          go-version: stable
+          cache-dependency-path: '**/go.mod'
 
       - name: Run 'go generate ./...'
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          cache-dependency-path: '**/*.sum'
+          go-version: stable
+          cache-dependency-path: '**/go.mod'
 
       # Obtains the current configured version tag from source, and verifies it is a valid tag name.
       # Also checks whether the tag already exists.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: 'stable'
-          cache-dependency-path: "**/*.sum"
+          go-version: stable
+          cache-dependency-path: "**/go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6
         with:
@@ -46,8 +46,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.22', '1.23']
-    name: Unit tests (go${{ matrix.go-version }})
+        go-version: [oldstable, stable]
+    name: Unit tests (go ${{ matrix.go-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache-dependency-path: "**/*.sum"
+          cache-dependency-path: "**/go.mod"
       - name: Run unit tests
         run: |-
           mkdir -p coverage
@@ -64,10 +64,8 @@ jobs:
       - name: Determine simple go version
         if: always() && github.event_name != 'merge_group'
         id: simple-go-version
-        run: echo "version=${COMPLETE_VERSION:0:4}" >> "${GITHUB_OUTPUT}"
+        run: echo "version=$(go version | cut -d' ' -f3 | grep -oE '\d+\.\d+')" >> "${GITHUB_OUTPUT}"
         shell: bash
-        env:
-          COMPLETE_VERSION: ${{ matrix.go-version }}
       - name: Upload coverage report
         # We want this even if the tests failed
         if: always() && github.event_name != 'merge_group'
@@ -76,25 +74,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: go${{ steps.simple-go-version.outputs.version }},${{ runner.os }},${{ runner.arch }},unit
           files: ./coverage/unit.out,./coverage/integration.out
-          name: Unit Tests (go${{ matrix.go-version }})
+          name: Unit Tests (go ${{ matrix.go-version }})
 
   integration-tests:
     strategy:
       fail-fast: false
       matrix:
         runs-on: [macos, ubuntu, windows]
-        go-version: ['1.22', '1.23']
+        go-version: [oldstable, stable]
         build-mode: [DRIVER]
         include:
           # Alternate build modes (only on ubuntu, latest go; to save CI time)
           - runs-on: ubuntu
-            go-version: '1.22'
+            go-version: oldstable
             build-mode: TOOLEXEC
           - runs-on: ubuntu
-            go-version: '1.22'
+            go-version: oldstable
             build-mode: GOFLAGS
     runs-on: ${{ matrix.runs-on }}-latest
-    name: Integration tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
+    name: Integration tests (go ${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -102,7 +100,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache-dependency-path: "**/*.sum"
+          cache-dependency-path: "**/go.mod"
       - name: Setup python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
         with:
@@ -146,10 +144,8 @@ jobs:
       - name: Determine simple go version
         if: github.event_name != 'merge_group'
         id: simple-go-version
-        run: echo "version=${COMPLETE_VERSION:0:4}" >> "${GITHUB_OUTPUT}"
+        run: echo "version=$(go version | cut -d' ' -f3 | grep -oE '\d+\.\d+')" >> "${GITHUB_OUTPUT}"
         shell: bash
-        env:
-          COMPLETE_VERSION: ${{ matrix.go-version }}
       - name: Upload coverage report
         if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4
@@ -157,7 +153,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: go${{ steps.simple-go-version.outputs.version }},${{ runner.os }},${{ runner.arch }},integration
           files: ./coverage/integration.out
-          name: Integration Tests (go${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
+          name: Integration Tests (go ${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
 
   # This is just a join point intended to simplify branch protection settings
   complete:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,11 +136,7 @@ jobs:
           GOFLAGS: -tags=integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
       - name: Consolidate coverage report
         if: github.event_name != 'merge_group'
-        # Using gotip because the fix for https://github.com/golang/go/issues/68468 is not yet released.
-        run: |-
-          go install golang.org/dl/gotip@latest
-          gotip download
-          gotip tool covdata textfmt -i ./coverage/raw -o ./coverage/integration.out
+        run: go tool covdata textfmt -i ./coverage/raw -o ./coverage/integration.out
       - name: Determine simple go version
         if: github.event_name != 'merge_group'
         id: simple-go-version

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: 'stable'
-          cache-dependency-path: "**/*.sum"
+          go-version: stable
+          cache-dependency-path: "**/go.mod"
       - name: Setup python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
         with:


### PR DESCRIPTION
This allows us to never have to change our workflow configuration when a new go release is issued, as these labels automatically resolve via the published release manifest.

Also uses `go.mod` files instead of `go.sum` files to compute cache keys, as the `go.sum` files are technically not a dependency manifest.