### PR TITLE
feat(injector: join): signature-contains

### DIFF
--- a/internal/injector/aspect/join/function.go
+++ b/internal/injector/aspect/join/function.go
@@ -217,6 +217,40 @@ func (fo *signature) Hash(h *fingerprint.Hasher) error {
 	)
 }
 
+type signatureContains struct {
+	signature
+}
+
+// SignatureContains matches function declarations based on their arguments and
+// return value types in any order and does not require all arguments or return values to be present.
+func SignatureContains(args []TypeName, ret []TypeName) FunctionOption {
+	return &signatureContains{signature{Arguments: args, Results: ret}}
+}
+
+func (fo *signatureContains) Hash(h *fingerprint.Hasher) error {
+	return h.Named(
+		"signature-contains",
+		fingerprint.List[TypeName](fo.Arguments),
+		fingerprint.List[TypeName](fo.Results),
+	)
+}
+
+func (fo *signatureContains) evaluate(info functionInformation) bool {
+	for i := 0; i < len(fo.Results); i++ {
+		if fo.Results[i].Matches(info.Type.Results.List[i].Type) {
+			return true
+		}
+	}
+
+	for i := 0; i < len(fo.Arguments); i++ {
+		if fo.Arguments[i].Matches(info.Type.Params.List[i].Type) {
+			return true
+		}
+	}
+
+	return false
+}
+
 type receiver struct {
 	TypeName TypeName
 }
@@ -354,7 +388,7 @@ func (o *unmarshalFuncDeclOption) UnmarshalYAML(node *yaml.Node) error {
 			return err
 		}
 		o.FunctionOption = Receiver(tn)
-	case "signature":
+	case "signature", "signature-contains":
 		var sig struct {
 			Extra map[string]yaml.Node `yaml:",inline"`
 			Args  []string             `yaml:"args"`
@@ -393,7 +427,12 @@ func (o *unmarshalFuncDeclOption) UnmarshalYAML(node *yaml.Node) error {
 			}
 		}
 
-		o.FunctionOption = Signature(args, ret)
+		switch key {
+		case "signature":
+			o.FunctionOption = Signature(args, ret)
+		case "signature-contains":
+			o.FunctionOption = SignatureContains(args, ret)
+		}
 	default:
 		return fmt.Errorf("line %d: unknown FuncDeclOption name: %q", node.Content[0].Line, key)
 	}

