### PR TITLE
feat: instrument source files in parallel

### DIFF
--- a/internal/injector/aspect/context/node.go
+++ b/internal/injector/aspect/context/node.go
@@ -56,6 +56,6 @@ func (n *NodeChain) PropertyName() string {
 	return n.name
 }
 
-func (n *NodeChain) Index() string {
-	return n.Index()
+func (n *NodeChain) Index() int {
+	return n.index
 }

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -138,6 +138,10 @@ func (i *Injector) validate() error {
 	if i.Lookup == nil {
 		err = errors.Join(err, fmt.Errorf("invalid %T: missing Lookup", i))
 	}
+
+	// Initialize the restorerResolver field, too...
+	i.restorerResolver = &lookupResolver{lookup: i.Lookup}
+
 	return err
 }
 

--- a/internal/injector/restorer.go
+++ b/internal/injector/restorer.go
@@ -10,6 +10,7 @@ import (
 	"go/importer"
 	"go/token"
 	"go/types"
+	"sync"
 
 	"github.com/dave/dst/decorator"
 	"golang.org/x/tools/go/gcexportdata"
@@ -20,6 +21,8 @@ type lookupResolver struct {
 
 	fset    *token.FileSet
 	imports map[string]*types.Package
+
+	mu sync.Mutex
 }
 
 func (i *Injector) newRestorer(filename string) *decorator.FileRestorer {
@@ -38,6 +41,9 @@ func (r *lookupResolver) ResolvePackage(path string) (string, error) {
 	if path == "unsafe" {
 		return "unsafe", nil
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	// If this is present in "cache", we can return right away!
 	if pkg, ok := r.imports[path]; ok {

--- a/internal/injector/restorer.go
+++ b/internal/injector/restorer.go
@@ -26,10 +26,6 @@ type lookupResolver struct {
 }
 
 func (i *Injector) newRestorer(filename string) *decorator.FileRestorer {
-	if i.restorerResolver == nil {
-		i.restorerResolver = &lookupResolver{lookup: i.Lookup}
-	}
-
 	return &decorator.FileRestorer{
 		Restorer: decorator.NewRestorerWithImports(i.ImportPath, i.restorerResolver),
 		Name:     filename,

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -139,7 +139,7 @@ func (s *service) resolve(req *ResolveRequest) (ResolveResponse, error) {
 			return nil, err
 		}
 
-		var resp ResolveResponse
+		resp := make(ResolveResponse)
 		for _, pkg := range pkgs {
 			resp.mergeFrom(pkg)
 		}
@@ -150,16 +150,6 @@ func (s *service) resolve(req *ResolveRequest) (ResolveResponse, error) {
 	}
 
 	return resp, nil
-}
-
-func hashArray(items []string) string {
-	h := sha512.New512_224()
-
-	for idx, item := range items {
-		_, _ = fmt.Fprintf(h, "\x01%d\x02%s\x03", idx, item)
-	}
-
-	return base64.URLEncoding.EncodeToString(h.Sum(nil))
 }
 
 func (r *ResolveRequest) canonicalize() {
@@ -186,15 +176,14 @@ func (r *ResolveRequest) hash() (string, error) {
 	return base64.URLEncoding.EncodeToString(hash.Sum(sum[:0])), nil
 }
 
-func (r *ResolveResponse) mergeFrom(pkg *packages.Package) {
-	if pkg.PkgPath == "" || pkg.PkgPath == "unsafe" {
+func (r ResolveResponse) mergeFrom(pkg *packages.Package) {
+	if pkg.PkgPath == "" || pkg.PkgPath == "unsafe" || r[pkg.PkgPath] != "" {
+		// Ignore the "unsafe" package (no archive file, ever), packages with an empty import path
+		// (standard library), and those already present in the map (already processed previously).
 		return
 	}
-	if *r == nil {
-		*r = make(ResolveResponse)
-	}
-	(*r)[pkg.PkgPath] = pkg.ExportFile
 
+	r[pkg.PkgPath] = pkg.ExportFile
 	for _, dep := range pkg.Imports {
 		r.mergeFrom(dep)
 	}


### PR DESCRIPTION
Instrumentation of source files can be performed in parallel, as the AST transformations do not span across files. Once the files are parsed & type checked, using a distinct decorator per file enables parallel processing & more efficient post-processing (fewer items in the decorator maps, none of which irrelevant to the current AST being post-processed).

This would improve the performance of builds, and a local profile showed a 70% improvement on the specific package I was playing with.