### PR TITLE
fix(injector: redigo) undefined: redis

### DIFF
--- a/internal/injector/builtin/generated.go
+++ b/internal/injector/builtin/generated.go
@@ -535,7 +535,7 @@ var Aspects = [...]aspect.Aspect{
 		JoinPoint: join.FunctionCall("github.com/gomodule/redigo/redis.Dial"),
 		Advice: []advice.Advice{
 			advice.WrapExpression(code.MustTemplate(
-				"func() (redis.Conn, error) {\n  {{ if .AST.Ellipsis }}\n    opts := {{ index .AST.Args 2 }}\n    anyOpts := make([]interface{}, len(opts))\n    for i, v := range opts {\n      anyOpts[i] = v\n    }\n    return redigotrace.Dial({{ index .AST.Args 0 }}, {{ index .AST.Args 1 }}, anyOpts...)\n  {{ else }}\n    return redigotrace.Dial(\n      {{- range .AST.Args -}}\n        {{ . }},\n      {{- end -}}\n    )\n  {{ end }}\n}()",
+				"func() (redigo.Conn, error) {\n  {{ if .AST.Ellipsis }}\n    opts := {{ index .AST.Args 2 }}\n    anyOpts := make([]interface{}, len(opts))\n    for i, v := range opts {\n      anyOpts[i] = v\n    }\n    return redigotrace.Dial({{ index .AST.Args 0 }}, {{ index .AST.Args 1 }}, anyOpts...)\n  {{ else }}\n    return redigotrace.Dial(\n      {{- range .AST.Args -}}\n        {{ . }},\n      {{- end -}}\n    )\n  {{ end }}\n}()",
 				map[string]string{
 					"redigo":      "github.com/gomodule/redigo/redis",
 					"redigotrace": "gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo",
@@ -547,7 +547,7 @@ var Aspects = [...]aspect.Aspect{
 		JoinPoint: join.FunctionCall("github.com/gomodule/redigo/redis.DialContext"),
 		Advice: []advice.Advice{
 			advice.WrapExpression(code.MustTemplate(
-				"func() (redis.Conn, error) {\n  {{ if .AST.Ellipsis }}\n    opts := {{ index .AST.Args 3 }}\n    anyOpts := make([]interface{}, len(opts))\n    for i, v := range opts {\n      anyOpts[i] = v\n    }\n    return redigotrace.DialContext({{ index .AST.Args 0 }}, {{ index .AST.Args 1 }}, {{ index .AST.Args 2 }}, anyOpts...)\n  {{ else }}\n    return redigotrace.DialContext(\n      {{- range .AST.Args -}}\n        {{ . }},\n      {{- end -}}\n    )\n  {{ end }}\n}()",
+				"func() (redigo.Conn, error) {\n  {{ if .AST.Ellipsis }}\n    opts := {{ index .AST.Args 3 }}\n    anyOpts := make([]interface{}, len(opts))\n    for i, v := range opts {\n      anyOpts[i] = v\n    }\n    return redigotrace.DialContext({{ index .AST.Args 0 }}, {{ index .AST.Args 1 }}, {{ index .AST.Args 2 }}, anyOpts...)\n  {{ else }}\n    return redigotrace.DialContext(\n      {{- range .AST.Args -}}\n        {{ . }},\n      {{- end -}}\n    )\n  {{ end }}\n}()",
 				map[string]string{
 					"redigo":      "github.com/gomodule/redigo/redis",
 					"redigotrace": "gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo",
@@ -559,7 +559,7 @@ var Aspects = [...]aspect.Aspect{
 		JoinPoint: join.FunctionCall("github.com/gomodule/redigo/redis.DialURL"),
 		Advice: []advice.Advice{
 			advice.WrapExpression(code.MustTemplate(
-				"func() (redis.Conn, error) {\n  {{ if .AST.Ellipsis }}\n    opts := {{ index .AST.Args 1 }}\n    anyOpts := make([]interface{}, len(opts))\n    for i, v := range opts {\n      anyOpts[i] = v\n    }\n    return redigotrace.DialURL({{ index .AST.Args 0 }}, anyOpts...)\n  {{ else }}\n    return redigotrace.DialURL(\n      {{- range .AST.Args -}}\n        {{ . }},\n      {{- end -}}\n    )\n  {{ end }}\n}()",
+				"func() (redigo.Conn, error) {\n  {{ if .AST.Ellipsis }}\n    opts := {{ index .AST.Args 1 }}\n    anyOpts := make([]interface{}, len(opts))\n    for i, v := range opts {\n      anyOpts[i] = v\n    }\n    return redigotrace.DialURL({{ index .AST.Args 0 }}, anyOpts...)\n  {{ else }}\n    return redigotrace.DialURL(\n      {{- range .AST.Args -}}\n        {{ . }},\n      {{- end -}}\n    )\n  {{ end }}\n}()",
 				map[string]string{
 					"redigo":      "github.com/gomodule/redigo/redis",
 					"redigotrace": "gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo",
@@ -1321,4 +1321,4 @@ var InjectedPaths = [...]string{
 }
 
 // Checksum is a checksum of the built-in configuration which can be used to invalidate caches.
-const Checksum = "sha512:nZo/jzc10MyCH6GjUsBxWg9EttIf+t+q37i9pbw40RuNJFo/l7iYfZ2sEC9bUR497hMEt2FXzPBXcEytF1Jyvw=="
+const Checksum = "sha512:QKpZ+2KC7FrIK9q175W6B/4qFTtJl3aFqZspjyVh3qwa0DqVYt0qjL+akIBeq6RxPyl4gqN0mGssSgCDcmc1tQ=="

--- a/internal/injector/builtin/testdata/client/redis.go.snap
+++ b/internal/injector/builtin/testdata/client/redis.go.snap
@@ -108,7 +108,7 @@ func redigoClient(ctx context.Context, net, addr string) {
 
 	if conn, err :=
 //line <generated>
-		func() (redis.Conn, error) {
+		func() (redigo.Conn, error) {
 			return __orchestrion_redigotrace.Dial(
 //line samples/client/redis.go:61
 				net, addr)
@@ -122,7 +122,7 @@ func redigoClient(ctx context.Context, net, addr string) {
 
 	if conn, err :=
 //line <generated>
-		func() (redis.Conn, error) {
+		func() (redigo.Conn, error) {
 			return __orchestrion_redigotrace.DialContext(
 //line samples/client/redis.go:67
 				ctx, net, addr, redigo.DialConnectTimeout(5*time.Second))
@@ -136,7 +136,7 @@ func redigoClient(ctx context.Context, net, addr string) {
 
 	if conn, err :=
 //line <generated>
-		func() (redis.Conn, error) {
+		func() (redigo.Conn, error) {
 			opts :=
 //line samples/client/redis.go:73
 				options

--- a/internal/injector/builtin/yaml/databases/redigo.yml
+++ b/internal/injector/builtin/yaml/databases/redigo.yml
@@ -21,7 +21,7 @@ aspects:
             redigo: github.com/gomodule/redigo/redis
             redigotrace: gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo
           template: |-
-            func() (redis.Conn, error) {
+            func() (redigo.Conn, error) {
               {{ if .AST.Ellipsis }}
                 opts := {{ index .AST.Args 2 }}
                 anyOpts := make([]interface{}, len(opts))
@@ -49,7 +49,7 @@ aspects:
             redigo: github.com/gomodule/redigo/redis
             redigotrace: gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo
           template: |-
-            func() (redis.Conn, error) {
+            func() (redigo.Conn, error) {
               {{ if .AST.Ellipsis }}
                 opts := {{ index .AST.Args 3 }}
                 anyOpts := make([]interface{}, len(opts))
@@ -77,7 +77,7 @@ aspects:
             redigo: github.com/gomodule/redigo/redis
             redigotrace: gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo
           template: |-
-            func() (redis.Conn, error) {
+            func() (redigo.Conn, error) {
               {{ if .AST.Ellipsis }}
                 opts := {{ index .AST.Args 1 }}
                 anyOpts := make([]interface{}, len(opts))


### PR DESCRIPTION
Fix badly used import creating this error
```
❯ orchestrion go test ./... -work           
WORK=/var/folders/42/00hrt9gj3276cy8h0_d9nw480000gq/T/go-build1245716950
# go.ddbuild.io/dd-source/x/libs/go/redis
/Users/tony.redondo/go/pkg/mod/go.ddbuild.io/dd-source/x@v0.0.0-20241021135812-b13784d37c9c/libs/go/redis/connector.go:40: undefined: redis
exit status 2
```