### PR TITLE
feat: improve context in error advice messages

### DIFF
--- a/internal/injector/aspect/advice/assign.go
+++ b/internal/injector/aspect/advice/assign.go
@@ -26,12 +26,12 @@ func AssignValue(template *code.Template) *assignValue {
 func (a *assignValue) Apply(ctx context.AdviceContext) (bool, error) {
 	spec, ok := ctx.Node().(*dst.ValueSpec)
 	if !ok {
-		return false, fmt.Errorf("expected *dst.ValueSpec, got %T", ctx.Node())
+		return false, fmt.Errorf("assign-value: expected *dst.ValueSpec, got %T", ctx.Node())
 	}
 
 	expr, err := a.Template.CompileExpression(ctx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("assign-value: %w", err)
 	}
 
 	spec.Values = make([]dst.Expr, len(spec.Names))

--- a/internal/injector/aspect/advice/block.go
+++ b/internal/injector/aspect/advice/block.go
@@ -29,12 +29,12 @@ func PrependStmts(template *code.Template) *prependStatements {
 func (a *prependStatements) Apply(ctx context.AdviceContext) (bool, error) {
 	block, ok := ctx.Node().(*dst.BlockStmt)
 	if !ok {
-		return false, fmt.Errorf("expected *dst.BlockStmt, got %T", ctx.Node())
+		return false, fmt.Errorf("prepend-statements: expected *dst.BlockStmt, got %T", ctx.Node())
 	}
 
 	stmts, err := a.Template.CompileBlock(ctx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("prepend-statements: %w", err)
 	}
 
 	list := make([]dst.Stmt, 1+len(block.List))

--- a/internal/injector/aspect/advice/call.go
+++ b/internal/injector/aspect/advice/call.go
@@ -32,7 +32,7 @@ func AppendArgs(typeName join.TypeName, templates ...*code.Template) *appendArgs
 func (a *appendArgs) Apply(ctx context.AdviceContext) (bool, error) {
 	call, ok := ctx.Node().(*dst.CallExpr)
 	if !ok {
-		return false, fmt.Errorf("expected a *dst.CallExpr, received %T", ctx.Node())
+		return false, fmt.Errorf("append-arguments: expected a *dst.CallExpr, received %T", ctx.Node())
 	}
 
 	newArgs := make([]dst.Expr, len(a.Templates))
@@ -40,7 +40,7 @@ func (a *appendArgs) Apply(ctx context.AdviceContext) (bool, error) {
 	for i, t := range a.Templates {
 		newArgs[i], err = t.CompileExpression(ctx)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("append-arguments[%d]: %w", i, err)
 		}
 		ctx.EnsureMinGoLang(t.Lang)
 	}

--- a/internal/injector/aspect/advice/inject.go
+++ b/internal/injector/aspect/advice/inject.go
@@ -6,6 +6,8 @@
 package advice
 
 import (
+	"fmt"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
@@ -26,7 +28,7 @@ func InjectDeclarations(template *code.Template, links []string) injectDeclarati
 func (a injectDeclarations) Apply(ctx context.AdviceContext) (bool, error) {
 	decls, err := a.Template.CompileDeclarations(ctx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("inject-declarations: %w", err)
 	}
 
 	if len(decls) == 0 {

--- a/internal/injector/aspect/advice/wrap.go
+++ b/internal/injector/aspect/advice/wrap.go
@@ -33,12 +33,12 @@ func (a *wrapExpression) Apply(ctx context.AdviceContext) (bool, error) {
 		ctx = ctx.Child(kve.Value, "Value", -1)
 		defer ctx.Release()
 	} else if _, ok = ctx.Node().(dst.Expr); !ok {
-		return false, fmt.Errorf("expected dst.Expr or *dst.KeyValueExpr, got %T", ctx.Node())
+		return false, fmt.Errorf("wrap-expression: expected dst.Expr or *dst.KeyValueExpr, got %T", ctx.Node())
 	}
 
 	repl, err := a.Template.CompileExpression(ctx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("wrap-expression: %w", err)
 	}
 
 	if kve == nil {

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -159,7 +159,7 @@ func (i *Injector) injectFile(decorator *decorator.Decorator, file *dst.File, ty
 	var err error
 	result.Modified, result.References, result.GoLang, err = i.applyAspects(decorator, file, i.RootConfig, typeInfo)
 	if err != nil {
-		return result, err
+		return result, fmt.Errorf("%q: %w", result.Filename, err)
 	}
 
 	if result.Modified {
@@ -239,14 +239,14 @@ func (i *Injector) injectNode(ctx context.AdviceContext) (mod bool, err error) {
 		if !inj.JoinPoint.Matches(ctx) {
 			continue
 		}
-		for _, act := range inj.Advice {
+		for idx, act := range inj.Advice {
 			var changed bool
 			changed, err = act.Apply(ctx)
 			if changed {
 				mod = true
 			}
 			if err != nil {
-				return
+				return mod, fmt.Errorf("%q[%d]: %w", inj.ID, idx, err)
 			}
 		}
 	}


### PR DESCRIPTION
Provide more context information in the error messages propagated from advice application errors, so that they are easier to troubleshoot. These messages aim to provide a lineage that allows maintainers to know exactly what advice failed, on what file.