### PR TITLE
chore: use larger runners for linux integration tests

### DIFF
--- a/.github/actions/codecov-cli/action.yml
+++ b/.github/actions/codecov-cli/action.yml
@@ -12,6 +12,7 @@ runs:
       uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
       with:
         python-version: '3.x'
+        cache-dependency-path: ${{ github.action_path }}/requirements-dev.txt
 
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/actions/codecov-cli/action.yml
+++ b/.github/actions/codecov-cli/action.yml
@@ -20,5 +20,5 @@ runs:
       id: install
       shell: bash
       run: |-
-        pip install codecov-cli==0.8.0
+        pip install codecov-cli~=0.7.6
         echo "codecov=$(which codecovcli)" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/codecov-cli/action.yml
+++ b/.github/actions/codecov-cli/action.yml
@@ -13,9 +13,12 @@ runs:
       with:
         python-version: '3.x'
 
+    - name: Setup Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+
     - name: Install codecov-cli
       id: install
       shell: bash
       run: |-
-        pip install codecov-cli==0.7.4
+        pip install codecov-cli==0.8.0
         echo "codecov=$(which codecovcli)" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/codecov-cli/action.yml
+++ b/.github/actions/codecov-cli/action.yml
@@ -20,5 +20,5 @@ runs:
       id: install
       shell: bash
       run: |-
-        pip install codecov-cli~=0.7.6
+        pip install -r "${{ github.action_path }}/requirements-dev.txt"
         echo "codecov=$(which codecovcli)" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/codecov-cli/requirements-dev.txt
+++ b/.github/actions/codecov-cli/requirements-dev.txt
@@ -1,0 +1,22 @@
+codecov-cli==0.7.4
+## The following requirements were added by pip freeze:
+anyio==4.6.2.post1
+certifi==2024.8.30
+charset-normalizer==3.4.0
+click==8.1.7
+exceptiongroup==1.2.2
+h11==0.14.0
+httpcore==0.16.3
+httpx==0.23.3
+idna==3.10
+ijson==3.3.0
+PyYAML==6.0.2
+regex==2024.9.11
+requests==2.32.3
+responses==0.21.0
+rfc3986==1.5.0
+sniffio==1.3.1
+test_results_parser==0.1.0
+tree-sitter==0.20.4
+typing_extensions==4.12.2
+urllib3==2.2.3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
     groups:
       Python Dependencies:
         applies-to: version-updates
+
+  - package-ecosystem: pip
+    directory: /.github/actions/codecov-cli
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      Python Dependencies:
+        applies-to: version-updates

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -305,6 +305,8 @@ jobs:
           sudo apt update
           sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
           sudo chown root:$(groups | cut -d' ' -f1) /var/run/docker.sock
+
+          echo "DOCKER_DEFAULT_PLATFORM=linux/arm64" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Setup go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -292,7 +292,18 @@ jobs:
     steps:
       - name: Start docker daemon (arm-4core-linux only)
         if: matrix.runs-on == 'ubuntu'
-        run: sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        run: |-
+          sudo apt update
+          sudo apt install -y ca-certificates curl
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt update
+          sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Setup go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -294,7 +294,7 @@ jobs:
         if: matrix.runs-on == 'ubuntu'
         run: |-
           sudo apt update
-          sudo apt install -y ca-certificates curl
+          sudo apt install -y build-essential ca-certificates curl
           sudo install -m 0755 -d /etc/apt/keyrings
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
           sudo chmod a+r /etc/apt/keyrings/docker.asc
@@ -307,9 +307,6 @@ jobs:
           sudo chown root:$(groups | cut -d' ' -f1) /var/run/docker.sock
 
           echo "DOCKER_DEFAULT_PLATFORM=linux/arm64" >> "${GITHUB_ENV}"
-
-          sudo apt install -y build-essential
-          echo "CGO_ENABLED=1" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Setup go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -334,7 +334,7 @@ jobs:
         shell: bash
         run: |-
           mkdir -p "${GOCOVERDIR}"
