### PR TITLE
feat: support auto-instrumentation when `net/http.DefaultServeMux` is used implicitly

### DIFF
--- a/internal/injector/builtin/yaml/stdlib/net-http.server.yml
+++ b/internal/injector/builtin/yaml/stdlib/net-http.server.yml
@@ -27,6 +27,8 @@ aspects:
       - prepend-statements:
           template: |-
             {{- $srv := .Function.Receiver -}}
-            if {{ $srv }}.Handler != nil {
+            if {{ $srv }}.Handler == nil {
+              {{ $srv }}.Handler = __dd_orchestrion_instrument_WrapHandler(DefaultServeMux)
+            } else {
               {{ $srv }}.Handler = __dd_orchestrion_instrument_WrapHandler({{ $srv }}.Handler)
             }


### PR DESCRIPTION
### Motivation

`orchestrion` doesn't do auto-instrumentation for this code because `handler` in [http.ListenAndServe()](https://github.com/golang/go/blob/c5adb8216968be46bd11f7b7360a7c8bde1258d9/src/net/http/server.go#L3650-L3660) is set to `nil`. Setting `nil` in `http.ListenAndServe()` is generally a common practice.

```go
package main

import (
	"context"
	"log/slog"
	"net/http"
	"os"
	"os/signal"
)

func main() {
	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
	defer cancel()
	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
		slog.InfoContext(r.Context(), "Request received at /hello")
		resp, err := http.Get("https://example.com")
		if err != nil {
			http.Error(w, err.Error(), http.StatusInternalServerError)
			return
		}
		defer resp.Body.Close()
		slog.InfoContext(r.Context(), "Response received from example.com", slog.String("status", resp.Status))
		w.WriteHeader(http.StatusOK)
	})
	slog.Info("Starting server on port 8080")
	go http.ListenAndServe(":8080", nil)
	<-ctx.Done()
	slog.Info("Server stopped")
}
```

### Workaround

Set `http.DefaultServeMux` to `http.Server.Handler` explicitly.

```diff
+	s := http.Server{
+		Addr:    ":8080",
+		Handler: http.DefaultServeMux,
+	}
+	go s.ListenAndServe()
-	go http.ListenAndServe(":8080", nil)
```

### Generated code

`srv.Handler` is `nil`, when we set `nil` in `http.ListenAndServe()`.

```go
func (srv *Server) Serve(l net.Listener) error {
	//line <generated>
	{
		if srv.Handler == nil {
			srv.Handler = __dd_orchestrion_instrument_WrapHandler(DefaultServeMux)
		} else {
			srv.Handler = __dd_orchestrion_instrument_WrapHandler(srv.Handler)
		}
	}
	//line /snap/go/10743/src/net/http/server.go:3301
	if fn := testHookServerServe; fn != nil {
		fn(srv, l) // call hook with unwrapped listener
	}
	// ...skip....
```

How I checked generated code? Use `fmt.Println(buf.String())` in [/internal/injector/write.go](https://github.com/DataDog/orchestrion/blob/0b3286e2f1258c073e20e4f149ce8647c75efaac/internal/injector/write.go#L39-L42)

Replace `github.com/DataDog/orchestrion` with the project in my local.

```
module orchestrion-poc

go 1.23.3

require github.com/DataDog/orchestrion v1.0.1

replace github.com/DataDog/orchestrion => /home/ubuntu/workspace/orchestrion
....skip...
```