--- a/internal/injector/aspect/join/function.go
+++ b/internal/injector/aspect/join/function.go
@@ -236,15 +236,31 @@ func (fo *signatureContains) Hash(h *fingerprint.Hasher) error {
 }
 
 func (fo *signatureContains) evaluate(info functionInformation) bool {
-	for i := 0; i < len(fo.Results); i++ {
-		if fo.Results[i].Matches(info.Type.Results.List[i].Type) {
-			return true
-		}
+	if containsAnyType(fo.Results, info.Type.Results) {
+		return true
 	}
 
-	for i := 0; i < len(fo.Arguments); i++ {
-		if fo.Arguments[i].Matches(info.Type.Params.List[i].Type) {
-			return true
+	if containsAnyType(fo.Arguments, info.Type.Params) {
+		return true
+	}
+
+	return false
+}
+
+// containsAnyType checks if any of the expected types match any of the actual types in the field list.
+// Returns false if either slice is empty or nil.
+func containsAnyType(expectedTypes []TypeName, fieldList *dst.FieldList) bool {
+	// Quick return if either side is empty.
+	if len(expectedTypes) == 0 || fieldList == nil || len(fieldList.List) == 0 {
+		return false
+	}
+
+	// Check if any expected type matches any actual type.
+	for _, expected := range expectedTypes {
+		for _, actual := range fieldList.List {
+			if expected.Matches(actual.Type) {
+				return true
+			}
 		}
 	}
 

--- a/internal/injector/aspect/join/function_test.go
+++ b/internal/injector/aspect/join/function_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package join
+
+import (
+	"testing"
+
+	"github.com/dave/dst"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
+)
+
+func TestSignatureContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []TypeName
+		ret      []TypeName
+		funcInfo functionInformation
+		want     bool
+	}{
+		{
+			name: "single argument matches",
+			args: []TypeName{
+				{name: "string"},
+			},
+			ret: make([]TypeName, 0),
+			funcInfo: functionInformation{
+				Type: &dst.FuncType{
+					Params: &dst.FieldList{
+						List: []*dst.Field{
+							{Type: &dst.Ident{Name: "string"}},
+							{Type: &dst.Ident{Name: "int"}},
+						},
+					},
+					Results: &dst.FieldList{
+						List: make([]*dst.Field, 0),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "single return matches",
+			args: make([]TypeName, 0),
+			ret: []TypeName{
+				{name: "error"},
+			},
+			funcInfo: functionInformation{
+				Type: &dst.FuncType{
+					Params: &dst.FieldList{
+						List: make([]*dst.Field, 0),
+					},
+					Results: &dst.FieldList{
+						List: []*dst.Field{
+							{Type: &dst.Ident{Name: "error"}},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "argument in any position matches",
+			args: []TypeName{
+				{name: "string"},
+			},
+			ret: make([]TypeName, 0),
+			funcInfo: functionInformation{
+				Type: &dst.FuncType{
+					Params: &dst.FieldList{
+						List: []*dst.Field{
+							{Type: &dst.Ident{Name: "int"}},
+							{Type: &dst.Ident{Name: "string"}},
+						},
+					},
+					Results: &dst.FieldList{
+						List: make([]*dst.Field, 0),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "return in any position matches",
+			args: make([]TypeName, 0),
+			ret: []TypeName{
+				{name: "error"},
+			},
+			funcInfo: functionInformation{
+				Type: &dst.FuncType{
+					Params: &dst.FieldList{
+						List: make([]*dst.Field, 0),
+					},
+					Results: &dst.FieldList{
+						List: []*dst.Field{
+							{Type: &dst.Ident{Name: "string"}},
+							{Type: &dst.Ident{Name: "error"}},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no match for empty fields",
+			args: []TypeName{
+				{name: "string"},
+			},
+			ret: make([]TypeName, 0),
+			funcInfo: functionInformation{
+				Type: &dst.FuncType{
+					Params:  nil,
+					Results: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no match for different type",
+			args: []TypeName{
+				{name: "float64"},
+			},
+			ret: []TypeName{
+				{name: "byte"},
+			},
+			funcInfo: functionInformation{
+				Type: &dst.FuncType{
+					Params: &dst.FieldList{
+						List: []*dst.Field{
+							{Type: &dst.Ident{Name: "string"}},
+						},
+					},
+					Results: &dst.FieldList{
+						List: []*dst.Field{
+							{Type: &dst.Ident{Name: "error"}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "complex type match",
+			args: []TypeName{
+				{name: "CustomType", path: "pkg"},
+			},
+			ret: make([]TypeName, 0),
+			funcInfo: functionInformation{
+				Type: &dst.FuncType{
+					Params: &dst.FieldList{
+						List: []*dst.Field{
+							{
+								Type: &dst.SelectorExpr{
+									X:   &dst.Ident{Name: "pkg"},
+									Sel: &dst.Ident{Name: "CustomType"},
+								},
+							},
+						},
+					},
+					Results: &dst.FieldList{
+						List: make([]*dst.Field, 0),
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fo := SignatureContains(tt.args, tt.ret)
+			got := fo.(*signatureContains).evaluate(tt.funcInfo)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSignatureContainsHash(t *testing.T) {
+	args := []TypeName{{name: "string"}, {name: "int"}}
+	ret := []TypeName{{name: "error"}}
+
+	fo := SignatureContains(args, ret)
+
+	h1 := fingerprint.New()
+	err := fo.Hash(h1)
+	require.NoError(t, err, "Hash failed")
+
+	fp1 := h1.Finish()
+
+	fo2 := SignatureContains(args, ret)
+	h2 := fingerprint.New()
+	err = fo2.Hash(h2)
+	require.NoError(t, err, "Hash failed")
+
+	fp2 := h2.Finish()
+
+	assert.Equal(t, fp1, fp2, "Hash() gave different results for identical signatures")
+
+	fo3 := SignatureContains([]TypeName{{name: "float64"}}, ret)
+	h3 := fingerprint.New()
+	err = fo3.Hash(h3)
+	require.NoError(t, err, "Hash failed")
+
+	fp3 := h3.Finish()
+
+	assert.NotEqual(t, fp1, fp3, "Hash() gave same result for different signatures")
+}
+
+func TestUnmarshalYAMLSignatureContains(t *testing.T) {
+	yamlStr := `
+signature-contains:
+  args: [string, error]
+  returns: [bool]
+`
+
+	var option unmarshalFuncDeclOption
+	err := yaml.Unmarshal([]byte(yamlStr), &option)
+	require.NoError(t, err, "Failed to unmarshal YAML")
+
+	signatureContains, ok := option.FunctionOption.(*signatureContains)
+	require.True(t, ok, "Expected *signatureContains, got %T", option.FunctionOption)
+
+	require.Len(t, signatureContains.Arguments, 2, "Expected 2 arguments")
+	assert.Equal(t, "string", signatureContains.Arguments[0].Name(), "First argument should be string")
+	assert.Equal(t, "error", signatureContains.Arguments[1].Name(), "Second argument should be error")
+
+	require.Len(t, signatureContains.Results, 1, "Expected 1 result")
+	assert.Equal(t, "bool", signatureContains.Results[0].Name(), "Result should be bool")
+}

--- a/internal/injector/testdata/injector/signature-contains/config.yml
+++ b/internal/injector/testdata/injector/signature-contains/config.yml
@@ -1,0 +1,67 @@
+%YAML 1.1
+---
+aspects:
+  - join-point:
+      function-body:
+        function:
+          - signature-contains:
+              args: [context.Context]
+              returns: [error]
+    advice:
+      - prepend-statements:
+          imports:
+            tracer: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer
+          template: |-
+            {{ $ctx := .Function.ArgumentOfType "context.Context" -}}
+            {{- if (eq $ctx "") -}}
+              {{- $ctx = "ctx" -}}
+              ctx := context.TODO()
+            {{ end -}}
+
+            var span tracer.Span
+            span, {{ $ctx }} = tracer.StartSpanFromContext({{ $ctx }}, {{ printf "%q" .Function.Name }},
+              tracer.Tag("function-name", {{ printf "%q" .Function.Name }}),
+            )
+
+            {{ with .Function.ResultOfType "error" -}}
+              defer func() {
+                span.Finish(tracer.WithError({{ . }}))
+              }()
+            {{ else -}}
+              defer span.Finish()
+            {{- end -}}
+
+syntheticReferences:
+  gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer: true
+
+code: |-
+  package test
+
+  import (
+    "context"
+  )
+
+  // Matches both: has context in args and error in returns
+  func withContextAndError(ctx context.Context, data []byte) (string, error) {
+    return "", nil
+  }
+
+  // Matches both: has context in middle of args and error in returns
+  func withContextInMiddle(data []byte, ctx context.Context, moreData []byte) (string, error) {
+    return "", nil
+  }
+
+  // Matches only error return (multiple returns)
+  func onlyError(data []byte) (string, error) {
+    return "", nil
+  }
+
+  // Matches only context argument (multiple args)
+  func onlyContext(data []byte, ctx context.Context, moreData []byte) string {
+    return ""
+  }
+
+  // Matches neither
+  func noMatch(data []byte) string {
+    return ""
+  }

--- a/internal/injector/testdata/injector/signature-contains/modified.go.snap
+++ b/internal/injector/testdata/injector/signature-contains/modified.go.snap
@@ -1,0 +1,85 @@
+//line input.go:1:1
+package test
+
+import (
+  "context"
+//line <generated>:1
+  __orchestrion_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// Matches both: has context in args and error in returns
+//
+//line input.go:8
+func withContextAndError(ctx context.Context, data []byte) (_ string, __result__1 error) {
+//line <generated>:1
+  {
+    var span __orchestrion_tracer.Span
+    span, ctx = __orchestrion_tracer.StartSpanFromContext(ctx, "withContextAndError",
+      __orchestrion_tracer.Tag("function-name", "withContextAndError"),
+    )
+
+    defer func() {
+      span.Finish(__orchestrion_tracer.WithError(__result__1))
+    }()
+
+  }
+//line input.go:9
+  return "", nil
+}
+
+// Matches both: has context in middle of args and error in returns
+func withContextInMiddle(data []byte, ctx context.Context, moreData []byte) (_ string, __result__1 error) {
+//line <generated>:1
+  {
+    var span __orchestrion_tracer.Span
+    span, ctx = __orchestrion_tracer.StartSpanFromContext(ctx, "withContextInMiddle",
+      __orchestrion_tracer.Tag("function-name", "withContextInMiddle"),
+    )
+
+    defer func() {
+      span.Finish(__orchestrion_tracer.WithError(__result__1))
+    }()
+
+  }
+//line input.go:14
+  return "", nil
+}
+
+// Matches only error return (multiple returns)
+func onlyError(data []byte) (_ string, __result__1 error) {
+//line <generated>:1
+  {
+    ctx := context.TODO()
+    var span __orchestrion_tracer.Span
+    span, ctx = __orchestrion_tracer.StartSpanFromContext(ctx, "onlyError",
+      __orchestrion_tracer.Tag("function-name", "onlyError"),
+    )
+
+    defer func() {
+      span.Finish(__orchestrion_tracer.WithError(__result__1))
+    }()
+
+  }
+//line input.go:19
+  return "", nil
+}
+
+// Matches only context argument (multiple args)
+func onlyContext(data []byte, ctx context.Context, moreData []byte) string {
+//line <generated>:1
+  {
+    var span __orchestrion_tracer.Span
+    span, ctx = __orchestrion_tracer.StartSpanFromContext(ctx, "onlyContext",
+      __orchestrion_tracer.Tag("function-name", "onlyContext"),
+    )
+
+    defer span.Finish()
+  }
+//line input.go:24
+  return ""
+}
+
+// Matches neither
+func noMatch(data []byte) string {
+  return ""
+}


### PR DESCRIPTION
Adds flexible function signature matching to support partial and order-independent type matching. 

This enables simpler instrumentation configuration when targeting functions that share common types (e.g. context.Context or error) regardless of their position or other parameters. 

The change simplifies instrumentation configuration by reducing the need for multiple matchers when targeting related function groups

## Changes

- Added SignatureContains matcher that checks for presence of types anywhere in function signatures
- Supports matching on partial argument/return types without requiring exact matches
- Added tests 