### PR TITLE
fix(goflags): using `-cover` causes fingerprint mismatch

### DIFF
--- a/internal/ensure/requiredversion_test.go
+++ b/internal/ensure/requiredversion_test.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/datadog/orchestrion/internal/goenv"
 	"github.com/datadog/orchestrion/internal/version"
 	"github.com/stretchr/testify/require"
 )
@@ -80,7 +81,7 @@ func TestGoModVersion(t *testing.T) {
 }
 
 func TestRequiredVersion(t *testing.T) {
-	goBin, err := exec.LookPath("go")
+	goBin, err := goenv.GoBinPath()
 	require.NoError(t, err, "could not resolve go command path")
 
 	testError := errors.New("simulated failure")

--- a/internal/goenv/gobin.go
+++ b/internal/goenv/gobin.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package goenv
+
+import "os/exec"
+
+var goBinPath string
+
+// GoBinPath returns the resolved path to the `go` command's binary. The result is cached to avoid
+// looking it up multiple times. If the lookup fails, the error is returned and the result is not
+// cached.
+func GoBinPath() (string, error) {
+	if goBinPath == "" {
+		goBin, err := exec.LookPath("go")
+		if err != nil {
+			return "", err
+		}
+		goBinPath = goBin
+	}
+	return goBinPath, nil
+}

--- a/internal/goenv/gobin_test.go
+++ b/internal/goenv/gobin_test.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package goenv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	path, err := GoBinPath()
+	require.NoError(t, err)
+	t.Logf("GOBIN: %s", path)
+}

--- a/internal/goflags/quoted/quoted.go
+++ b/internal/goflags/quoted/quoted.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package quoted provides string manipulation utilities. This is elements
+// copied from the go command's internals:
+// https://github.com/golang/go/blob/go1.23rc2/src/cmd/go/internal/base/goflags.go
+package quoted
+
+import (
+	"fmt"
+)
+
+func isSpaceByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// Split splits s into a list of fields,
+// allowing single or double quotes around elements.
+// There is no unescaping or other processing within
+// quoted fields.
+//
+// Keep in sync with cmd/dist/quoted.go
+func Split(s string) ([]string, error) {
+	// Split fields allowing '' or "" around elements.
+	// Quotes further inside the string do not count.
+	var f []string
+	for len(s) > 0 {
+		for len(s) > 0 && isSpaceByte(s[0]) {
+			s = s[1:]
+		}
+		if len(s) == 0 {
+			break
+		}
+		// Accepted quoted string. No unescaping inside.
+		if s[0] == '"' || s[0] == '\'' {
+			quote := s[0]
+			s = s[1:]
+			i := 0
+			for i < len(s) && s[i] != quote {
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			f = append(f, s[:i])
+			s = s[i+1:]
+			continue
+		}
+		i := 0
+		for i < len(s) && !isSpaceByte(s[i]) {
+			i++
+		}
+		f = append(f, s[:i])
+		s = s[i:]
+	}
+	return f, nil
+}

--- a/internal/goflags/quoted/quoted_test.go
+++ b/internal/goflags/quoted/quoted_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package quoted
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		value   string
+		want    []string
+		wantErr string
+	}{
+		{name: "empty", value: "", want: nil},
+		{name: "space", value: " ", want: nil},
+		{name: "one", value: "a", want: []string{"a"}},
+		{name: "leading_space", value: " a", want: []string{"a"}},
+		{name: "trailing_space", value: "a ", want: []string{"a"}},
+		{name: "two", value: "a b", want: []string{"a", "b"}},
+		{name: "two_multi_space", value: "a  b", want: []string{"a", "b"}},
+		{name: "two_tab", value: "a\tb", want: []string{"a", "b"}},
+		{name: "two_newline", value: "a\nb", want: []string{"a", "b"}},
+		{name: "quote_single", value: `'a b'`, want: []string{"a b"}},
+		{name: "quote_double", value: `"a b"`, want: []string{"a b"}},
+		{name: "quote_both", value: `'a '"b "`, want: []string{"a ", "b "}},
+		{name: "quote_contains", value: `'a "'"'b"`, want: []string{`a "`, `'b`}},
+		{name: "escape", value: `\'`, want: []string{`\'`}},
+		{name: "quote_unclosed", value: `'a`, wantErr: "unterminated ' string"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Split(test.value)
+			if err != nil {
+				if test.wantErr == "" {
+					t.Fatalf("unexpected error: %v", err)
+				} else if errMsg := err.Error(); !strings.Contains(errMsg, test.wantErr) {
+					t.Fatalf("error %q does not contain %q", errMsg, test.wantErr)
+				}
+				return
+			}
+			if test.wantErr != "" {
+				t.Fatalf("unexpected success; wanted error containing %q", test.wantErr)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %q; want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/goproxy/dashc.go
+++ b/internal/goproxy/dashc.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package goproxy
+
+import (
+	"os"
+	"strings"
+
+	"github.com/datadog/orchestrion/internal/log"
+)
+
+// ProcessDashC gets the command line arguments passed to a "go" command (without "go" itself), and processes the "-C"
+// flag present at the beginning of the slice (if present), changing directories as requested, then returns the slice
+// without it.
+//
+// The "-C" flags is reuqired to be the very first argument provided to "go" commands.
+func ProcessDashC(args []string) ([]string, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	arg0 := args[0]
+	if !strings.HasPrefix(arg0, "-C") {
+		return args, nil
+	}
+
+	if arg0 == "-C" && len(args) > 1 {
+		// ["-C", "directory", ...]
+		log.Tracef("Found -C %q flag, changing directory\n", args[1])
+		return args[2:], os.Chdir(args[1])
+	}
+
+	if !strings.HasPrefix(arg0, "-C=") {
+		// Probably not the flag we're looking for... ignoring that...
+		log.Tracef("Ignoring unknown flag with -C prefix: %q\n", arg0)
+		return args, nil
+	}
+
+	// ["-C=directory", ...]
+	log.Tracef("Found %q flag, changing directory\n", arg0)
+	return args[1:], os.Chdir(arg0[3:])
+}


### PR DESCRIPTION
In order to properly convey coverage flags to child processes when doing injected package resolution, it is important the `-cover` flags only applies to packages selected for instrumentation by the user, otherwise some packages may be instrumented or not instrumented depending on whether they are directly resolved or a transitive dependency of a directly resolved package; and this leads to link-time fingerprint mismatches.

This implies we must make the default value of `-coverpkg` explicit if it is not provided by the user.