### PR TITLE
chore: allow validation to run for ALL commits on push

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || ((github.event_name == 'push' && github.sha) || github.ref) }}
   cancel-in-progress: true
 
 permissions: read-all


### PR DESCRIPTION
The concurrency group naming results in cancelling concurrent executions on the same ref on all events, which means individual commits pushed to `main` may not be fully validated. In particular, this results in missing coverage information & benchmarking results.

Changed the naming so that on `push` events, the commit SHA is used instead of the commit ref, allowing individual commits to run independently from each other.