### PR TITLE
chore: dependency upgrade workflow fails

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -111,11 +111,14 @@ jobs:
       - name: Create PR
         run: |-
           git fetch origin "${{ steps.create-branch.outputs.branch }}"
+          git reset --hard HEAD
           git switch "${{ steps.create-branch.outputs.branch }}"
           gh pr create --title "chore: update all dependencies" \
                        --body "Updated all go.mod dependencies to latest." \
                        --head="${{ steps.create-branch.outputs.branch }}"
         env:
+          # Create the PR as "github-actions[bot]" so that even the owner of the mutator token can
+          # approve the PR.
           GITHUB_TOKEN: ${{ github.token }}
 
       # The standard GitHub Token will not trigger downstream workflows, so in order to kick off CI,


### PR DESCRIPTION
The procedure to create the PR requires the branch is checked out, but the work tree is dirty at time of doing so; as the commit is created from the dirty files via the GitHub API. Clean up the working copy before switching to the newly created commit.