### PR TITLE
fix: orchestrion fail to instrument if is not in the go.mod folder

### DIFF
--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -91,13 +91,12 @@ func (w Weaver) OnCompile(cmd *proxy.CompileCommand) (err error) {
 		err = writeLinkDeps(cmd, &linkDeps, orchestrionDir)
 	}()
 
-	var goModDir string
-	if goMod, err := goenv.GOMOD("."); err != nil {
-		return err
-	} else {
-		goModDir = filepath.Dir(goMod)
-		log.Tracef("Identified module directory: %s\n", goModDir)
+	goMod, err := goenv.GOMOD(".")
+	if err != nil {
+		return fmt.Errorf("go env GOMOD: %w", err)
 	}
+	goModDir := filepath.Dir(goMod)
+	log.Tracef("Identified module directory: %s\n", goModDir)
 
 	cfg, err := config.NewLoader(goModDir, false).Load()
 	if err != nil {

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/DataDog/orchestrion/internal/goenv"
 	"github.com/DataDog/orchestrion/internal/injector"
 	"github.com/DataDog/orchestrion/internal/injector/aspect"
 	"github.com/DataDog/orchestrion/internal/injector/config"
@@ -90,7 +91,15 @@ func (w Weaver) OnCompile(cmd *proxy.CompileCommand) (err error) {
 		err = writeLinkDeps(cmd, &linkDeps, orchestrionDir)
 	}()
 
-	cfg, err := config.NewLoader(".", false).Load()
+	var goModDir string
+	if goMod, err := goenv.GOMOD("."); err != nil {
+		return err
+	} else {
+		goModDir = filepath.Dir(goMod)
+		log.Tracef("Identified module directory: %s\n", goModDir)
+	}
+
+	cfg, err := config.NewLoader(goModDir, false).Load()
 	if err != nil {
 		return fmt.Errorf("loading injector configuration: %w", err)
 	}


### PR DESCRIPTION
Load the configuration from the module root instead of the current working directory, so that it no longer fails when building a package in a sub-directory.

Fixes #464