### PR TITLE
chore: standardize on `errors.Is(err, fs.ErrNotExist)`

### DIFF
--- a/internal/pin/gomod.go
+++ b/internal/pin/gomod.go
@@ -8,8 +8,10 @@ package pin
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -105,7 +107,7 @@ func runGoModEdit(modfile string, edits ...goModEdit) error {
 
 	vendorDir := filepath.Join(modfile, "..", "vendor")
 	stat, err := os.Stat(vendorDir)
-	if os.IsNotExist(err) || (err == nil && !stat.IsDir()) {
+	if errors.Is(err, fs.ErrNotExist) || (err == nil && !stat.IsDir()) {
 		//  No `vendor` directory, nothing to do...
 		return nil
 	}

--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -13,6 +13,7 @@ import (
 	"go/token"
 	goversion "go/version"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -256,7 +257,7 @@ func pruneImports(importSet *importSet, opts Options) (bool, error) {
 		}
 		integrationsFile := filepath.Join(someFile, "..", orchestrionDotYML)
 		if _, err := os.Stat(integrationsFile); err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				pruned = pruneImport(importSet, pkg.PkgPath, "there is no "+orchestrionDotYML+" file in this package", opts) || pruned
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
@@ -122,7 +123,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			if err := os.MkdirAll(profilePath, 0775); err != nil && !os.IsExist(err) {
+			if err := os.MkdirAll(profilePath, 0775); err != nil && !errors.Is(err, fs.ErrExist) {
 				return err
 			}
 			if err := os.Setenv(envVarOrchestrionProfilePath, profilePath); err != nil {


### PR DESCRIPTION
The documentation for `os.IsNotExist` states:

> This function predates [errors.Is](https://pkg.go.dev/errors#Is). It only supports errors returned by the os package. New code should use `errors.Is(err, fs.ErrNotExist)`.