### PR TITLE
chore: use t.Cleanup() for integration tests cleanup

### DIFF
--- a/_integration-tests/tests/99designs.gqlgen/gqlgen.go
+++ b/_integration-tests/tests/99designs.gqlgen/gqlgen.go
@@ -58,8 +58,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	}, resp)
 }
 
-func (*TestCase) Teardown(*testing.T) {}
-
 func (*TestCase) ExpectedTraces() trace.Traces {
 	return trace.Traces{
 		{

--- a/_integration-tests/tests/aws.v1/aws.go
+++ b/_integration-tests/tests/aws.v1/aws.go
@@ -8,10 +8,8 @@
 package awsv1
 
 import (
-	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"datadoghq.dev/orchestrion/_integration-tests/utils"
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
@@ -45,12 +43,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	ddb := dynamodb.New(session.Must(session.NewSession(tc.cfg)))
 	_, err := ddb.ListTables(nil)
 	require.NoError(t, err)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	require.NoError(t, tc.server.Terminate(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/aws.v2/base.go
+++ b/_integration-tests/tests/aws.v2/base.go
@@ -34,12 +34,6 @@ func (b *base) setup(t *testing.T) {
 	b.server, b.host, b.port = utils.StartDynamoDBTestContainer(t)
 }
 
-func (b *base) teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	require.NoError(t, b.server.Terminate(ctx))
-}
-
 func (b *base) run(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()

--- a/_integration-tests/tests/aws.v2/load_default_config.go
+++ b/_integration-tests/tests/aws.v2/load_default_config.go
@@ -39,10 +39,6 @@ func (tc *TestCaseLoadDefaultConfig) Run(t *testing.T) {
 	tc.base.run(t)
 }
 
-func (tc *TestCaseLoadDefaultConfig) Teardown(t *testing.T) {
-	tc.base.teardown(t)
-}
-
 func (tc *TestCaseLoadDefaultConfig) ExpectedTraces() trace.Traces {
 	return tc.base.expectedTraces()
 }

--- a/_integration-tests/tests/aws.v2/new_config.go
+++ b/_integration-tests/tests/aws.v2/new_config.go
@@ -34,10 +34,6 @@ func (tc *TestCaseNewConfig) Run(t *testing.T) {
 	tc.base.run(t)
 }
 
-func (tc *TestCaseNewConfig) Teardown(t *testing.T) {
-	tc.base.teardown(t)
-}
-
 func (tc *TestCaseNewConfig) ExpectedTraces() trace.Traces {
 	return tc.base.expectedTraces()
 }

--- a/_integration-tests/tests/aws.v2/struct_literal.go
+++ b/_integration-tests/tests/aws.v2/struct_literal.go
@@ -34,10 +34,6 @@ func (tc *TestCaseStructLiteral) Run(t *testing.T) {
 	tc.base.run(t)
 }
 
-func (tc *TestCaseStructLiteral) Teardown(t *testing.T) {
-	tc.base.teardown(t)
-}
-
 func (tc *TestCaseStructLiteral) ExpectedTraces() trace.Traces {
 	return tc.base.expectedTraces()
 }

--- a/_integration-tests/tests/aws.v2/struct_literal_ptr.go
+++ b/_integration-tests/tests/aws.v2/struct_literal_ptr.go
@@ -35,10 +35,6 @@ func (tc *TestCaseStructLiteralPtr) Run(t *testing.T) {
 	tc.base.run(t)
 }
 
-func (tc *TestCaseStructLiteralPtr) Teardown(t *testing.T) {
-	tc.base.teardown(t)
-}
-
 func (tc *TestCaseStructLiteralPtr) ExpectedTraces() trace.Traces {
 	return tc.base.expectedTraces()
 }

--- a/_integration-tests/tests/chi.v5/chi.go
+++ b/_integration-tests/tests/chi.v5/chi.go
@@ -39,19 +39,17 @@ func (tc *TestCase) Setup(t *testing.T) {
 	})
 
 	go func() { assert.ErrorIs(t, tc.Server.ListenAndServe(), http.ErrServerClosed) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		assert.NoError(t, tc.Server.Shutdown(ctx))
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/", tc.Server.Addr))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.Server.Shutdown(ctx))
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/confluent-kafka-go.v1/kafka.go
+++ b/_integration-tests/tests/confluent-kafka-go.v1/kafka.go
@@ -8,7 +8,6 @@
 package kafka
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -102,13 +101,6 @@ func (tc *TestCase) consumeMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "key2", string(m.Key))
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.container.Terminate(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/confluent-kafka-go.v1/skip_windows.go
+++ b/_integration-tests/tests/confluent-kafka-go.v1/skip_windows.go
@@ -20,7 +20,6 @@ func (skip) Setup(t *testing.T) {
 }
 
 func (skip) Run(t *testing.T)             {}
-func (skip) Teardown(t *testing.T)        {}
 func (skip) ExpectedTraces() trace.Traces { return nil }
 
 type TestCase = skip

--- a/_integration-tests/tests/confluent-kafka-go.v2/kafka.go
+++ b/_integration-tests/tests/confluent-kafka-go.v2/kafka.go
@@ -8,7 +8,6 @@
 package kafka
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -102,13 +101,6 @@ func (tc *TestCase) consumeMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "key2", string(m.Key))
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.container.Terminate(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/confluent-kafka-go.v2/skip_windows.go
+++ b/_integration-tests/tests/confluent-kafka-go.v2/skip_windows.go
@@ -20,7 +20,6 @@ func (skip) Setup(t *testing.T) {
 }
 
 func (skip) Run(t *testing.T)             {}
-func (skip) Teardown(t *testing.T)        {}
 func (skip) ExpectedTraces() trace.Traces { return nil }
 
 type TestCase = skip

--- a/_integration-tests/tests/dd-span/ddspan.go
+++ b/_integration-tests/tests/dd-span/ddspan.go
@@ -30,8 +30,6 @@ func (*TestCase) Run(t *testing.T) {
 	_, _ = spanFromHTTPRequest(req)
 }
 
-func (*TestCase) Teardown(*testing.T) {}
-
 //dd:span foo:bar
 func spanFromHTTPRequest(*http.Request) (string, error) {
 	return tagSpecificSpan()

--- a/_integration-tests/tests/echo.v4/echo.go
+++ b/_integration-tests/tests/echo.v4/echo.go
@@ -36,19 +36,17 @@ func (tc *TestCase) Setup(t *testing.T) {
 	tc.addr = "127.0.0.1:" + utils.GetFreePort(t)
 
 	go func() { assert.ErrorIs(t, tc.Echo.Start(tc.addr), http.ErrServerClosed) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, tc.Echo.Shutdown(ctx))
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
 	resp, err := http.Get("http://" + tc.addr + "/ping")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.Echo.Shutdown(ctx))
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/fiber.v2/fiber.go
+++ b/_integration-tests/tests/fiber.v2/fiber.go
@@ -30,16 +30,15 @@ func (tc *TestCase) Setup(t *testing.T) {
 	tc.addr = "127.0.0.1:" + utils.GetFreePort(t)
 
 	go func() { assert.NoError(t, tc.App.Listen(tc.addr)) }()
+	t.Cleanup(func() {
+		assert.NoError(t, tc.App.ShutdownWithTimeout(time.Second))
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
 	resp, err := http.Get("http://" + tc.addr + "/ping")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	require.NoError(t, tc.App.ShutdownWithTimeout(time.Second))
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/gin/gin.go
+++ b/_integration-tests/tests/gin/gin.go
@@ -36,19 +36,17 @@ func (tc *TestCase) Setup(t *testing.T) {
 	engine.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"message": "pong"}) })
 
 	go func() { assert.ErrorIs(t, tc.Server.ListenAndServe(), http.ErrServerClosed) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		assert.NoError(t, tc.Server.Shutdown(ctx))
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
 	resp, err := http.Get("http://" + tc.Server.Addr + "/ping")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.Server.Shutdown(ctx))
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/go-elasticsearch/base.go
+++ b/_integration-tests/tests/go-elasticsearch/base.go
@@ -18,7 +18,6 @@ import (
 
 	"datadoghq.dev/orchestrion/_integration-tests/utils"
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	testelasticsearch "github.com/testcontainers/testcontainers-go/modules/elasticsearch"
@@ -48,6 +47,7 @@ func (b *base) Setup(t *testing.T, image string, newClient func(addr string, caC
 		testcontainers.WithWaitStrategyAndDeadline(time.Minute, wait.ForLog(`.*("message":\s?"started(\s|")?.*|]\sstarted\n)`).AsRegexp()),
 	)
 	utils.AssertTestContainersError(t, err)
+	utils.RegisterContainerCleanup(t, b.container)
 
 	b.client, err = newClient(b.container.Settings.Address, b.container.Settings.CACert)
 	require.NoError(t, err)
@@ -64,13 +64,6 @@ func (b *base) Run(t *testing.T, doRequest func(t *testing.T, client esClient, b
 	require.NoError(t, err)
 
 	doRequest(t, b.client, bytes.NewReader(data))
-}
-
-func (b *base) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	assert.NoError(t, b.container.Terminate(ctx))
 }
 
 func (*base) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/go-elasticsearch/skip_windows.go
+++ b/_integration-tests/tests/go-elasticsearch/skip_windows.go
@@ -20,7 +20,6 @@ func (skip) Setup(t *testing.T) {
 }
 
 func (skip) Run(t *testing.T)             {}
-func (skip) Teardown(t *testing.T)        {}
 func (skip) ExpectedTraces() trace.Traces { return nil }
 
 type TestCaseV6 = skip

--- a/_integration-tests/tests/go-redis.v0/go-redis.go
+++ b/_integration-tests/tests/go-redis.v0/go-redis.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"datadoghq.dev/orchestrion/_integration-tests/utils"
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
@@ -40,6 +39,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	tc.server = container
 
 	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() {
+		assert.NoError(t, tc.Client.Close())
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
@@ -48,16 +50,6 @@ func (tc *TestCase) Run(t *testing.T) {
 
 	require.NoError(t, tc.Client.WithContext(ctx).Set(tc.key, "test_value", 0).Err())
 	require.NoError(t, tc.Client.WithContext(ctx).Get(tc.key).Err())
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	assert.NoError(t, tc.Client.Close())
-	if tc.server != nil && assert.NoError(t, tc.server.Terminate(ctx)) {
-		tc.server = nil
-	}
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/go-redis.v7/go-redis.go
+++ b/_integration-tests/tests/go-redis.v7/go-redis.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"datadoghq.dev/orchestrion/_integration-tests/utils"
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
@@ -40,6 +39,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	tc.server = container
 
 	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() {
+		assert.NoError(t, tc.Client.Close())
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
@@ -48,16 +50,6 @@ func (tc *TestCase) Run(t *testing.T) {
 
 	require.NoError(t, tc.Client.WithContext(ctx).Set(tc.key, "test_value", 0).Err())
 	require.NoError(t, tc.Client.WithContext(ctx).Get(tc.key).Err())
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	assert.NoError(t, tc.Client.Close())
-	if tc.server != nil && assert.NoError(t, tc.server.Terminate(ctx)) {
-		tc.server = nil
-	}
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/go-redis.v8/go-redis.go
+++ b/_integration-tests/tests/go-redis.v8/go-redis.go
@@ -10,7 +10,6 @@ package goredis
 import (
 	"context"
 	"testing"
-	"time"
 
 	"datadoghq.dev/orchestrion/_integration-tests/utils"
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
@@ -39,6 +38,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	tc.server = container
 
 	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() {
+		assert.NoError(t, tc.Client.Close())
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
@@ -47,14 +49,6 @@ func (tc *TestCase) Run(t *testing.T) {
 
 	require.NoError(t, tc.Client.Set(ctx, "test_key", "test_value", 0).Err())
 	require.NoError(t, tc.Client.Get(ctx, "test_key").Err())
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	assert.NoError(t, tc.Client.Close())
-	assert.NoError(t, tc.server.Terminate(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/go-redis.v9/go-redis.go
+++ b/_integration-tests/tests/go-redis.v9/go-redis.go
@@ -40,6 +40,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	tc.server = container
 
 	tc.Client = redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() {
+		assert.NoError(t, tc.Client.Close())
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {

--- a/_integration-tests/tests/gocql/base.go
+++ b/_integration-tests/tests/gocql/base.go
@@ -42,6 +42,7 @@ func (b *base) setup(t *testing.T) {
 		utils.WithTestLogConsumer(t),
 	)
 	utils.AssertTestContainersError(t, err)
+	utils.RegisterContainerCleanup(t, b.container)
 
 	b.hostPort, err = b.container.ConnectionHost(ctx)
 	require.NoError(t, err)

--- a/_integration-tests/tests/gocql/new_cluster.go
+++ b/_integration-tests/tests/gocql/new_cluster.go
@@ -26,14 +26,13 @@ func (tc *TestCaseNewCluster) Setup(t *testing.T) {
 	cluster := gocql.NewCluster(tc.hostPort)
 	tc.session, err = cluster.CreateSession()
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		tc.session.Close()
+	})
 }
 
 func (tc *TestCaseNewCluster) Run(t *testing.T) {
 	tc.base.run(t)
-}
-
-func (tc *TestCaseNewCluster) Teardown(t *testing.T) {
-	tc.base.teardown(t)
 }
 
 func (tc *TestCaseNewCluster) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/gocql/struct_literal.go
+++ b/_integration-tests/tests/gocql/struct_literal.go
@@ -43,14 +43,13 @@ func (tc *TestCaseStructLiteral) Setup(t *testing.T) {
 	}
 	tc.session, err = cluster.CreateSession()
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		tc.session.Close()
+	})
 }
 
 func (tc *TestCaseStructLiteral) Run(t *testing.T) {
 	tc.base.run(t)
-}
-
-func (tc *TestCaseStructLiteral) Teardown(t *testing.T) {
-	tc.base.teardown(t)
 }
 
 func (tc *TestCaseStructLiteral) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/gocql/struct_literal_ptr.go
+++ b/_integration-tests/tests/gocql/struct_literal_ptr.go
@@ -43,14 +43,13 @@ func (tc *TestCaseStructLiteralPtr) Setup(t *testing.T) {
 	}
 	tc.session, err = cluster.CreateSession()
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		tc.session.Close()
+	})
 }
 
 func (tc *TestCaseStructLiteralPtr) Run(t *testing.T) {
 	tc.base.run(t)
-}
-
-func (tc *TestCaseStructLiteralPtr) Teardown(t *testing.T) {
-	tc.base.teardown(t)
 }
 
 func (tc *TestCaseStructLiteralPtr) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/gorm.jinzhu/gorm.go
+++ b/_integration-tests/tests/gorm.jinzhu/gorm.go
@@ -28,6 +28,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	var err error
 	tc.DB, err = gorm.Open("sqlite3", "file::memory:")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tc.DB.Close())
+	})
 
 	require.NoError(t, tc.DB.AutoMigrate(&Note{}).Error)
 	for _, note := range []*Note{
@@ -48,10 +51,6 @@ func (tc *TestCase) Run(t *testing.T) {
 
 	var note Note
 	require.NoError(t, gormtrace.WithContext(ctx, tc.DB).Where("user_id = ?", 2).First(&note).Error)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	assert.NoError(t, tc.DB.Close())
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/gorm/gorm.go
+++ b/_integration-tests/tests/gorm/gorm.go
@@ -48,8 +48,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	require.NoError(t, tc.DB.WithContext(ctx).Where("user_id = ?", 2).First(&note).Error)
 }
 
-func (*TestCase) Teardown(*testing.T) {}
-
 func (*TestCase) ExpectedTraces() trace.Traces {
 	return trace.Traces{
 		{

--- a/_integration-tests/tests/graph-gophers/graphql-go.go
+++ b/_integration-tests/tests/graph-gophers/graphql-go.go
@@ -45,6 +45,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	require.NoError(t, err)
 
 	tc.server = httptest.NewServer(&relay.Handler{Schema: schema})
+	t.Cleanup(func() {
+		tc.server.Close()
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
@@ -65,10 +68,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(body, &res))
 	require.Equal(t, "Hello, world!", res.Data.Hello)
-}
-
-func (tc *TestCase) Teardown(*testing.T) {
-	tc.server.Close()
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/graphql-go/graphql.go
+++ b/_integration-tests/tests/graphql-go/graphql.go
@@ -44,6 +44,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	require.NoError(t, err)
 
 	tc.server = httptest.NewServer(handler.New(&handler.Config{Schema: &schema}))
+	t.Cleanup(func() {
+		tc.server.Close()
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
@@ -64,10 +67,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(body, &res))
 	require.Equal(t, "Hello, world!", res.Data.Hello)
-}
-
-func (tc *TestCase) Teardown(*testing.T) {
-	tc.server.Close()
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/grpc/grpc.go
+++ b/_integration-tests/tests/grpc/grpc.go
@@ -35,6 +35,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	helloworld.RegisterGreeterServer(tc.Server, &server{})
 
 	go func() { assert.NoError(t, tc.Server.Serve(lis)) }()
+	t.Cleanup(func() {
+		tc.Server.GracefulStop()
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
@@ -49,10 +52,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	resp, err := client.SayHello(ctx, &helloworld.HelloRequest{Name: "rob"})
 	require.NoError(t, err)
 	require.Equal(t, "Hello rob", resp.GetMessage())
-}
-
-func (tc *TestCase) Teardown(*testing.T) {
-	tc.Server.GracefulStop()
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/ibm_sarama/ibm_sarama.go
+++ b/_integration-tests/tests/ibm_sarama/ibm_sarama.go
@@ -8,7 +8,6 @@
 package ibm_sarama
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -113,13 +112,6 @@ func consumeMessage(t *testing.T, addrs []string, cfg *sarama.Config) {
 func (tc *TestCase) Run(t *testing.T) {
 	produceMessage(t, tc.addrs, tc.cfg)
 	consumeMessage(t, tc.addrs, tc.cfg)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.server.Terminate(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/julienschmidt_httprouter/julienschmidt_httprouter.go
+++ b/_integration-tests/tests/julienschmidt_httprouter/julienschmidt_httprouter.go
@@ -42,18 +42,17 @@ func (tc *TestCase) Setup(t *testing.T) {
 		WriteTimeout: 10 * time.Second,
 	}
 	go func() { assert.ErrorIs(t, tc.Server.ListenAndServe(), http.ErrServerClosed) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		assert.NoError(t, tc.Server.Shutdown(ctx))
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/ping", tc.Server.Addr))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	require.NoError(t, tc.Server.Shutdown(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/k8s_client_go/base.go
+++ b/_integration-tests/tests/k8s_client_go/base.go
@@ -33,13 +33,12 @@ func (b *base) setup(t *testing.T) {
 	b.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("Hello World"))
 	}))
+	t.Cleanup(func() {
+		b.server.Close()
+	})
 	tsURL, err := url.Parse(b.server.URL)
 	require.NoError(t, err)
 	b.serverURL = tsURL
-}
-
-func (b *base) teardown(*testing.T) {
-	b.server.Close()
 }
 
 func (b *base) run(t *testing.T) {

--- a/_integration-tests/tests/k8s_client_go/new_cfg_func.go
+++ b/_integration-tests/tests/k8s_client_go/new_cfg_func.go
@@ -39,10 +39,6 @@ func (tc *TestCaseNewCfgFunc) Run(t *testing.T) {
 	tc.base.run(t)
 }
 
-func (tc *TestCaseNewCfgFunc) Teardown(t *testing.T) {
-	tc.base.teardown(t)
-}
-
 func (tc *TestCaseNewCfgFunc) ExpectedTraces() trace.Traces {
 	return tc.base.expectedTraces()
 }

--- a/_integration-tests/tests/k8s_client_go/struct_literal_with_param.go
+++ b/_integration-tests/tests/k8s_client_go/struct_literal_with_param.go
@@ -44,10 +44,6 @@ func (tc *TestCaseStructLiteralWithParam) Run(t *testing.T) {
 	assert.True(t, tc.wtCalled, "the original WrapTransport function was not called")
 }
 
-func (tc *TestCaseStructLiteralWithParam) Teardown(t *testing.T) {
-	tc.base.teardown(t)
-}
-
 func (tc *TestCaseStructLiteralWithParam) ExpectedTraces() trace.Traces {
 	return tc.base.expectedTraces()
 }

--- a/_integration-tests/tests/k8s_client_go/struct_literal_without_param.go
+++ b/_integration-tests/tests/k8s_client_go/struct_literal_without_param.go
@@ -37,10 +37,6 @@ func (tc *TestCaseStructLiteralWithoutParam) Run(t *testing.T) {
 	tc.base.run(t)
 }
 
-func (tc *TestCaseStructLiteralWithoutParam) Teardown(t *testing.T) {
-	tc.base.teardown(t)
-}
-
 func (tc *TestCaseStructLiteralWithoutParam) ExpectedTraces() trace.Traces {
 	return tc.base.expectedTraces()
 }

--- a/_integration-tests/tests/logrus/global_logger.go
+++ b/_integration-tests/tests/logrus/global_logger.go
@@ -31,8 +31,6 @@ func (tc *TestCaseGlobalLogger) Run(t *testing.T) {
 	runTest(t, tc.logs, tc.Log)
 }
 
-func (*TestCaseGlobalLogger) Teardown(*testing.T) {}
-
 func (*TestCaseGlobalLogger) ExpectedTraces() trace.Traces {
 	return expectedTraces()
 }

--- a/_integration-tests/tests/logrus/new_logger.go
+++ b/_integration-tests/tests/logrus/new_logger.go
@@ -33,8 +33,6 @@ func (tc *TestCaseNewLogger) Run(t *testing.T) {
 	runTest(t, tc.logs, tc.Log)
 }
 
-func (*TestCaseNewLogger) Teardown(*testing.T) {}
-
 func (*TestCaseNewLogger) ExpectedTraces() trace.Traces {
 	return expectedTraces()
 }

--- a/_integration-tests/tests/logrus/struct_literal_ptr.go
+++ b/_integration-tests/tests/logrus/struct_literal_ptr.go
@@ -41,8 +41,6 @@ func (tc *TestCaseStructLiteralPtr) Run(t *testing.T) {
 	runTest(t, tc.logs, tc.Log)
 }
 
-func (*TestCaseStructLiteralPtr) Teardown(*testing.T) {}
-
 func (*TestCaseStructLiteralPtr) ExpectedTraces() trace.Traces {
 	return expectedTraces()
 }

--- a/_integration-tests/tests/logrus/struct_literal_val.go
+++ b/_integration-tests/tests/logrus/struct_literal_val.go
@@ -41,8 +41,6 @@ func (tc *TestCaseStructLiteralVal) Run(t *testing.T) {
 	runTest(t, tc.logs, tc.Log)
 }
 
-func (*TestCaseStructLiteralVal) Teardown(*testing.T) {}
-
 func (*TestCaseStructLiteralVal) ExpectedTraces() trace.Traces {
 	return expectedTraces()
 }

--- a/_integration-tests/tests/mux/mux.go
+++ b/_integration-tests/tests/mux/mux.go
@@ -40,19 +40,17 @@ func (tc *TestCase) Setup(t *testing.T) {
 	}).Methods("GET")
 
 	go func() { assert.ErrorIs(t, tc.Server.ListenAndServe(), http.ErrServerClosed) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		assert.NoError(t, tc.Server.Shutdown(ctx))
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://%s/ping", tc.Server.Addr))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.Server.Shutdown(ctx))
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/redigo/redigo.go
+++ b/_integration-tests/tests/redigo/redigo.go
@@ -55,6 +55,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 			return err
 		},
 	}
+	t.Cleanup(func() {
+		assert.NoError(t, tc.Pool.Close())
+	})
 }
 
 func (tc *TestCase) Run(t *testing.T) {
@@ -71,16 +74,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	res, err := client.Do("GET", tc.key, ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, res)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	assert.NoError(t, tc.Pool.Close())
-	if tc.server != nil && assert.NoError(t, tc.server.Terminate(ctx)) {
-		tc.server = nil
-	}
 }
 
 func (tc *TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/segmentio_kafka.v0/segmentio_kafka.go
+++ b/_integration-tests/tests/segmentio_kafka.v0/segmentio_kafka.go
@@ -130,12 +130,6 @@ func (tc *TestCase) consume(t *testing.T) {
 	require.NoError(t, readerB.Close())
 }
 
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	require.NoError(t, tc.kafka.Terminate(ctx))
-}
-
 func (*TestCase) ExpectedTraces() trace.Traces {
 	return trace.Traces{
 		{

--- a/_integration-tests/tests/shopify_sarama/shopify_sarama.go
+++ b/_integration-tests/tests/shopify_sarama/shopify_sarama.go
@@ -8,7 +8,6 @@
 package shopify_sarama
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -89,13 +88,6 @@ func consumeMessage(t *testing.T, addrs []string, cfg *sarama.Config) {
 func (tc *TestCase) Run(t *testing.T) {
 	produceMessage(t, tc.addrs, tc.cfg)
 	consumeMessage(t, tc.addrs, tc.cfg)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.server.Terminate(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/slog/slog.go
+++ b/_integration-tests/tests/slog/slog.go
@@ -70,6 +70,4 @@ func (tc *TestCase) Run(t *testing.T) {
 	}
 }
 
-func (*TestCase) Teardown(*testing.T) {}
-
 func (*TestCase) ExpectedTraces() trace.Traces { return trace.Traces{} }

--- a/_integration-tests/tests/sql/sql.go
+++ b/_integration-tests/tests/sql/sql.go
@@ -14,6 +14,7 @@ import (
 
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
 	_ "github.com/mattn/go-sqlite3" // Auto-register sqlite3 driver
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,6 +26,9 @@ func (tc *TestCase) Setup(t *testing.T) {
 	var err error
 	tc.DB, err = sql.Open("sqlite3", "file::memory:")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, tc.DB.Close())
+	})
 
 	_, err = tc.DB.ExecContext(context.Background(),
 		`CREATE TABLE IF NOT EXISTS notes (
@@ -52,10 +56,6 @@ func (tc *TestCase) Run(t *testing.T) {
 		`INSERT INTO notes (userid, content, created) VALUES (?, ?, datetime('now'));`,
 		1337, "This is Elite!")
 	require.NoError(t, err)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	require.NoError(t, tc.DB.Close())
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/twirp/twirp.go
+++ b/_integration-tests/tests/twirp/twirp.go
@@ -39,6 +39,12 @@ func (tc *TestCase) Setup(t *testing.T) {
 	go func() {
 		assert.ErrorIs(t, tc.srv.Serve(lis), http.ErrServerClosed)
 	}()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		assert.NoError(t, tc.srv.Shutdown(ctx))
+	})
+
 	tc.client = example.NewHaberdasherJSONClient(tc.addr, http.DefaultClient)
 }
 
@@ -46,13 +52,6 @@ func (tc *TestCase) Run(t *testing.T) {
 	ctx := context.Background()
 	_, err := tc.client.MakeHat(ctx, &example.Size{Inches: 6})
 	require.NoError(t, err)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.srv.Shutdown(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/tests/vault/vault.go
+++ b/_integration-tests/tests/vault/vault.go
@@ -9,6 +9,8 @@ package vault
 
 import (
 	"context"
+	"testing"
+
 	"datadoghq.dev/orchestrion/_integration-tests/utils"
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
 	"github.com/hashicorp/vault/api"
@@ -16,7 +18,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	testvault "github.com/testcontainers/testcontainers-go/modules/vault"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"testing"
 )
 
 type TestCase struct {

--- a/_integration-tests/tests/vault/vault.go
+++ b/_integration-tests/tests/vault/vault.go
@@ -9,9 +9,6 @@ package vault
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"datadoghq.dev/orchestrion/_integration-tests/utils"
 	"datadoghq.dev/orchestrion/_integration-tests/validator/trace"
 	"github.com/hashicorp/vault/api"
@@ -19,6 +16,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	testvault "github.com/testcontainers/testcontainers-go/modules/vault"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"testing"
 )
 
 type TestCase struct {
@@ -39,6 +37,7 @@ func (tc *TestCase) Setup(t *testing.T) {
 		testvault.WithToken("root"),
 	)
 	utils.AssertTestContainersError(t, err)
+	utils.RegisterContainerCleanup(t, tc.server)
 
 	addr, err := tc.server.HttpHostAddress(ctx)
 	if err != nil {
@@ -62,13 +61,6 @@ func (tc *TestCase) Run(t *testing.T) {
 
 	_, err := tc.Logical().ReadWithContext(ctx, "secret/key")
 	require.NoError(t, err)
-}
-
-func (tc *TestCase) Teardown(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	require.NoError(t, tc.server.Terminate(ctx))
 }
 
 func (*TestCase) ExpectedTraces() trace.Traces {

--- a/_integration-tests/utils/suite.go
+++ b/_integration-tests/utils/suite.go
@@ -37,12 +37,6 @@ type TestCase interface {
 	// outstanding spans are flushed to the agent.
 	Run(*testing.T)
 
-	// Teardown runs if [TestCase.Setup] was executed successfully and did not
-	// call [testing.T.SkipNow]. This can be used to clean up any resources
-	// created during [TestCase.Setup], such as stopping services or deleting test
-	// data.
-	Teardown(*testing.T)
-
 	// ExpectedTraces returns a trace.Traces object describing all traces expected
 	// to be produced by the [TestCase.Run] function. There should be one entry
 	// per trace root span expected to be produced. Every item in the returned
@@ -61,11 +55,6 @@ func RunTest(t *testing.T, tc TestCase) {
 
 	t.Log("Running setup")
 	tc.Setup(t)
-
-	defer func() {
-		t.Log("Running teardown")
-		tc.Teardown(t)
-	}()
 
 	sess, err := mockAgent.NewSession(t)
 	require.NoError(t, err)

--- a/_integration-tests/utils/testcontainers.go
+++ b/_integration-tests/utils/testcontainers.go
@@ -8,7 +8,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"os"
 	"runtime"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"

--- a/_integration-tests/utils/testcontainers.go
+++ b/_integration-tests/utils/testcontainers.go
@@ -8,10 +8,12 @@ package utils
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"net/url"
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
@@ -45,16 +47,17 @@ func StartDynamoDBTestContainer(t *testing.T) (testcontainers.Container, string,
 	}
 
 	ctx := context.Background()
-	server, err := testcontainers.GenericContainer(ctx, req)
+	container, err := testcontainers.GenericContainer(ctx, req)
 	AssertTestContainersError(t, err)
+	RegisterContainerCleanup(t, container)
 
-	mappedPort, err := server.MappedPort(ctx, nat.Port(exposedPort))
+	mappedPort, err := container.MappedPort(ctx, nat.Port(exposedPort))
 	require.NoError(t, err)
 
-	host, err := server.Host(ctx)
+	host, err := container.Host(ctx)
 	require.NoError(t, err)
 
-	return server, host, mappedPort.Port()
+	return container, host, mappedPort.Port()
 }
 
 // StartKafkaTestContainer starts a new Kafka test container and returns the connection string.
@@ -77,6 +80,7 @@ func StartKafkaTestContainer(t *testing.T) (*kafka.KafkaContainer, string) {
 		),
 	)
 	AssertTestContainersError(t, err)
+	RegisterContainerCleanup(t, container)
 
 	mappedPort, err := container.MappedPort(ctx, nat.Port(exposedPort))
 	require.NoError(t, err)
@@ -111,6 +115,7 @@ func StartRedisTestContainer(t *testing.T) (*redis.RedisContainer, string) {
 		),
 	)
 	AssertTestContainersError(t, err)
+	RegisterContainerCleanup(t, container)
 
 	connStr, err := container.ConnectionString(ctx)
 	require.NoError(t, err)
@@ -132,6 +137,15 @@ func AssertTestContainersError(t *testing.T, err error) {
 		return
 	}
 	require.NoError(t, err)
+}
+
+// RegisterContainerCleanup registers a function to terminate the provided container to be executed after the test finishes.
+func RegisterContainerCleanup(t *testing.T, container testcontainers.Container) {
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		assert.NoError(t, container.Terminate(ctx))
+	})
 }
 
 // SkipIfProviderIsNotHealthy calls [testcontainers.SkipIfProviderIsNotHealthy] to skip tests of


### PR DESCRIPTION
Use `t.Cleanup` to make sure the cleanup logic is registered right after the resource is created and always gets executed when the test finishes.