### PR TITLE
fix(injector: lineinfo): line directive without line number is ignored

### DIFF
--- a/internal/injector/builtin/testdata/client/aws.go.snap
+++ b/internal/injector/builtin/testdata/client/aws.go.snap
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-//line <generated>
+//line <generated>:1
 	__orchestrion_awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
 )
 
@@ -18,7 +18,7 @@ import (
 func AWSClientV1() {
 	cfg := aws.NewConfig().WithRegion("us-west-2")
 	sess := session.Must(
-//line <generated>
+//line <generated>:1
 		func(sess *session.Session, err error) (*session.Session, error) {
 			if sess != nil {
 				sess = __orchestrion_awstrace.WrapSession(sess)

--- a/internal/injector/builtin/testdata/client/aws_v2.go.snap
+++ b/internal/injector/builtin/testdata/client/aws_v2.go.snap
@@ -12,7 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-//line <generated>
+//line <generated>:1
 	__orchestrion_awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go-v2/aws"
 )
 
@@ -32,7 +32,7 @@ func AWSClientV2() {
 
 func newCfg1() aws.Config {
 	cfg :=
-//line <generated>
+//line <generated>:1
 		func(cfg *aws.Config) *aws.Config {
 			__orchestrion_awstrace.AppendMiddleware(cfg)
 			return cfg
@@ -44,7 +44,7 @@ func newCfg1() aws.Config {
 
 func newCfg2() aws.Config {
 	cfg :=
-//line <generated>
+//line <generated>:1
 		func(cfg *aws.Config) *aws.Config {
 			__orchestrion_awstrace.AppendMiddleware(cfg)
 			return cfg
@@ -59,7 +59,7 @@ func newCfg2() aws.Config {
 }
 
 func newCfg3() aws.Config {
-	return func //line <generated>
+	return func //line <generated>:1
 	(cfg aws.Config) aws.Config {
 		__orchestrion_awstrace.AppendMiddleware(&cfg)
 		return cfg

--- a/internal/injector/builtin/testdata/client/elasticsearch.go.snap
+++ b/internal/injector/builtin/testdata/client/elasticsearch.go.snap
@@ -13,7 +13,7 @@ import (
 	esv6 "github.com/elastic/go-elasticsearch/v6"
 	esv7 "github.com/elastic/go-elasticsearch/v7"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
-//line <generated>
+//line <generated>:1
 	__orchestrion_elastictrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/elastic/go-elasticsearch.v6"
 )
 
@@ -29,7 +29,7 @@ func SampleGoElasticsearch() {
 
 	v6Client, err = esv6.NewDefaultClient()
 	v6Client, err = esv6.NewClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv6.Config) esv6.Config {
 			if cfg.Transport == nil {
 				cfg.Transport = __orchestrion_elastictrace.NewRoundTripper()
@@ -42,7 +42,7 @@ func SampleGoElasticsearch() {
 //line samples/client/elasticsearch.go:27
 			esv6.Config{}))
 	v6Client, err = esv6.NewClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv6.Config) esv6.Config {
 			if cfg.Transport == nil {
 				cfg.Transport = __orchestrion_elastictrace.NewRoundTripper()
@@ -59,7 +59,7 @@ func SampleGoElasticsearch() {
 
 	v7Client, err = esv7.NewDefaultClient()
 	v7Client, err = esv7.NewClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv7.Config) esv7.Config {
 			if cfg.CACert != nil {
 				// refuse to set transport as it will make the NewClient call fail.
@@ -76,7 +76,7 @@ func SampleGoElasticsearch() {
 //line samples/client/elasticsearch.go:33
 			esv7.Config{}))
 	v7Client, err = esv7.NewClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv7.Config) esv7.Config {
 			if cfg.CACert != nil {
 				// refuse to set transport as it will make the NewClient call fail.
@@ -97,7 +97,7 @@ func SampleGoElasticsearch() {
 
 	v8Client, err = esv8.NewDefaultClient()
 	v8Client, err = esv8.NewClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv8.Config) esv8.Config {
 			if cfg.CACert != nil {
 				// refuse to set transport as it will make the NewClient call fail.
@@ -114,7 +114,7 @@ func SampleGoElasticsearch() {
 //line samples/client/elasticsearch.go:39
 			esv8.Config{}))
 	v8Client, err = esv8.NewClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv8.Config) esv8.Config {
 			if cfg.CACert != nil {
 				// refuse to set transport as it will make the NewClient call fail.
@@ -133,7 +133,7 @@ func SampleGoElasticsearch() {
 				Transport: http.DefaultTransport,
 			}))
 	v8TypedClient, err = esv8.NewTypedClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv8.Config) esv8.Config {
 			if cfg.CACert != nil {
 				// refuse to set transport as it will make the NewClient call fail.
@@ -150,7 +150,7 @@ func SampleGoElasticsearch() {
 //line samples/client/elasticsearch.go:43
 			esv8.Config{}))
 	v8TypedClient, err = esv8.NewTypedClient(
-//line <generated>
+//line <generated>:1
 		func(cfg esv8.Config) esv8.Config {
 			if cfg.CACert != nil {
 				// refuse to set transport as it will make the NewClient call fail.
@@ -170,7 +170,7 @@ func SampleGoElasticsearch() {
 			}))
 
 	cfgPtr :=
-//line <generated>
+//line <generated>:1
 		func(cfg *esv8.Config) *esv8.Config {
 			if cfg.CACert != nil {
 				// refuse to set transport as it will make the NewClient call fail.

--- a/internal/injector/builtin/testdata/client/gocql.go.snap
+++ b/internal/injector/builtin/testdata/client/gocql.go.snap
@@ -10,14 +10,14 @@ import (
 	"log"
 
 	"github.com/gocql/gocql"
-//line <generated>
+//line <generated>:1
 	__orchestrion_gocqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gocql/gocql"
 )
 
 //line samples/client/gocql.go:14
 func SampleGoCQL1() {
 	cluster :=
-//line <generated>
+//line <generated>:1
 		func(cluster *gocql.ClusterConfig) *gocql.ClusterConfig {
 			obs := __orchestrion_gocqltrace.NewObserver(cluster)
 			cluster.QueryObserver = obs
@@ -35,7 +35,7 @@ func SampleGoCQL1() {
 
 func SampleGoCQL2() {
 	cluster :=
-//line <generated>
+//line <generated>:1
 		func(cluster gocql.ClusterConfig) gocql.ClusterConfig {
 			obs := __orchestrion_gocqltrace.NewObserver(&cluster)
 			cluster.QueryObserver = obs
@@ -53,7 +53,7 @@ func SampleGoCQL2() {
 
 func SampleGoCQL3() {
 	cluster :=
-//line <generated>
+//line <generated>:1
 		func(cluster *gocql.ClusterConfig) *gocql.ClusterConfig {
 			obs := __orchestrion_gocqltrace.NewObserver(cluster)
 			cluster.QueryObserver = obs

--- a/internal/injector/builtin/testdata/client/gorm.go.snap
+++ b/internal/injector/builtin/testdata/client/gorm.go.snap
@@ -15,7 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	_ "github.com/mattn/go-sqlite3"
-//line <generated>
+//line <generated>:1
 	__orchestrion_sql "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 	__orchestrion_gorm "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorm.io/gorm.v1"
 	__orchestrion_gormtrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/jinzhu/gorm"
@@ -43,12 +43,12 @@ func gormClient() {
 
 func jinzhuGormClient() {
 	db, err :=
-//line <generated>
+//line <generated>:1
 		func() (*jinzhu.DB, error) {
 			db, err :=
 //line samples/client/gorm.go:39
 				jinzhu.Open("sqlite3", "file::memory:?cache=shared")
-//line <generated>
+//line <generated>:1
 			if err != nil {
 				return nil, err
 			}

--- a/internal/injector/builtin/testdata/client/grpc.go.snap
+++ b/internal/injector/builtin/testdata/client/grpc.go.snap
@@ -10,14 +10,14 @@ import (
 	"log"
 
 	"google.golang.org/grpc"
-//line <generated>
+//line <generated>:1
 	__orchestrion_grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
 )
 
 //line samples/client/grpc.go:14
 func grpcClient() {
 	conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure(),
-//line <generated>
+//line <generated>:1
 		grpc.WithChainStreamInterceptor(__orchestrion_grpctrace.StreamClientInterceptor()), grpc.WithChainUnaryInterceptor(__orchestrion_grpctrace.UnaryClientInterceptor()))
 //line samples/client/grpc.go:16
 	if err != nil {

--- a/internal/injector/builtin/testdata/client/http.go.snap
+++ b/internal/injector/builtin/testdata/client/http.go.snap
@@ -12,14 +12,14 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-//line <generated>
+//line <generated>:1
 	__orchestrion_instrument "github.com/DataDog/orchestrion/instrument/net/http"
 )
 
 //line samples/client/http.go:16
 func shortHandsWithContext(__argument__0 context.Context) {
 	resp, err :=
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.Get(
 			__argument__0,
 //line samples/client/http.go:17
@@ -30,7 +30,7 @@ func shortHandsWithContext(__argument__0 context.Context) {
 	resp.Body.Close()
 
 	resp, err =
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.Head(
 			__argument__0,
 //line samples/client/http.go:23
@@ -41,7 +41,7 @@ func shortHandsWithContext(__argument__0 context.Context) {
 	resp.Body.Close()
 
 	resp, err =
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.Post(
 			__argument__0,
 //line samples/client/http.go:29
@@ -52,7 +52,7 @@ func shortHandsWithContext(__argument__0 context.Context) {
 	resp.Body.Close()
 
 	resp, err =
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.PostForm(
 			__argument__0,
 //line samples/client/http.go:35
@@ -65,7 +65,7 @@ func shortHandsWithContext(__argument__0 context.Context) {
 
 func shortHandsWithRequest(__argument__0 *http.Request /* for context */) {
 	resp, err :=
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.Get(
 			__argument__0.Context(),
 //line samples/client/http.go:43
@@ -76,7 +76,7 @@ func shortHandsWithRequest(__argument__0 *http.Request /* for context */) {
 	resp.Body.Close()
 
 	resp, err =
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.Head(
 			__argument__0.Context(),
 //line samples/client/http.go:49
@@ -87,7 +87,7 @@ func shortHandsWithRequest(__argument__0 *http.Request /* for context */) {
 	resp.Body.Close()
 
 	resp, err =
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.Post(
 			__argument__0.Context(),
 //line samples/client/http.go:55
@@ -98,7 +98,7 @@ func shortHandsWithRequest(__argument__0 *http.Request /* for context */) {
 	resp.Body.Close()
 
 	resp, err =
-//line <generated>
+//line <generated>:1
 		__orchestrion_instrument.PostForm(
 			__argument__0.Context(),
 //line samples/client/http.go:61

--- a/internal/injector/builtin/testdata/client/ibm_sarama.go.snap
+++ b/internal/injector/builtin/testdata/client/ibm_sarama.go.snap
@@ -9,7 +9,7 @@ package main
 import (
 	"github.com/IBM/sarama"
 
-//line <generated>
+//line <generated>:1
 	__orchestrion_saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/IBM/sarama.v1"
 )
 
@@ -17,7 +17,7 @@ import (
 func ibmSaramaConsumer() {
 	cfg := sarama.NewConfig()
 	consumer, err :=
-//line <generated>
+//line <generated>:1
 		func(c sarama.Consumer, err error) (sarama.Consumer, error) {
 			if c != nil {
 				c = __orchestrion_saramatrace.WrapConsumer(c)

--- a/internal/injector/builtin/testdata/client/logrus.go.snap
+++ b/internal/injector/builtin/testdata/client/logrus.go.snap
@@ -11,7 +11,7 @@ import "github.com/sirupsen/logrus"
 //line samples/client/logrus.go:10
 func SampleLogrus() {
 	logger :=
-//line <generated>
+//line <generated>:1
 		func(logger *logrus.Logger) *logrus.Logger {
 			logger.AddHook(&logrus.DDContextLogHook{})
 			return logger

--- a/internal/injector/builtin/testdata/client/main.go.snap
+++ b/internal/injector/builtin/testdata/client/main.go.snap
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 	"time"
-//line <generated>
+//line <generated>:1
 	__orchestrion_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	__orchestrion_profiler "gopkg.in/DataDog/dd-trace-go.v1/profiler"
 	__orchestrion_log "log"
@@ -23,7 +23,7 @@ import (
 //dd:span
 //line samples/client/main.go:19
 func main() {
-//line <generated>
+//line <generated>:1
 	{
 		defer __orchestrion_tracer.Stop()
 		defer __orchestrion_profiler.Stop()
@@ -66,7 +66,7 @@ func main() {
 	fmt.Println(string(b))
 }
 
-//line <generated>
+//line <generated>:1
 func init() {
 	__orchestrion_tracer.Start(__orchestrion_tracer.WithOrchestrion(map[string]string{"version": "<version.Tag>"}))
 }

--- a/internal/injector/builtin/testdata/client/mongo.go.snap
+++ b/internal/injector/builtin/testdata/client/mongo.go.snap
@@ -12,7 +12,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-//line <generated>
+//line <generated>:1
 	__orchestrion_mongotrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -20,10 +20,10 @@ import (
 func mongoClient() {
 	ctx := context.Background()
 	opts :=
-//line <generated>
+//line <generated>:1
 //line samples/client/mongo.go:18
 		options.Client().
-//line <generated>
+//line <generated>:1
 			SetMonitor(__orchestrion_mongotrace.NewMonitor()).
 //line samples/client/mongo.go:18
 			ApplyURI("mongodb://localhost:27017")

--- a/internal/injector/builtin/testdata/client/pgx.go.snap
+++ b/internal/injector/builtin/testdata/client/pgx.go.snap
@@ -11,7 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-//line <generated>
+//line <generated>:1
 	__orchestrion_pgx "gopkg.in/DataDog/dd-trace-go.v1/contrib/jackc/pgx.v5"
 )
 

--- a/internal/injector/builtin/testdata/client/redis.go.snap
+++ b/internal/injector/builtin/testdata/client/redis.go.snap
@@ -16,7 +16,7 @@ import (
 	redisv8 "github.com/go-redis/redis/v8"
 	redigo "github.com/gomodule/redigo/redis"
 	redisv9 "github.com/redis/go-redis/v9"
-//line <generated>
+//line <generated>:1
 	__orchestrion_trace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis"
 	__orchestrion_trace1 "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis.v7"
 	__orchestrion_trace2 "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis.v8"
@@ -27,12 +27,12 @@ import (
 //line samples/client/redis.go:20
 func redisV0Client() {
 	client :=
-//line <generated>
+//line <generated>:1
 		func() (client *redisv0.Client) {
 			client =
 //line samples/client/redis.go:21
 				redisv0.NewClient(&redisv0.Options{Addr: "127.0.0.1", Password: "", DB: 0})
-//line <generated>
+//line <generated>:1
 			__orchestrion_trace.WrapClient(client)
 			return
 		}()
@@ -45,12 +45,12 @@ func redisV0Client() {
 
 func redisV7Client() {
 	client :=
-//line <generated>
+//line <generated>:1
 		func() (client *redisv7.Client) {
 			client =
 //line samples/client/redis.go:29
 				redisv7.NewClient(&redisv7.Options{Addr: "127.0.0.1", Password: "", DB: 0})
-//line <generated>
+//line <generated>:1
 			__orchestrion_trace1.WrapClient(client)
 			return
 		}()
@@ -63,12 +63,12 @@ func redisV7Client() {
 
 func redisV8Client(ctx context.Context) {
 	client :=
-//line <generated>
+//line <generated>:1
 		func() (client *redisv8.Client) {
 			client =
 //line samples/client/redis.go:37
 				redisv8.NewClient(&redisv8.Options{Addr: "127.0.0.1", Password: "", DB: 0})
-//line <generated>
+//line <generated>:1
 			__orchestrion_trace2.WrapClient(client)
 			return
 		}()
@@ -81,12 +81,12 @@ func redisV8Client(ctx context.Context) {
 
 func redisV9Client(ctx context.Context) {
 	client :=
-//line <generated>
+//line <generated>:1
 		func() (client *redisv9.Client) {
 			client =
 //line samples/client/redis.go:45
 				redisv9.NewClient(&redisv9.Options{Addr: "127.0.0.1", Password: "", DB: 0})
-//line <generated>
+//line <generated>:1
 			__orchestrion_trace3.WrapClient(client)
 			return
 		}()
@@ -107,7 +107,7 @@ func redigoClient(ctx context.Context, net, addr string) {
 	}
 
 	if conn, err :=
-//line <generated>
+//line <generated>:1
 		func() (redigo.Conn, error) {
 			return __orchestrion_redigotrace.Dial(
 //line samples/client/redis.go:61
@@ -121,7 +121,7 @@ func redigoClient(ctx context.Context, net, addr string) {
 	}
 
 	if conn, err :=
-//line <generated>
+//line <generated>:1
 		func() (redigo.Conn, error) {
 			return __orchestrion_redigotrace.DialContext(
 //line samples/client/redis.go:67
@@ -135,12 +135,12 @@ func redigoClient(ctx context.Context, net, addr string) {
 	}
 
 	if conn, err :=
-//line <generated>
+//line <generated>:1
 		func() (redigo.Conn, error) {
 			opts :=
 //line samples/client/redis.go:73
 				options
-//line <generated>
+//line <generated>:1
 			anyOpts := make([]interface{}, len(opts))
 			for i, v := range opts {
 				anyOpts[i] = v
@@ -148,7 +148,7 @@ func redigoClient(ctx context.Context, net, addr string) {
 			return __orchestrion_redigotrace.DialURL(
 //line samples/client/redis.go:73
 				fmt.Sprintf("%s://%s", net, addr),
-//line <generated>
+//line <generated>:1
 				anyOpts...)
 		}();
 //line samples/client/redis.go:73

--- a/internal/injector/builtin/testdata/client/shopify_sarama.go.snap
+++ b/internal/injector/builtin/testdata/client/shopify_sarama.go.snap
@@ -9,7 +9,7 @@ package main
 import (
 	"github.com/Shopify/sarama"
 
-//line <generated>
+//line <generated>:1
 	__orchestrion_saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama"
 )
 
@@ -17,7 +17,7 @@ import (
 func shopifySaramaConsumer() {
 	cfg := sarama.NewConfig()
 	consumer, err :=
-//line <generated>
+//line <generated>:1
 		func(c sarama.Consumer, err error) (sarama.Consumer, error) {
 			if c != nil {
 				c = __orchestrion_saramatrace.WrapConsumer(c)

--- a/internal/injector/builtin/testdata/client/vault.go.snap
+++ b/internal/injector/builtin/testdata/client/vault.go.snap
@@ -10,18 +10,18 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/vault/api"
-//line <generated>
+//line <generated>:1
 	__orchestrion_vaulttrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/hashicorp/vault"
 )
 
 //line samples/client/vault.go:14
 func vaultClient() {
 	c, err := api.NewClient(&
-//line <generated>
+//line <generated>:1
 //line samples/client/vault.go:15
 	api.Config{
 		Address: "http://vault.mydomain.com:8200",
-//line <generated>
+//line <generated>:1
 		HttpClient: __orchestrion_vaulttrace.NewHTTPClient(),
 	})
 //line samples/client/vault.go:18
@@ -33,10 +33,10 @@ func vaultClient() {
 
 func vaultProvidedClient() {
 	c, err := api.NewClient(&
-//line <generated>
+//line <generated>:1
 //line samples/client/vault.go:25
 	api.Config{
-//line <generated>
+//line <generated>:1
 		HttpClient: __orchestrion_vaulttrace.WrapHTTPClient(
 //line samples/client/vault.go:26
 			&http.Client{}),

--- a/internal/injector/builtin/testdata/server/chiv5.go.snap
+++ b/internal/injector/builtin/testdata/server/chiv5.go.snap
@@ -10,19 +10,19 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-//line <generated>
+//line <generated>:1
 	__orchestrion_chitrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5"
 )
 
 //line samples/server/chiv5.go:14
 func chiV5Server() {
 	router :=
-//line <generated>
+//line <generated>:1
 		func() *chi.Mux {
 			mux :=
 //line samples/server/chiv5.go:15
 				chi.NewRouter()
-//line <generated>
+//line <generated>:1
 			mux.Use(__orchestrion_chitrace.Middleware())
 			return mux
 		}()

--- a/internal/injector/builtin/testdata/server/database.go.snap
+++ b/internal/injector/builtin/testdata/server/database.go.snap
@@ -12,13 +12,13 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"log"
-//line <generated>
+//line <generated>:1
 	__orchestrion_sql "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
 )
 
 //line samples/server/database.go:16
 func init() {
-//line <generated>
+//line <generated>:1
 	func(driverName string, driver driver.Driver) {
 		sql.Register(driverName, driver)
 		__orchestrion_sql.Register(driverName, driver)

--- a/internal/injector/builtin/testdata/server/echov4.go.snap
+++ b/internal/injector/builtin/testdata/server/echov4.go.snap
@@ -10,19 +10,19 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-//line <generated>
+//line <generated>:1
 	__orchestrion_echotrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4"
 )
 
 //line samples/server/echov4.go:14
 func echoV4Server() {
 	r :=
-//line <generated>
+//line <generated>:1
 		func() *echo.Echo {
 			e :=
 //line samples/server/echov4.go:15
 				echo.New()
-//line <generated>
+//line <generated>:1
 			e.Use(__orchestrion_echotrace.Middleware())
 			return e
 		}()
@@ -41,12 +41,12 @@ type api struct {
 
 func (a *api) echoV4Server() {
 	a.srv =
-//line <generated>
+//line <generated>:1
 		func() *echo.Echo {
 			e :=
 //line samples/server/echov4.go:29
 				echo.New()
-//line <generated>
+//line <generated>:1
 			e.Use(__orchestrion_echotrace.Middleware())
 			return e
 		}()

--- a/internal/injector/builtin/testdata/server/fiberv2.go.snap
+++ b/internal/injector/builtin/testdata/server/fiberv2.go.snap
@@ -8,19 +8,19 @@ package main
 
 import (
 	"github.com/gofiber/fiber/v2"
-//line <generated>
+//line <generated>:1
 	__orchestrion_fibertrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gofiber/fiber.v2"
 )
 
 //line samples/server/fiberv2.go:12
 func fiberV2Server() {
 	r :=
-//line <generated>
+//line <generated>:1
 		func() *fiber.App {
 			app :=
 //line samples/server/fiberv2.go:13
 				fiber.New()
-//line <generated>
+//line <generated>:1
 			app.Use(__orchestrion_fibertrace.Middleware())
 			return app
 		}()

--- a/internal/injector/builtin/testdata/server/gin.go.snap
+++ b/internal/injector/builtin/testdata/server/gin.go.snap
@@ -10,19 +10,19 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-//line <generated>
+//line <generated>:1
 	__orchestrion_gintrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin"
 )
 
 //line samples/server/gin.go:14
 func ginServer() {
 	r :=
-//line <generated>
+//line <generated>:1
 		func() *gin.Engine {
 			e :=
 //line samples/server/gin.go:15
 				gin.Default()
-//line <generated>
+//line <generated>:1
 			e.Use(__orchestrion_gintrace.Middleware(""))
 			return e
 		}()

--- a/internal/injector/builtin/testdata/server/graphqlgen.go.snap
+++ b/internal/injector/builtin/testdata/server/graphqlgen.go.snap
@@ -14,7 +14,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
-//line <generated>
+//line <generated>:1
 	__orchestrion_gqlgentrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/99designs/gqlgen"
 )
 
@@ -31,7 +31,7 @@ func Serve99Designs() {
 `})
 
 	server :=
-//line <generated>
+//line <generated>:1
 		func(s *handler.Server) *handler.Server {
 			s.Use(__orchestrion_gqlgentrace.NewTracer())
 			return s

--- a/internal/injector/builtin/testdata/server/grpc.go.snap
+++ b/internal/injector/builtin/testdata/server/grpc.go.snap
@@ -11,7 +11,7 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
-//line <generated>
+//line <generated>:1
 	__orchestrion_grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
 )
 
@@ -23,7 +23,7 @@ func grpcServer() {
 	}
 
 	s := grpc.NewServer(grpc.EmptyServerOption{},
-//line <generated>
+//line <generated>:1
 		grpc.ChainStreamInterceptor(__orchestrion_grpctrace.StreamServerInterceptor()), grpc.ChainUnaryInterceptor(__orchestrion_grpctrace.UnaryServerInterceptor()))
 //line samples/server/grpc.go:22
 	if err := s.Serve(ln); err != nil {

--- a/internal/injector/builtin/testdata/server/ibm_sarama.go.snap
+++ b/internal/injector/builtin/testdata/server/ibm_sarama.go.snap
@@ -9,7 +9,7 @@ package main
 import (
 	"github.com/IBM/sarama"
 
-//line <generated>
+//line <generated>:1
 	__orchestrion_saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/IBM/sarama.v1"
 )
 
@@ -19,7 +19,7 @@ func ibmSaramaProducer() {
 	cfg.Producer.Return.Successes = true
 
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.SyncProducer, err error) (sarama.SyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapSyncProducer(nil, p)
@@ -43,7 +43,7 @@ func ibmSaramaProducerFromClient() {
 		panic(err)
 	}
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.SyncProducer, err error) (sarama.SyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapSyncProducer(nil, p)
@@ -63,7 +63,7 @@ func ibmSaramaAsyncProducer() {
 	cfg.Version = sarama.V0_11_0_0 // minimum version that supports headers which are required for tracing
 
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.AsyncProducer, err error) (sarama.AsyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapAsyncProducer(nil, p)
@@ -87,7 +87,7 @@ func ibmSaramaAsyncProducerFromClient() {
 		panic(err)
 	}
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.AsyncProducer, err error) (sarama.AsyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapAsyncProducer(nil, p)

--- a/internal/injector/builtin/testdata/server/main.go.snap
+++ b/internal/injector/builtin/testdata/server/main.go.snap
@@ -10,7 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
-//line <generated>
+//line <generated>:1
 	__orchestrion_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	__orchestrion_profiler "gopkg.in/DataDog/dd-trace-go.v1/profiler"
 	__orchestrion_os "os"
@@ -18,7 +18,7 @@ import (
 
 //line samples/server/main.go:14
 func main() {
-//line <generated>
+//line <generated>:1
 	{
 		defer __orchestrion_tracer.Stop()
 		defer __orchestrion_profiler.Stop()
@@ -61,7 +61,7 @@ func instrumentedHandler(w http.ResponseWriter, r *http.Request) {
 
 // comment that is just hanging out unattached
 //
-//line <generated>
+//line <generated>:1
 func init() {
 	__orchestrion_tracer.Start(__orchestrion_tracer.WithOrchestrion(map[string]string{"version": "<version.Tag>"}))
 }

--- a/internal/injector/builtin/testdata/server/other_handlers.go.snap
+++ b/internal/injector/builtin/testdata/server/other_handlers.go.snap
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 	"time"
-//line <generated>
+//line <generated>:1
 	__orchestrion_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -78,7 +78,7 @@ func buildHandlers() {
 
 //dd:span foo:bar type:potato
 func myFunc(__argument__0 context.Context, name string) {
-//line <generated>
+//line <generated>:1
 	{
 		var span __orchestrion_tracer.Span
 		span, __argument__0 = __orchestrion_tracer.StartSpanFromContext(__argument__0, "myFunc",
@@ -95,7 +95,7 @@ func myFunc(__argument__0 context.Context, name string) {
 
 //dd:span foo2:bar2 type:request
 func myFunc2(name string, __argument__1 *http.Request) {
-//line <generated>
+//line <generated>:1
 	{
 		ctx := __argument__1.Context()
 		var span __orchestrion_tracer.Span
@@ -114,7 +114,7 @@ func myFunc2(name string, __argument__1 *http.Request) {
 
 //dd:span foo3:bar3 type:request span.name:customName
 func myFunc3(name string) (__result__0 error) {
-//line <generated>
+//line <generated>:1
 	{
 		ctx := context.TODO()
 		var span __orchestrion_tracer.Span

--- a/internal/injector/builtin/testdata/server/shopify_sarama.go.snap
+++ b/internal/injector/builtin/testdata/server/shopify_sarama.go.snap
@@ -9,7 +9,7 @@ package main
 import (
 	"github.com/Shopify/sarama"
 
-//line <generated>
+//line <generated>:1
 	__orchestrion_saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama"
 )
 
@@ -19,7 +19,7 @@ func shopifySaramaProducer() {
 	cfg.Producer.Return.Successes = true
 
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.SyncProducer, err error) (sarama.SyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapSyncProducer(nil, p)
@@ -43,7 +43,7 @@ func shopifySaramaProducerFromClient() {
 		panic(err)
 	}
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.SyncProducer, err error) (sarama.SyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapSyncProducer(nil, p)
@@ -63,7 +63,7 @@ func shopifySaramaAsyncProducer() {
 	cfg.Version = sarama.V0_11_0_0 // minimum version that supports headers which are required for tracing
 
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.AsyncProducer, err error) (sarama.AsyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapAsyncProducer(nil, p)
@@ -87,7 +87,7 @@ func shopifySaramaAsyncProducerFromClient() {
 		panic(err)
 	}
 	producer, err :=
-//line <generated>
+//line <generated>:1
 		func(p sarama.AsyncProducer, err error) (sarama.AsyncProducer, error) {
 			if p != nil {
 				p = __orchestrion_saramatrace.WrapAsyncProducer(nil, p)

--- a/internal/injector/builtin/testdata/server/twirp.go.snap
+++ b/internal/injector/builtin/testdata/server/twirp.go.snap
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	"github.com/twitchtv/twirp"
-//line <generated>
+//line <generated>:1
 	__orchestrion_twirptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/twitchtv/twirp"
 )
 
@@ -19,18 +19,18 @@ func twirpServerSample() {
 	var serverOpts *twirp.ServerOptions
 
 	serverOpts = &
-//line <generated>
+//line <generated>:1
 //line samples/server/twirp.go:17
 	twirp.ServerOptions{
-//line <generated>
+//line <generated>:1
 		Hooks: __orchestrion_twirptrace.NewServerHooks(),
 	}
 //line samples/server/twirp.go:18
 	serverOpts = &
-//line <generated>
+//line <generated>:1
 //line samples/server/twirp.go:18
 	twirp.ServerOptions{
-//line <generated>
+//line <generated>:1
 		Hooks: twirp.ChainHooks(__orchestrion_twirptrace.NewServerHooks(),
 //line samples/server/twirp.go:19
 			&twirp.ServerHooks{

--- a/internal/injector/lineinfo/annotation.go
+++ b/internal/injector/lineinfo/annotation.go
@@ -93,7 +93,7 @@ func (v *annotationVisitor) Visit(node ast.Node) ast.Visitor {
 		}
 
 		// This is a synthetic node...
-		v.adjFile, v.adjLine = generated, 0
+		v.adjFile, v.adjLine = generated, 1
 
 		if prevInfo.adjFile != generated {
 			decs := dstNode.Decorations()

--- a/internal/injector/testdata/injector/access-return-value/expected.diff
+++ b/internal/injector/testdata/injector/access-return-value/expected.diff
@@ -11,7 +11,7 @@
  
 -func test() (interface{}, error) {
 +func test() (_ interface{}, __result__1 error) {
-+//line <generated>
++//line <generated>:1
 +  {
 +    defer func() {
 +      if __result__1 != nil {

--- a/internal/injector/testdata/injector/chi5-newroute-dotimport/expected.diff
+++ b/internal/injector/testdata/injector/chi5-newroute-dotimport/expected.diff
@@ -9,7 +9,7 @@
    "net/http"
  
    . "github.com/go-chi/chi/v5"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_chitrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5"
  )
  
@@ -17,12 +17,12 @@
  func main() {
 -  router := NewRouter()
 +  router :=
-+//line <generated>
++//line <generated>:1
 +    func() *Mux {
 +      mux :=
 +//line input.go:11
 +        NewRouter()
-+//line <generated>
++//line <generated>:1
 +      mux.Use(__orchestrion_chitrace.Middleware())
 +      return mux
 +    }()

--- a/internal/injector/testdata/injector/chi5-newroute/expected.diff
+++ b/internal/injector/testdata/injector/chi5-newroute/expected.diff
@@ -9,7 +9,7 @@
    "net/http"
  
    "github.com/go-chi/chi/v5"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_chitrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5"
  )
  
@@ -17,12 +17,12 @@
  func main() {
 -  router := chi.NewRouter()
 +  router :=
-+//line <generated>
++//line <generated>:1
 +    func() *chi.Mux {
 +      mux :=
 +//line input.go:11
 +        chi.NewRouter()
-+//line <generated>
++//line <generated>:1
 +      mux.Use(__orchestrion_chitrace.Middleware())
 +      return mux
 +    }()

--- a/internal/injector/testdata/injector/database-sql/expected.diff
+++ b/internal/injector/testdata/injector/database-sql/expected.diff
@@ -8,7 +8,7 @@
 -  "database/sql"
 +//line input.go:5
    "database/sql/driver"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
  )
  
@@ -18,7 +18,7 @@
  func main() {
 -  db1, err := sql.Open("foo", "bar")
 +  db1, err :=
-+//line <generated>
++//line <generated>:1
 +    __orchestrion_sqltrace.Open(
 +//line input.go:11
 +      "foo", "bar")
@@ -29,7 +29,7 @@
  
 -  db2 := sql.OpenDB(conn)
 +  db2 :=
-+//line <generated>
++//line <generated>:1
 +    __orchestrion_sqltrace.OpenDB(
 +//line input.go:17
 +      conn)

--- a/internal/injector/testdata/injector/directive/expected.diff
+++ b/internal/injector/testdata/injector/directive/expected.diff
@@ -6,14 +6,14 @@
  
  import (
    "context"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
  )
  
  //dd:span foo:bar baz:qux
 +//line input.go:8
  func outer(ctx context.Context) {
-+//line <generated>
++//line <generated>:1
 +  {
 +    var span __orchestrion_tracer.Span
 +    span, ctx = __orchestrion_tracer.StartSpanFromContext(ctx, "outer",
@@ -27,7 +27,7 @@
    //dd:span
 +//line input.go:10
    inner := func(c context.Context) {
-+//line <generated>
++//line <generated>:1
 +    {
 +      var span __orchestrion_tracer.Span
 +      span, c = __orchestrion_tracer.StartSpanFromContext(c, "")

--- a/internal/injector/testdata/injector/grpc/expected.diff
+++ b/internal/injector/testdata/injector/grpc/expected.diff
@@ -9,7 +9,7 @@
    "net"
  
    "google.golang.org/grpc"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
  )
  
@@ -18,7 +18,7 @@
    dialOpts := []grpc.DialOption{grpc.WithInsecure()}
 -  conn, err := grpc.Dial("localhost:50051", dialOpts...)
 +  conn, err := grpc.Dial("localhost:50051",
-+//line <generated>
++//line <generated>:1
 +    func(opts ...grpc.DialOption) []grpc.DialOption {
 +      return append(opts, grpc.WithStreamInterceptor(__orchestrion_grpctrace.StreamClientInterceptor()), grpc.WithUnaryInterceptor(__orchestrion_grpctrace.UnaryClientInterceptor()))
 +    }(
@@ -33,7 +33,7 @@
  
 -  s := grpc.NewServer(grpc.EmptyServerOption{})
 +  s := grpc.NewServer(grpc.EmptyServerOption{},
-+//line <generated>
++//line <generated>:1
 +    grpc.StreamInterceptor(__orchestrion_grpctrace.StreamServerInterceptor()), grpc.UnaryInterceptor(__orchestrion_grpctrace.UnaryServerInterceptor()))
 +//line input.go:26
    if err := s.Serve(ln); err != nil {

--- a/internal/injector/testdata/injector/http-anonymous-handler/expected.diff
+++ b/internal/injector/testdata/injector/http-anonymous-handler/expected.diff
@@ -8,7 +8,7 @@
    "io"
    "log"
    "net/http"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_instrument "github.com/DataDog/orchestrion/instrument"
 +  __orchestrion_event "github.com/DataDog/orchestrion/instrument/event"
  )
@@ -18,7 +18,7 @@
    s := &http.Server{
      Addr: ":8085",
      Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-+//line <generated>
++//line <generated>:1
 +      {
 +        r = r.WithContext(__orchestrion_instrument.Report(
 +          r.Context(),

--- a/internal/injector/testdata/injector/http-default/expected.diff
+++ b/internal/injector/testdata/injector/http-default/expected.diff
@@ -8,7 +8,7 @@
    "io"
    "log"
    "net/http"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_instrument "github.com/DataDog/orchestrion/instrument"
 +  __orchestrion_event "github.com/DataDog/orchestrion/instrument/event"
  )
@@ -21,7 +21,7 @@
  }
  
  func handle(w http.ResponseWriter, r *http.Request) {
-+//line <generated>
++//line <generated>:1
 +  {
 +    r = r.WithContext(__orchestrion_instrument.Report(
 +      r.Context(),

--- a/internal/injector/testdata/injector/http-line-info/expected.diff
+++ b/internal/injector/testdata/injector/http-line-info/expected.diff
@@ -8,7 +8,7 @@
    "io"
    "log"
    "net/http"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_instrument "github.com/DataDog/orchestrion/instrument"
 +  __orchestrion_event "github.com/DataDog/orchestrion/instrument/event"
  )
@@ -21,7 +21,7 @@
  }
  
  func handle(w http.ResponseWriter, r *http.Request) {
-+//line <generated>
++//line <generated>:1
 +  {
 +    r = r.WithContext(__orchestrion_instrument.Report(
 +      r.Context(),

--- a/internal/injector/testdata/injector/http-no-arg-name/expected.diff
+++ b/internal/injector/testdata/injector/http-no-arg-name/expected.diff
@@ -7,7 +7,7 @@
  import (
    "log"
    "net/http"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_instrument "github.com/DataDog/orchestrion/instrument"
 +  __orchestrion_event "github.com/DataDog/orchestrion/instrument/event"
  )
@@ -22,7 +22,7 @@
  
 -func handle(http.ResponseWriter, *http.Request) {
 +func handle(_ http.ResponseWriter, __argument__1 *http.Request) {
-+//line <generated>
++//line <generated>:1
 +  {
 +    __argument__1 = __argument__1.WithContext(__orchestrion_instrument.Report(
 +      __argument__1.Context(),

--- a/internal/injector/testdata/injector/http-server/expected.diff
+++ b/internal/injector/testdata/injector/http-server/expected.diff
@@ -8,7 +8,7 @@
    "io"
    "log"
    "net/http"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_instrument "github.com/DataDog/orchestrion/instrument"
  )
  
@@ -20,7 +20,7 @@
 +    Addr: ":8085",
 +    Handler:
 +    //dd:startwrap
-+//line <generated>
++//line <generated>:1
 +    __orchestrion_instrument.WrapHandler(
 +//line input.go:12
 +      http.HandlerFunc(handle)),

--- a/internal/injector/testdata/injector/lang-level/expected.diff
+++ b/internal/injector/testdata/injector/lang-level/expected.diff
@@ -8,7 +8,7 @@
    "io"
    "log"
    "net/http"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_instrument "github.com/DataDog/orchestrion/instrument"
  )
  
@@ -20,7 +20,7 @@
 +    Addr: ":8085",
 +    Handler:
 +    //dd:startwrap
-+//line <generated>
++//line <generated>:1
 +    __orchestrion_instrument.WrapHandler(
 +//line input.go:12
 +      http.HandlerFunc(handle)),

--- a/internal/injector/testdata/injector/name-conflict/expected.diff
+++ b/internal/injector/testdata/injector/name-conflict/expected.diff
@@ -4,7 +4,7 @@
 +//line input.go:1:1
  package test
  
-+//line <generated>
++//line <generated>:1
 +import __orchestrion_fmt "fmt"
 +
 +//line input.go:3
@@ -12,7 +12,7 @@
  
  //dd:span
  func foo() {
-+//line <generated>
++//line <generated>:1
 +  {
 +    __orchestrion_fmt.Println("hello world")
 +  }

--- a/internal/injector/testdata/injector/redigo/expected.diff
+++ b/internal/injector/testdata/injector/redigo/expected.diff
@@ -8,7 +8,7 @@
    "time"
  
    "github.com/gomodule/redigo/redis"
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_redigotrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/gomodule/redigo"
  )
  
@@ -16,7 +16,7 @@
  func dial1(net, address string) error {
 -  c, err := redis.Dial(net, address)
 +  c, err :=
-+//line <generated>
++//line <generated>:1
 +    func() (redis.Conn, error) {
 +      return __orchestrion_redigotrace.Dial(
 +//line input.go:10
@@ -32,7 +32,7 @@
  func dial2(net, address string) error {
 -  c, err := redis.Dial(net, address, redis.DialConnectTimeout(5*time.Second), redis.DialConnectTimeout(time.Minute))
 +  c, err :=
-+//line <generated>
++//line <generated>:1
 +    func() (redis.Conn, error) {
 +      return __orchestrion_redigotrace.Dial(
 +//line input.go:19
@@ -51,12 +51,12 @@
    }
 -  c, err := redis.Dial(net, address, options...)
 +  c, err :=
-+//line <generated>
++//line <generated>:1
 +    func() (redis.Conn, error) {
 +      opts :=
 +//line input.go:31
 +        options
-+//line <generated>
++//line <generated>:1
 +      anyOpts := make([]interface{}, len(opts))
 +      for i, v := range opts {
 +        anyOpts[i] = v
@@ -64,7 +64,7 @@
 +      return __orchestrion_redigotrace.Dial(
 +//line input.go:31
 +        net, address,
-+//line <generated>
++//line <generated>:1
 +        anyOpts...)
 +    }()
 +//line input.go:32

--- a/internal/injector/testdata/injector/struct-literal/expected.diff
+++ b/internal/injector/testdata/injector/struct-literal/expected.diff
@@ -10,13 +10,13 @@
  
 -var cfgValue = aws.Config{}
 -var cfgPtr = &aws.Config{}
-+//line <generated>
++//line <generated>:1
 +  __orchestrion_awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go-v2/aws"
 +)
 +
 +//line input.go:5
 +var cfgValue =
-+//line <generated>
++//line <generated>:1
 +func(cfg aws.Config) aws.Config {
 +  __orchestrion_awstrace.AppendMiddleware(&cfg)
 +  return cfg
@@ -24,7 +24,7 @@
 +//line input.go:5
 +  aws.Config{})
 +var cfgPtr =
-+//line <generated>
++//line <generated>:1
 +func(cfg *aws.Config) *aws.Config {
 +  __orchestrion_awstrace.AppendMiddleware(cfg)
 +  return cfg


### PR DESCRIPTION
Previously, line directives from the `<generated>` file would appear without line number as `<generated>` because `<generated>:0` would make the compiler fail with the error: ` invalid line number: 0`. But we found out that `<generated>` is actually ignored by the go compiler. This means that we have to set the line number to 1 and let it appear