### PR TITLE
fix: fingerprint mismatch when using `-tags` that affect injected packages

### DIFF
--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -8,6 +8,7 @@ package instrument
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/DataDog/orchestrion/instrument/event"
 
@@ -31,7 +32,7 @@ func Report(ctx context.Context, e event.Event, metadata ...any) context.Context
 		var ok bool
 		span, ok = tracer.SpanFromContext(ctx)
 		if !ok {
-			_, _ = fmt.Printf("Error: Received end/return event but have no corresponding span in the context.\n")
+			_, _ = fmt.Fprintf(os.Stderr, "Error: Received end/return event but have no corresponding span in the context.\n")
 			return ctx
 		}
 		span.Finish()

--- a/internal/binpath/cmd.go
+++ b/internal/binpath/cmd.go
@@ -3,21 +3,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-package cmd
+package binpath
 
 import (
 	"os"
 	"path/filepath"
 )
 
-var orchestrionBinPath string
+var Orchestrion string
 
 func init() {
 	var err error
-	if orchestrionBinPath, err = os.Executable(); err != nil {
-		if orchestrionBinPath, err = filepath.Abs(os.Args[0]); err != nil {
-			orchestrionBinPath = os.Args[0]
+	if Orchestrion, err = os.Executable(); err != nil {
+		if Orchestrion, err = filepath.Abs(os.Args[0]); err != nil {
+			Orchestrion = os.Args[0]
 		}
 	}
-	orchestrionBinPath = filepath.Clean(orchestrionBinPath)
+	Orchestrion = filepath.Clean(Orchestrion)
 }

--- a/internal/cmd/go.go
+++ b/internal/cmd/go.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os/exec"
 
+	"github.com/DataDog/orchestrion/internal/binpath"
 	"github.com/DataDog/orchestrion/internal/goproxy"
 	"github.com/DataDog/orchestrion/internal/pin"
 	"github.com/urfave/cli/v2"
@@ -24,7 +25,7 @@ var (
 		Action: func(c *cli.Context) error {
 			pin.AutoPinOrchestrion()
 
-			if err := goproxy.Run(c.Args().Slice(), goproxy.WithToolexec(orchestrionBinPath, "toolexec")); err != nil {
+			if err := goproxy.Run(c.Args().Slice(), goproxy.WithToolexec(binpath.Orchestrion, "toolexec")); err != nil {
 				var exitErr *exec.ExitError
 				if errors.As(err, &exitErr) {
 					return cli.Exit("", exitErr.ExitCode())

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -40,7 +40,7 @@ var Toolexec = &cli.Command{
 		pin.AutoPinOrchestrion()
 
 		if proxyCmd.ShowVersion() {
-			log.Tracef("Toolexec version command: %q\n", proxyCmd)
+			log.Tracef("Toolexec version command: %#v\n", proxyCmd)
 			fullVersion, err := toolexec.ComputeVersion(proxyCmd)
 			if err != nil {
 				return err
@@ -64,6 +64,11 @@ var Toolexec = &cli.Command{
 		}
 
 		log.Tracef("Toolexec final command:    %q\n", proxyCmd.Args())
-		return proxy.RunCommand(proxyCmd)
+		if err := proxy.RunCommand(proxyCmd); err != nil {
+			// Logging as debug, as the error will likely surface back to the user anyway...
+			log.Debugf("Proxied command failed: %v\n", err)
+			return err
+		}
+		return nil
 	},
 }

--- a/internal/goproxy/proxy.go
+++ b/internal/goproxy/proxy.go
@@ -105,6 +105,7 @@ func Run(goArgs []string, opts ...Option) error {
 					log.Tracef("[JOBSERVER]: %s\n", server.CacheStats.String())
 				}()
 				env = append(env, fmt.Sprintf("%s=%s", client.EnvVarJobserverURL, server.ClientURL()))
+
 				// Set the process' goflags, since we know them already...
 				goflags.SetFlags("", argv[1:])
 			}

--- a/internal/jobserver/client/env.go
+++ b/internal/jobserver/client/env.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/orchestrion/internal/binpath"
 	"github.com/DataDog/orchestrion/internal/filelock"
 	"github.com/DataDog/orchestrion/internal/log"
 )
@@ -62,14 +63,9 @@ func FromEnvironment(workDir string) (*Client, error) {
 	log.Debugf("Connecting to job server rooted in %q\n", workDir)
 	urlFilePath := filepath.Join(workDir, urlFileName)
 
-	bin, err := os.Executable()
-	if err != nil {
-		bin = os.Args[0]
-	}
-
 	// Try to start a server. The server process is idempotent if the `-url-file` flag is used, so we do not check the
 	// command's exit status, because another process might act as our server down the line.
-	cmd := exec.Command(bin, "server", "-inactivity-timeout=15m", fmt.Sprintf("-url-file=%s", urlFilePath))
+	cmd := exec.Command(binpath.Orchestrion, "server", "-inactivity-timeout=15m", fmt.Sprintf("-url-file=%s", urlFilePath))
 	cmd.SysProcAttr = &sysProcAttrDaemon                   // Make sure go doesn't wait for this to exit...
 	cmd.Env = append(os.Environ(), "TOOLEXEC_IMPORTPATH=") // Suppress the TOOLEXEC_IMPORTPATH variable if it's set.
 	cmd.Stdin = nil                                        // Connect to `os.DevNull`

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -137,7 +137,7 @@ func (s *service) resolve(req *ResolveRequest) (ResolveResponse, error) {
 
 		goFlags, err := goflags.Flags()
 		if err != nil {
-			return nil, fmt.Errorf("resolving go build flags: %w", err)
+			log.Warnf("Failed to obtain go build flags: %v\n", err)
 		}
 		goFlags.Trim(
 			"-a",        // Re-building everything here would be VERY expensive, as we'd re-build a lot of stuff multiple times

--- a/internal/jobserver/pkgs/resolve_test.go
+++ b/internal/jobserver/pkgs/resolve_test.go
@@ -100,7 +100,7 @@ func Test(t *testing.T) {
 		resp, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
 			context.Background(),
 			conn,
-			&pkgs.ResolveRequest{BuildFlags: []string{"-definitely-not-a-valid-build=flag"}, Pattern: "definitely.not/a@valid\x01package"},
+			&pkgs.ResolveRequest{Pattern: "definitely.not/a@valid\x01package"},
 		)
 		assert.Nil(t, resp)
 		assert.EqualValues(t, 0, server.CacheStats.Hits())

--- a/internal/jobserver/pkgs/resolve_test.go
+++ b/internal/jobserver/pkgs/resolve_test.go
@@ -29,7 +29,6 @@ func Test(t *testing.T) {
 	goflags.SetFlags(wd, []string{"test"})
 
 	t.Run("Cache", func(t *testing.T) {
-
 		server, err := jobserver.New(nil)
 		require.NoError(t, err)
 		defer server.Shutdown()

--- a/internal/jobserver/pkgs/resolve_test.go
+++ b/internal/jobserver/pkgs/resolve_test.go
@@ -7,10 +7,13 @@ package pkgs_test
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"testing"
 
+	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/jobserver"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
 	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
@@ -19,81 +22,111 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCache(t *testing.T) {
-	server, err := jobserver.New(nil)
+func Test(t *testing.T) {
+	// Force the goflags so we don't get tainted by the `go test` flags!
+	wd, err := os.Getwd()
 	require.NoError(t, err)
-	defer server.Shutdown()
+	goflags.SetFlags(wd, []string{"test"})
 
-	conn, err := server.Connect()
-	require.NoError(t, err)
-	defer conn.Close()
+	t.Run("Cache", func(t *testing.T) {
 
-	env := os.Environ()
+		server, err := jobserver.New(nil)
+		require.NoError(t, err)
+		defer server.Shutdown()
 
-	// First request is expected to always be a cache miss
-	resp, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
-		context.Background(),
-		conn,
-		&pkgs.ResolveRequest{
-			Pattern: "net/http",
-			Env:     env,
-		},
-	)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(resp), 2)
-	require.EqualValues(t, 1, server.CacheStats.Count())
-	require.EqualValues(t, 0, server.CacheStats.Hits())
+		conn, err := server.Connect()
+		require.NoError(t, err)
+		defer conn.Close()
 
-	// Second request is equivalent, and should result in a cache hit. The order
-	// of entries in `env` is also shuffled, which should have no impact on the
-	// cache hitting or missing.
-	rand.Shuffle(len(env), func(i, j int) { env[i], env[j] = env[j], env[i] })
-	resp, err = client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
-		context.Background(),
-		conn,
-		&pkgs.ResolveRequest{
-			Pattern: "net/http",
-			Env:     env, // This was shuffled, so it's not the same as before
-		},
-	)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(resp), 2)
-	require.EqualValues(t, 2, server.CacheStats.Count())
-	require.EqualValues(t, 1, server.CacheStats.Hits())
+		env := os.Environ()
 
-	// Third request is different, should result in a cache miss again
-	resp, err = client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
-		context.Background(),
-		conn,
-		&pkgs.ResolveRequest{
-			Pattern: "os", // Not the same package as before...
-			Env:     env,
-		},
-	)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(resp), 3)
-	require.EqualValues(t, 3, server.CacheStats.Count())
-	require.EqualValues(t, 1, server.CacheStats.Hits())
+		// First request is expected to always be a cache miss
+		resp, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+			context.Background(),
+			conn,
+			&pkgs.ResolveRequest{
+				Pattern: "net/http",
+				Env:     env,
+			},
+		)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp), 2)
+		assert.EqualValues(t, 1, server.CacheStats.Count())
+		assert.EqualValues(t, 0, server.CacheStats.Hits())
+
+		// Second request is equivalent, and should result in a cache hit. The order
+		// of entries in `env` is also shuffled, which should have no impact on the
+		// cache hitting or missing.
+		rand.Shuffle(len(env), func(i, j int) { env[i], env[j] = env[j], env[i] })
+		resp, err = client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+			context.Background(),
+			conn,
+			&pkgs.ResolveRequest{
+				Pattern: "net/http",
+				Env:     env, // This was shuffled, so it's not the same as before
+			},
+		)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp), 2)
+		assert.EqualValues(t, 2, server.CacheStats.Count())
+		assert.EqualValues(t, 1, server.CacheStats.Hits())
+
+		// Third request is different, should result in a cache miss again
+		resp, err = client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+			context.Background(),
+			conn,
+			&pkgs.ResolveRequest{
+				Pattern: "os", // Not the same package as before...
+				Env:     env,
+			},
+		)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp), 3)
+		assert.EqualValues(t, 3, server.CacheStats.Count())
+		assert.EqualValues(t, 1, server.CacheStats.Hits())
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		log.SetLevel(log.LevelTrace)
+		t.Cleanup(func() { log.SetLevel(log.LevelNone) })
+
+		server, err := jobserver.New(nil)
+		require.NoError(t, err)
+		defer server.Shutdown()
+
+		conn, err := server.Connect()
+		require.NoError(t, err)
+		defer conn.Close()
+
+		resp, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+			context.Background(),
+			conn,
+			&pkgs.ResolveRequest{BuildFlags: []string{"-definitely-not-a-valid-build=flag"}, Pattern: "definitely.not/a@valid\x01package"},
+		)
+		assert.Nil(t, resp)
+		assert.EqualValues(t, 0, server.CacheStats.Hits())
+		require.Error(t, err)
+	})
 }
 
