### PR TITLE
fix(pin): segfault orchestrion.tool.go is not valid go code

### DIFF
--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -65,6 +65,10 @@ func PinOrchestrion(opts Options) error {
 		dstFile = defaultOrchestrionToolGo()
 	}
 
+	if err != nil {
+		return fmt.Errorf("parsing %q: %w", toolFile, err)
+	}
+
 	updateGoGenerateDirective(opts.NoGenerate, dstFile)
 
 	importSet, err := updateToolFile(dstFile)


### PR DESCRIPTION
Triggered it on top of #406 because it left the `orchestrion.tool.go` file empty. And an empty file is not valid go code...