### PR TITLE
fix: do not set container name for dynamodb

### DIFF
--- a/_integration-tests/utils/testcontainers.go
+++ b/_integration-tests/utils/testcontainers.go
@@ -26,7 +26,6 @@ func StartDynamoDBTestContainer(t *testing.T) (testcontainers.Container, string,
 			Image:        "amazon/dynamodb-local:latest",
 			ExposedPorts: []string{exposedPort},
 			WaitingFor:   wait.ForHTTP("").WithStatusCodeMatcher(func(int) bool { return true }),
-			Name:         "dynamodb-local",
 			WorkingDir:   "/home/dynamodblocal",
 			Cmd: []string{
 				"-jar", "DynamoDBLocal.jar",


### PR DESCRIPTION
Now that integration tests are in separate packages, tests are no longer running sequentially, so since both aws v1 and v2 tests use this container, we should not be setting a name and instead let testcontainers generate it.