### PR TITLE
chore: temporarily disable testing on Windows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -277,7 +277,10 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        runs-on: [macos, ubuntu, windows]
+        runs-on:
+          - macos
+          - ubuntu
+          # - windows # Temporarily disabled because excruciatingly slow for no obvious reason.
         go-version: [oldstable, stable]
         build-mode: [DRIVER]
         include:


### PR DESCRIPTION
For some reason the Windows GitHub runners have become EXTREMELY slow as of late.