### PR TITLE
chore: make array expansions empty-safe

### DIFF
--- a/.github/actions/codecov-upload/action.yml
+++ b/.github/actions/codecov-upload/action.yml
@@ -49,10 +49,10 @@ runs:
           --verbose                                                             \
           do-upload                                                             \
           --disable-search                                                      \
-          "${file[@]}"                                                          \
+          ${file[@]+"${file[@]}"}                                               \
           --name="${{ inputs.name }}"                                           \
-          "${pr[@]}"                                                            \
-          "${flag[@]}"                                                          \
+          ${pr[@]+"${pr[@]}"}                                                   \
+          ${flag[@]+"${flag[@]}"}                                               \
           --sha="${sha}"                                                        \
           --fail-on-error                                                       \
           --git-service=github                                                  \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -268,7 +268,7 @@ jobs:
           if [ "${{ github.event_name }}" != "merge_group" ]; then
             build_args+=("-cover" "-covermode=atomic" "-coverpkg=./...")
           fi
-          go build "${build_args[@]}" -o="bin/orchestrion.exe" .
+          go build ${build_args[@]+"${build_args[@]}"} -o="bin/orchestrion.exe" .
       - name: Run Integration Tests
         shell: bash
         run: |-
@@ -378,7 +378,7 @@ jobs:
             --verbose                                                           \
             create-commit                                                       \
             --parent-sha="${parentsha}"                                         \
-            "${pr[@]}"                                                          \
+            ${pr[@]+"${pr[@]}"}                                                 \
             --sha="${sha}"                                                      \
             --fail-on-error                                                     \
             --git-service=github                                                \
@@ -391,7 +391,7 @@ jobs:
             --auto-load-params-from=GithubActions                               \
             --verbose                                                           \
             create-report                                                       \
-            "${pr[@]}"                                                          \
+            ${pr[@]+"${pr[@]}"}                                                 \
             --sha="${sha}"                                                      \
             --fail-on-error                                                     \
             --git-service=github                                                \


### PR DESCRIPTION
Bash treats arrays as defined only if at least one index has been assigned a value, meaning empty arrays are treated as undefined, which trips when `set -u` is being used. The safe idiom to use in this case is `${arr[@]+"${arr[@]}"}`, which only tries expanding the array if it is deemed set. This is not very pretty, but should do the deed.