-          test_args=("-shuffle=on" "-v")
+          test_args=("-shuffle=on")
           if [ "${{ github.event_name }}" != "merge_group" ]; then
             test_args+=("-coverpkg=./...,github.com/DataDog/orchestrion/..." "-covermode=atomic" "-cover" "-coverprofile=${{ github.workspace }}/coverage/integration.run.out")
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -307,6 +307,9 @@ jobs:
           sudo chown root:$(groups | cut -d' ' -f1) /var/run/docker.sock
 
           echo "DOCKER_DEFAULT_PLATFORM=linux/arm64" >> "${GITHUB_ENV}"
+
+          sudo apt install -y build-essential
+          echo "CGO_ENABLED=1" >> "${GITHUB_ENV}"
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Setup go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -288,8 +288,8 @@ jobs:
     runs-on: ${{ matrix.runs-on == 'ubuntu' && 'arm-4core-linux' || format('{0}-latest', matrix.runs-on) }}
     name: Integration tests (go ${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
     steps:
-      - name: Start docker daemon
-        if: runner.name == 'arm-4core-linux'
+      - name: Start docker daemon (arm-4core-linux only)
+        if: matrix.runs-on == 'ubuntu'
         run: sudo systemctl start docker
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -247,6 +247,8 @@ jobs:
         run: |-
           set -euo pipefail
           go test -bench=. -timeout=1h -run=^$ . | tee ${{ runner.temp }}/benchmarks.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload benchmark report (raw)
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -303,9 +303,8 @@ jobs:
             $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt update
-          sudo groupadd docker
-          sudo usermod -aG docker $USER
           sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo chown root:$(groups | cut -d' ' -f1) /var/run/docker.sock
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Setup go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -285,9 +285,12 @@ jobs:
           - runs-on: ubuntu
             go-version: oldstable
             build-mode: GOFLAGS
-    runs-on: ${{ matrix.runs-on }}-latest
+    runs-on: ${{ matrix.runs-on == 'ubuntu' && 'arm-4core-linux' || format('{0}-latest', matrix.runs-on) }}
     name: Integration tests (go ${{ matrix.go-version }}, ${{ matrix.runs-on }}, ${{ matrix.build-mode }})
     steps:
+      - name: Start docker daemon
+        if: runner.name == 'arm-4core-linux'
+        run: sudo systemctl start docker
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Setup go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -320,9 +320,9 @@ jobs:
         with:
           python-version: 3.x
           cache: pip
-          cache-dependency-path: _integration-tests/utils/agent/requirements.txt
+          cache-dependency-path: _integration-tests/utils/agent/requirements-dev.txt
       - name: Install python dependencies
-        run: pip install -r _integration-tests/utils/agent/requirements.txt
+        run: pip install -r _integration-tests/utils/agent/requirements-dev.txt
       - name: Build orchestrion binary
         shell: bash
         run: |-

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -292,7 +292,7 @@ jobs:
     steps:
       - name: Start docker daemon (arm-4core-linux only)
         if: matrix.runs-on == 'ubuntu'
-        run: sudo systemctl start docker
+        run: sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Setup go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -303,6 +303,8 @@ jobs:
             $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
             sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt update
+          sudo groupadd docker
+          sudo usermod -aG docker $USER
           sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4

--- a/.github/workflows/workflow_call.yml
+++ b/.github/workflows/workflow_call.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           python-version: 3.x
           cache: pip
-          cache-dependency-path: orchestrion/_integration-tests/utils/agent/requirements.txt
+          cache-dependency-path: orchestrion/_integration-tests/utils/agent/requirements-dev.txt
       - name: Install python dependencies
-        run: pip install -r orchestrion/_integration-tests/utils/agent/requirements.txt
+        run: pip install -r orchestrion/_integration-tests/utils/agent/requirements-dev.txt
       - name: Build orchestrion binary
         run: go -C orchestrion/ build -o="./_integration-tests/orchestrion.exe" .
       - name: Run Integration Tests

--- a/_integration-tests/README.md
+++ b/_integration-tests/README.md
@@ -14,7 +14,7 @@ First, install the `ddapm-test-agent` if you haven't already:
 ``` console
 $ python3 -m venv venv
 $ source ./venv/bin/activate
-$ pip install -r ./utils/agent/requirements.txt
+$ pip install -r ./utils/agent/requirements-dev.txt
 ```
 
 Then, ensure that Docker is installed and the daemon is running.

--- a/_integration-tests/tests/gcp_pubsub/gcp_pubsub.go
+++ b/_integration-tests/tests/gcp_pubsub/gcp_pubsub.go
@@ -48,13 +48,6 @@ func (tc *TestCase) Setup(t *testing.T) {
 		gcloud.WithProjectID("pstest-orchestrion"),
 		testcontainers.WithLogger(testcontainers.TestLogger(t)),
 		utils.WithTestLogConsumer(t),
-		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
-			require.Len(t, req.Cmd, 3)
-			require.Equal(t, "/bin/sh", req.Cmd[0])
-			require.Equal(t, "-c", req.Cmd[1])
-			req.Cmd[2] = "yes | gcloud components install beta pubsub-emulator && " + req.Cmd[2]
-			return nil
-		}),
 	)
 	utils.AssertTestContainersError(t, err)
 

