### PR TITLE
fix: blank links in documentation

### DIFF
--- a/docs/content/contributing/aspects/code-templates.md
+++ b/docs/content/contributing/aspects/code-templates.md
@@ -13,7 +13,7 @@ references to the matched node.
 ### Template Syntax
 
 Orchestrion code templates are rendered using the Go standard library
-{{<godoc "text/template">}} module. Refer to the module's documentation to learn
+{{<godoc import-path="text/template">}} module. Refer to the module's documentation to learn
 about the general syntax of these template values.
 
 In addition to the template text, Orchestrion code templates allow for two
@@ -109,9 +109,9 @@ they would be reported as belonging to generated code in the application's stack
 trace.
 
 The complete type hierarchy for these views corresponds to the
-{{<godoc "github.com/dave/dst" "Node">}} implementations, which provide the
+{{<godoc import-path="github.com/dave/dst" package="dst" name="Node">}} implementations, which provide the
 underlying AST model. Node properties can be accessed using their usual name
-from {{<godoc "github.com/dave/dst">}}.
+from {{<godoc import-path="github.com/dave/dst">}}.
 
 #### The `.DirectiveArgs` method
 

--- a/docs/content/contributing/aspects/guidelines.md
+++ b/docs/content/contributing/aspects/guidelines.md
@@ -45,7 +45,7 @@ some examples follow:
 - Don't `panic` unless you **absolutely** must, and even then, probably still
   don't `panic`;
 - Don't alter error values unless you are certain customers are not able to
-  check them using {{<godoc "errors" "Is">}} (but it's okay to return other
+  check them using {{<godoc import-path="errors" name="Is">}} (but it's okay to return other
   errors when an instrumentation feature demands it);
 
 ## Reduce, Reuse, Recycle

--- a/docs/content/docs/custom-trace.md
+++ b/docs/content/docs/custom-trace.md
@@ -121,23 +121,25 @@ precedence list (first non-empty is selected):
 
 ### Trace Context Propagation
 
-If the annotated function accepts a {{<godoc "context" "Context" >}} argument,
-that context will be used for trace propagation. Otherwise, if the function
-accepts a {{<godoc "net/http" "Request" "*">}} argument, the request's context
-will be used for trace propagation.
+If the annotated function accepts a {{<godoc import-path="context" name="Context" >}}
+argument, that context will be used for trace propagation. Otherwise, if the
+function accepts a {{<godoc import-path="net/http" package="http" name="Request" prefix="*">}}
+argument, the request's context will be used for trace propagation.
 
 Functions that accept neither solely rely on _goroutine local storage_ for trace
 propagation. This means that traces may be split on _goroutine_ boundaries
-unless a {{<godoc "context" "Context" >}} or {{<godoc "net/http" "Request" "*">}}
+unless a {{<godoc import-path="context" name="Context" >}} or
+{{<godoc import-path="net/http" package="http" name="Request" prefix="*">}}
 value carying trace context is passed across.
 
-Trace context carrying {{<godoc "context" "Context" >}} values are those that:
+Trace context carrying {{<godoc import-path="context" name="Context" >}} values
+are those that:
 
 - have been received by a `//dd:span` annotated function, as instrumentation
   will create a new trace root span if if did not already carry trace context
 - are returned by:
-  - {{<godoc "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" "StartSpanFromContext" >}}
-  - {{<godoc "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" "ContextWithSpan" >}}
+  - {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" package="tracer" name="StartSpanFromContext" >}}
+  - {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" package="tracer" name="ContextWithSpan" >}}
 
 ```go
 package demo
@@ -160,10 +162,11 @@ func callee(ctx context.Context, done chan<- struct{}) {
 
 ### Manual Instrumentation
 
-The {{<godoc "gopkg.in/DataDog/dd-trace-go.v1">}} library can be used to
-manually instrument sections of your code even when building with `orchestrion`.
+The {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1">}} library can be
+used to manually instrument sections of your code even when building with
+`orchestrion`.
 
-You can use APIs such as {{<godoc "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" "StartSpanFromContext" >}}
+You can use APIs such as {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" package="tracer" name="StartSpanFromContext" >}}
 to create spans in any section of your code. This can be useful to delimit a
 specific section of your code with a span without having to refactor it in a
 separate function (which would allow the use of the `//dd:span` directive), or
@@ -171,9 +174,9 @@ when you need to customize the span more than the `//dd:span` directive allows.
 
 {{<callout emoji="⚠️">}}
 You may also use integrations from the packages within
-{{<godoc "gopkg.in/DataDog/dd-trace-go.v1/contrib">}}, although this may result
-in duplicated trace spans if `orchestrion` supports automatic instrumentation of
-the same integration.
+{{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/contrib">}}, although this
+may result in duplicated trace spans if `orchestrion` supports automatic
+instrumentation of the same integration.
 
 This can be useful to instrument calls that `orchestrion` does not yet support.
 If you directly use integrations, we encourage you carefully review the

--- a/docs/content/docs/features.md
+++ b/docs/content/docs/features.md
@@ -17,8 +17,8 @@ are available in the [documentation][env-var-doc].
 
 If the `main` function is annotated with the `//dd:ignore` directive, the tracer
 will not be started automatically, and you are responsible for calling
-{{<godoc "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" "Start" >}} with your
-preferred configuration options.
+{{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer" package="tracer" name="Start" >}}
+with your preferred configuration options.
 
 [env-var-doc]: https://docs.datadoghq.com/tracing/trace_collection/library_config/go/#unified-service-tagging
 
@@ -31,10 +31,10 @@ to `1` or `true`. If profiling is enabled via the
 set to `auto`.
 
 When enabled, the continuous profiler will activate the following profiles:
-- {{<godoc "gopkg.in/DataDog/dd-trace-go.v1/profiler" "CPUProfile" >}}
-- {{<godoc "gopkg.in/DataDog/dd-trace-go.v1/profiler" "HeapProfile" >}}
-- {{<godoc "gopkg.in/DataDog/dd-trace-go.v1/profiler" "GoroutineProfile" >}}
-- {{<godoc "gopkg.in/DataDog/dd-trace-go.v1/profiler" "MutexProfile" >}}
+- {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/profiler" package="profiler" name="CPUProfile" >}}
+- {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/profiler" package="profiler" name="HeapProfile" >}}
+- {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/profiler" package="profiler" name="GoroutineProfile" >}}
+- {{<godoc import-path="gopkg.in/DataDog/dd-trace-go.v1/profiler" package="profiler" name="MutexProfile" >}}
 
 [dd-adm-controller]: https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=datadogoperator
 


### PR DESCRIPTION
Incorrect use of the godoc shortcode resulted in blank links being rendered.