### PR TITLE
chore: uniformly pass log.Tracef as packages.Load logger

### DIFF
--- a/internal/ensure/requiredversion.go
+++ b/internal/ensure/requiredversion.go
@@ -128,7 +128,11 @@ func requiredVersion(
 // working directory is used. The version may be blank if a replace directive is in effect; in which
 // case the path value may indicate the location of the source code that is being used instead.
 func goModVersion(dir string) (moduleVersion string, moduleDir string, err error) {
-	cfg := &packages.Config{Dir: dir, Mode: packages.NeedModule}
+	cfg := &packages.Config{
+		Dir:  dir,
+		Mode: packages.NeedModule,
+		Logf: func(format string, args ...any) { log.Tracef(format+"\n", args...) },
+	}
 	pkgs, err := packages.Load(cfg, orchestrionPkgPath)
 	if err != nil {
 		return "", "", err

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datadog/orchestrion/internal/injector/aspect/context"
 	"github.com/datadog/orchestrion/internal/injector/builtin"
 	"github.com/datadog/orchestrion/internal/injector/typed"
+	"github.com/datadog/orchestrion/internal/log"
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/dave/dst/decorator/resolver/guess"
@@ -79,6 +80,7 @@ func New(pkgDir string, opts Options) (*Injector, error) {
 			packages.NeedSyntax |
 			packages.NeedTypesInfo,
 		Tests: opts.IncludeTests,
+		Logf:  func(format string, args ...any) { log.Tracef(format+"\n", args...) },
 	}
 	if flags, err := goflags.Flags(); err == nil {
 		// Honor any `-tags`  flags provided by the user, as these may affect what

--- a/internal/jobserver/buildid/version.go
+++ b/internal/jobserver/buildid/version.go
@@ -51,6 +51,7 @@ func (s *service) versionSuffix(req *VersionSuffixRequest) (VersionSuffixRespons
 		&packages.Config{
 			Mode:       packages.NeedDeps | packages.NeedEmbedFiles | packages.NeedFiles | packages.NeedImports | packages.NeedModule,
 			BuildFlags: []string{"-toolexec="}, // Explicitly disable toolexec to avoid infinite recursion
+			Logf:       func(format string, args ...any) { log.Tracef(format+"\n", args...) },
 		},
 		builtin.InjectedPaths[:]...,
 	)

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/datadog/orchestrion/internal/jobserver/client"
+	"github.com/datadog/orchestrion/internal/log"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -130,6 +131,7 @@ func (s *service) resolve(req *ResolveRequest) (ResolveResponse, error) {
 				Dir:        req.Dir,
 				Env:        env,
 				BuildFlags: req.BuildFlags,
+				Logf:       func(format string, args ...any) { log.Tracef(format+"\n", args...) },
 			},
 			req.Pattern,
 		)


### PR DESCRIPTION
This allows to get more debugging information with the TRACE log level.