--- a/_integration-tests/tests/gcp_pubsub/gcp_pubsub.go
+++ b/_integration-tests/tests/gcp_pubsub/gcp_pubsub.go
@@ -44,10 +44,17 @@ func (tc *TestCase) Setup(t *testing.T) {
 	)
 
 	tc.container, err = gcloud.RunPubsub(ctx,
-		"gcr.io/google.com/cloudsdktool/cloud-sdk:490.0.0-emulators",
+		"gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators",
 		gcloud.WithProjectID("pstest-orchestrion"),
 		testcontainers.WithLogger(testcontainers.TestLogger(t)),
 		utils.WithTestLogConsumer(t),
+		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
+			require.Len(t, req.Cmd, 3)
+			require.Equal(t, "/bin/sh", req.Cmd[0])
+			require.Equal(t, "-c", req.Cmd[1])
+			req.Cmd[2] = "yes | gcloud components install beta pubsub-emulator && " + req.Cmd[2]
+			return nil
+		}),
 	)
 	utils.AssertTestContainersError(t, err)
 

--- a/_integration-tests/utils/agent/agent.go
+++ b/_integration-tests/utils/agent/agent.go
@@ -62,7 +62,7 @@ func New(t *testing.T) (*MockAgent, error) {
 		t.Logf("Installing requirements in venv...\n")
 		_, thisFile, _, _ := runtime.Caller(0)
 		thisDir := filepath.Dir(thisFile)
-		if err = exec.Command(filepath.Join(venvBin, "pip"), "install", "-r", filepath.Join(thisDir, "requirements.txt")).Run(); err != nil {
+		if err = exec.Command(filepath.Join(venvBin, "pip"), "install", "-r", filepath.Join(thisDir, "requirements-dev.txt")).Run(); err != nil {
 			return nil, err
 		}
 

--- a/_integration-tests/utils/agent/requirements-dev.txt
+++ b/_integration-tests/utils/agent/requirements-dev.txt
@@ -3,6 +3,7 @@ ddapm-test-agent==1.18.0
 aiohappyeyeballs==2.4.3
 aiohttp==3.10.10
 aiosignal==1.3.1
+async-timeout==4.0.3
 attrs==24.2.0
 certifi==2024.8.30
 charset-normalizer==3.4.0
@@ -11,6 +12,7 @@ frozenlist==1.4.1
 idna==3.10
 msgpack==1.1.0
 multidict==6.1.0
+propcache==0.2.0
 protobuf==5.28.2
 requests==2.32.3
 six==1.16.0


### PR DESCRIPTION
The reasoning is I hope this reduces flakiness, assuming it is caused at least in parts by our test containers running against runner resource limits.

This implies:
- Switching to the `arm-4core-linux` runner
- Installing `docker` on those new runners (not there by default)
- Installing `build-essential` on those new runners (required for CGO, which sqlite3 needs)
- Switching the image used by the GCP pubsub tests, as the one that was used was the older, deprecated one; which does not support `linux/arm64` platforms, in favor of the new, maintained one which does support it