-func TestError(t *testing.T) {
-	log.SetLevel(log.LevelTrace)
-	t.Cleanup(func() { log.SetLevel(log.LevelNone) })
+func init() {
+	if len(os.Args) <= 2 || os.Args[1] != "toolexec" {
+		return
+	}
 
-	server, err := jobserver.New(nil)
-	require.NoError(t, err)
-	defer server.Shutdown()
+	// We're invoked with `toolexec` so pretend we're a toolexec proxy...
+	cmd := exec.Command(os.Args[2], os.Args[3:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-	conn, err := server.Connect()
-	require.NoError(t, err)
-	defer conn.Close()
-
-	resp, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
-		context.Background(),
-		conn,
-		&pkgs.ResolveRequest{BuildFlags: []string{"-definitely-not-a-valid-build=flag"}, Pattern: "definitely.not/a@valid\x00package"},
-	)
-	assert.Nil(t, resp)
-	assert.EqualValues(t, 0, server.CacheStats.Hits())
-	require.Error(t, err)
+	if err := cmd.Run(); err != nil {
+		if err, ok := err.(*exec.ExitError); ok {
+			os.Exit(err.ExitCode())
+			return
+		}
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/internal/toolexec/aspect/resolve.go
+++ b/internal/toolexec/aspect/resolve.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
-	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
 	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
 )
@@ -29,15 +29,14 @@ func resolvePackageFiles(importPath string, workDir string) (map[string]string, 
 		return nil, err
 	}
 
-	flags, err := goflags.Flags()
-	if err != nil {
-		return nil, fmt.Errorf("retrieving go command flags: %w", err)
+	req := pkgs.NewResolveRequest(cwd, nil, importPath)
+	if workDir != "" {
+		req.TempDir = filepath.Join(workDir, "__tmp__")
 	}
-
 	archives, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
 		context.Background(),
 		conn,
-		pkgs.NewResolveRequest(cwd, flags.Slice(), importPath),
+		req,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/toolexec/aspect/resolve.go
+++ b/internal/toolexec/aspect/resolve.go
@@ -29,8 +29,10 @@ func resolvePackageFiles(importPath string, workDir string) (map[string]string, 
 		return nil, err
 	}
 
-	req := pkgs.NewResolveRequest(cwd, nil, importPath)
+	req := pkgs.NewResolveRequest(cwd, importPath)
 	if workDir != "" {
+		// Nest the future GOTMPDIR under this $WORK directory, so that builds with `-work` are nested,
+		// and the root work tree contains all child work trees involved in resolutions.
 		req.TempDir = filepath.Join(workDir, "__tmp__")
 	}
 	archives, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](


### PR DESCRIPTION
In certain conditions, using `-tags` that affect injected packages, such as `-tags=appsec` when `CGO_ENABLED=0` results in a fingerprint mismatch at link time, due to the go build flags being incorrectly discovered.

This is fixed by making several changes:
- Changes how the "shared" build flags are set in the job server's `pkgs.Resolve` operation, so that they are resolved during execution, instead of when creating the request; ensuring the pre-set flags are used in cases where "driver mode" is used;
- Actively parse `-a` and `-toolexec` from go process args, so we explicitly prevent them from being forwarded (`-a` in particular causes builds to be A LOT slower due to re-building many injected packages over and over again);
- Adds trace logging here and there to make this type of issues a little easier to debug in the future (essentially persisted the debugging logs I've added when investigating this issue),
- Set `GOTMPDIR` when building packages in `pkgs.Resolve` so that the downstream builds are easy to find, and are organized in a way that matches the original build's process hierarchy;
- The build ID for the version now also gets the original build flags, as they may affect what files get compiled or not (which in turns will affect the content checksum).