### PR TITLE
release: v1.0.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,4 +6,4 @@
 package version
 
 // Tag specifies the current release tag. It needs to be manually updated.
-const Tag = "v1.0.0"
+const Tag = "v1.0.1"


### PR DESCRIPTION
Includes a bug fix for an occasional `fingerprint mismatch` during `link`.