### PR TITLE
docs(README): remove mention of future OTel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Automatic compile-time instrumentation of Go code.
 
 [Orchestrion](https://en.wikipedia.org/wiki/Orchestrion) processes Go source code at compilation time and automatically
 inserts instrumentation. This instrumentation produces Datadog APM traces from the instrumented code and supports
-Datadog Application Security Management. Future work will include support for OpenTelemetry tracing as well.
+Datadog Application Security Management.
 
 > [!IMPORTANT]
 > Orchestrion is under active development. The supported features are rapidly growing, and the user experiece may evolve


### PR DESCRIPTION
We have not yet decided on any timeline for OTel support, or if we'd build it ourselves, merely enable it, etc... Adjusting the README.md content to avoid sounding like we have a plan in place.