### PR TITLE
fix(injector): source import shadowed results in build error "X is not a type"

### DIFF
--- a/internal/injector/aspect/context/context.go
+++ b/internal/injector/aspect/context/context.go
@@ -224,8 +224,13 @@ func (c *context) ParseSource(bytes []byte) (*dst.File, error) {
 	return c.sourceParser.Parse(bytes)
 }
 
-func (c *context) AddImport(path string, alias string) bool {
-	return c.refMap.AddImport(c.file, path, alias)
+func (c *context) AddImport(path string, name string) bool {
+	nodeChain := []dst.Node{c.node}
+	for p := c.NodeChain.parent; p != nil; p = p.parent {
+		nodeChain = append(nodeChain, p.node)
+	}
+
+	return c.refMap.AddImport(c.file, nodeChain, path, name)
 }
 
 func (c *context) AddLink(path string) bool {

--- a/internal/injector/check.go
+++ b/internal/injector/check.go
@@ -16,9 +16,12 @@ import (
 
 // typeCheck runs the Go type checker on the provided files, and returns the
 // Uses type information map that is built in the process.
-func (i *Injector) typeCheck(fset *token.FileSet, files []*ast.File) (map[*ast.Ident]types.Object, error) {
+func (i *Injector) typeCheck(fset *token.FileSet, files []*ast.File) (types.Info, error) {
 	pkg := types.NewPackage(i.ImportPath, i.Name)
-	typeInfo := types.Info{Uses: make(map[*ast.Ident]types.Object)}
+	typeInfo := types.Info{
+		Uses:   make(map[*ast.Ident]types.Object),
+		Scopes: make(map[ast.Node]*types.Scope),
+	}
 
 	checkerCfg := types.Config{
 		GoVersion: i.GoVersion,
@@ -27,8 +30,8 @@ func (i *Injector) typeCheck(fset *token.FileSet, files []*ast.File) (map[*ast.I
 	checker := types.NewChecker(&checkerCfg, fset, pkg, &typeInfo)
 
 	if err := checker.Files(files); err != nil {
-		return nil, fmt.Errorf("type-checking files: %w", err)
+		return types.Info{}, fmt.Errorf("type-checking files: %w", err)
 	}
 
-	return typeInfo.Uses, nil
+	return typeInfo, nil
 }

--- a/internal/injector/testdata/injector/chi5-newroute-dotimport/config.yml
+++ b/internal/injector/testdata/injector/chi5-newroute-dotimport/config.yml
@@ -16,6 +16,7 @@ aspects:
             }()
 
 syntheticReferences:
+  github.com/go-chi/chi/v5: true
   gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5: true
 
 code: |-

--- a/internal/injector/testdata/injector/import-shadowing/config.yml
+++ b/internal/injector/testdata/injector/import-shadowing/config.yml
@@ -1,0 +1,47 @@
+%YAML 1.1
+---
+aspects:
+  - id: Register
+    join-point:
+      function-call: database/sql.Register
+    advice:
+      - wrap-expression:
+          imports:
+            sqltrace: gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql
+            sql: database/sql
+            driver: database/sql/driver
+          template: |-
+            func(driverName string, driver driver.Driver) {
+                sql.Register(driverName, driver)
+                sqltrace.Register(driverName, driver)
+            }({{ index .AST.Args 0 }}, {{ index .AST.Args 1 }})
+
+syntheticReferences:
+  database/sql/driver: true # shadowed import
+  gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql: true
+
+code: |-
+  package test
+
+  import (
+    "database/sql"
+    "database/sql/driver"
+  )
+
+  var conn driver.Connector
+
+  func main() {
+    var driver string // shadowing import
+    sql.Register("foo", nil)
+
+    db1, err := sql.Open("foo", "bar")
+    if err != nil {
+      panic(err)
+    }
+    defer db1.Close()
+
+    println(driver)
+
+    db2 := sql.OpenDB(conn)
+    defer db2.Close()
+  }

--- a/internal/injector/testdata/injector/import-shadowing/expected.diff
+++ b/internal/injector/testdata/injector/import-shadowing/expected.diff
@@ -1,0 +1,31 @@
+--- input.go
++++ output.go
+@@ -1,15 +1,25 @@
++//line input.go:1:1
+ package test
+ 
+ import (
+   "database/sql"
+-  "database/sql/driver"
++//line <generated>:1
++  __orchestrion_driver "database/sql/driver"
++  __orchestrion_sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
+ )
+ 
+-var conn driver.Connector
++//line input.go:8
++var conn __orchestrion_driver.Connector
+ 
+ func main() {
+   var driver string // shadowing import
+-  sql.Register("foo", nil)
++//line <generated>:1
++  func(driverName string, driver __orchestrion_driver.Driver) {
++    sql.Register(driverName, driver)
++    __orchestrion_sqltrace.Register(driverName, driver)
++  }(
++//line input.go:12
++    "foo", nil)
+ 
+   db1, err := sql.Open("foo", "bar")
+   if err != nil {


### PR DESCRIPTION
### What

Previously we would only check if the import was present in a fix. Now, we are checking if import is accessible as the import we are looking for.

### References

Fixes #458
Fixes #448 