### PR TITLE
feat: never build twice

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -335,6 +335,7 @@ jobs:
         env:
           GOCOVERDIR: ${{ github.workspace }}/coverage/raw
           GOFLAGS: ${{ matrix.runs-on == 'ubuntu' && '-p=4' || ''}} -tags=githubci,integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
+          ORCHESTRION_LOG_LEVEL: warn
       - name: Consolidate coverage report
         if: github.event_name != 'merge_group' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
         run: go tool covdata textfmt -i ./coverage/raw -o ./coverage/integration.out

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -335,7 +335,14 @@ jobs:
         env:
           GOCOVERDIR: ${{ github.workspace }}/coverage/raw
           GOFLAGS: ${{ matrix.runs-on == 'ubuntu' && '-p=4' || ''}} -tags=githubci,integration,buildtag # Globally set build tags (buildtag is used by the dd-span test)
-          ORCHESTRION_LOG_LEVEL: warn
+          ORCHESTRION_LOG_LEVEL: trace
+          ORCHESTRION_LOG_FILE: ${{ runner.temp }}/orchestrion.log
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: integration+${{ matrix.build-mode }}+go@${{ matrix.go-version }}+${{ runner.os }}+${{ runner.arch }}.orchestrion.log
+          path: ${{ runner.temp }}/orchestrion.log
       - name: Consolidate coverage report
         if: github.event_name != 'merge_group' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
         run: go tool covdata textfmt -i ./coverage/raw -o ./coverage/integration.out

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dave/dst v0.27.3
 	github.com/dave/jennifer v1.7.1
 	github.com/fsnotify/fsnotify v1.8.0
+	github.com/google/uuid v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/nats-io/nats-server/v2 v2.10.24
 	github.com/nats-io/nats.go v1.38.0
@@ -119,7 +120,6 @@ require (
 	github.com/gomodule/redigo v1.9.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/graph-gophers/graphql-go v1.5.0 // indirect
 	github.com/graphql-go/graphql v0.8.1 // indirect

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -61,6 +61,14 @@ var Server = &cli.Command{
 				return nil
 			},
 		},
+		&cli.IntFlag{
+			Name:        "parent-pid",
+			Usage:       "Specify which process created this server. This is useful when the server is started as a daemon, as it needs to be able to resolve the top-level go command line.",
+			DefaultText: "This process' parent (may be inaccurate if the process is daemonized)",
+			Action: func(ctx *cli.Context, val int) error {
+				return goflags.SetFlagsFromPid(ctx.Context, val)
+			},
+		},
 	},
 	Hidden: true,
 	Action: func(ctx *cli.Context) error {

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -24,14 +24,14 @@ var Toolexec = &cli.Command{
 	UsageText:       "orchestrion toolexec [tool] [tool args...]",
 	Args:            true,
 	SkipFlagParsing: true,
-	Action: func(ctx *cli.Context) error {
+	Action: func(ctx *cli.Context) (resErr error) {
 		log := zerolog.Ctx(ctx.Context)
 
 		proxyCmd, err := proxy.ParseCommand(ctx.Args().Slice())
 		if err != nil {
 			return err
 		}
-		defer proxyCmd.Close()
+		defer func() { proxyCmd.Close(resErr) }()
 
 		if proxyCmd.Type() == proxy.CommandTypeOther {
 			// Immediately run the command if it's of the Other type, as we do not do

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -56,19 +56,19 @@ var Toolexec = &cli.Command{
 		log.Trace().Strs("command", proxyCmd.Args()).Msg("Toolexec original command")
 		weaver := aspect.Weaver{ImportPath: os.Getenv("TOOLEXEC_IMPORTPATH")}
 
-		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompile); errors.Is(err, proxy.SkipCommand) {
+		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompile); errors.Is(err, proxy.ErrSkipCommand) {
 			log.Info().Msg("OnCompile processor requested command skipping...")
 			return nil
 		} else if err != nil {
 			return err
 		}
-		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompileMain); errors.Is(err, proxy.SkipCommand) {
+		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompileMain); errors.Is(err, proxy.ErrSkipCommand) {
 			log.Info().Msg("OnCompileMain processor requested command skipping...")
 			return nil
 		} else if err != nil {
 			return err
 		}
-		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnLink); errors.Is(err, proxy.SkipCommand) {
+		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnLink); errors.Is(err, proxy.ErrSkipCommand) {
 			log.Info().Msg("OnLink processor requested command skipping...")
 			return nil
 		} else if err != nil {

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -36,6 +36,7 @@ var Toolexec = &cli.Command{
 		if proxyCmd.Type() == proxy.CommandTypeOther {
 			// Immediately run the command if it's of the Other type, as we do not do
 			// any kind of processing on these...
+			log.Trace().Strs("command", proxyCmd.Args()).Msg("Toolexec fast-forward command")
 			return proxy.RunCommand(proxyCmd)
 		}
 
@@ -53,32 +54,32 @@ var Toolexec = &cli.Command{
 			return err
 		}
 
-		log.Trace().Strs("command", proxyCmd.Args()).Msg("Toolexec original command")
+		log.Info().Strs("command", proxyCmd.Args()).Msg("Toolexec original command")
 		weaver := aspect.Weaver{ImportPath: os.Getenv("TOOLEXEC_IMPORTPATH")}
 
 		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompile); errors.Is(err, proxy.ErrSkipCommand) {
-			log.Info().Msg("OnCompile processor requested command skipping...")
+			log.Trace().Msg("OnCompile processor requested command skipping...")
 			return nil
 		} else if err != nil {
 			return err
 		}
 		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompileMain); errors.Is(err, proxy.ErrSkipCommand) {
-			log.Info().Msg("OnCompileMain processor requested command skipping...")
+			log.Trace().Msg("OnCompileMain processor requested command skipping...")
 			return nil
 		} else if err != nil {
 			return err
 		}
 		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnLink); errors.Is(err, proxy.ErrSkipCommand) {
-			log.Info().Msg("OnLink processor requested command skipping...")
+			log.Trace().Msg("OnLink processor requested command skipping...")
 			return nil
 		} else if err != nil {
 			return err
 		}
 
-		log.Trace().Strs("command", proxyCmd.Args()).Msg("Toolexec final command")
+		log.Debug().Strs("command", proxyCmd.Args()).Msg("Toolexec final command")
 		if err := proxy.RunCommand(proxyCmd); err != nil {
 			// Logging as debug, as the error will likely surface back to the user anyway...
-			log.Debug().Err(err).Msg("Proxied command failed")
+			log.Error().Strs("command", proxyCmd.Args()).Err(err).Msg("Proxied command failed")
 			return err
 		}
 		return nil

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -36,8 +36,15 @@ var Toolexec = &cli.Command{
 		if proxyCmd.Type() == proxy.CommandTypeOther {
 			// Immediately run the command if it's of the Other type, as we do not do
 			// any kind of processing on these...
-			log.Trace().Strs("command", proxyCmd.Args()).Msg("Toolexec fast-forward command")
-			return proxy.RunCommand(proxyCmd)
+			err := proxy.RunCommand(proxyCmd)
+			var event *zerolog.Event
+			if err != nil {
+				event = log.Error().Err(err)
+			} else {
+				event = log.Trace()
+			}
+			event.Strs("command", proxyCmd.Args()).Msg("Toolexec fast-forward command")
+			return err
 		}
 
 		// Ensure Orchestrion is properly pinned

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -55,13 +56,22 @@ var Toolexec = &cli.Command{
 		log.Trace().Strs("command", proxyCmd.Args()).Msg("Toolexec original command")
 		weaver := aspect.Weaver{ImportPath: os.Getenv("TOOLEXEC_IMPORTPATH")}
 
-		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompile); err != nil {
+		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompile); errors.Is(err, proxy.SkipCommand) {
+			log.Info().Msg("OnCompile processor requested command skipping...")
+			return nil
+		} else if err != nil {
 			return err
 		}
-		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompileMain); err != nil {
+		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnCompileMain); errors.Is(err, proxy.SkipCommand) {
+			log.Info().Msg("OnCompileMain processor requested command skipping...")
+			return nil
+		} else if err != nil {
 			return err
 		}
-		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnLink); err != nil {
+		if err := proxy.ProcessCommand(ctx.Context, proxyCmd, weaver.OnLink); errors.Is(err, proxy.SkipCommand) {
+			log.Info().Msg("OnLink processor requested command skipping...")
+			return nil
+		} else if err != nil {
 			return err
 		}
 

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package files
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/rs/zerolog"
+)
+
+func LinkOrCopy(ctx context.Context, oldname string, newname string) error {
+	err := os.Link(oldname, newname)
+	if err == nil {
+		return nil
+	}
+	log := zerolog.Ctx(ctx)
+	log.Info().
+		Str("oldname", oldname).
+		Str("newname", newname).
+		Err(err).
+		Msg("Could not hard link archive; attempting a copy instead...")
+
+		// Hard link can fail (e.g, if the original file & storage dir are not on the
+	// same file system). In those cases, we create a full copy of the file.
+	in, err := os.Open(oldname)
+	if err != nil {
+		return fmt.Errorf("open %q: %w", oldname, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(newname)
+	if err != nil {
+		return fmt.Errorf("create %q: %w", newname, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %q to %q: %w", oldname, newname, err)
+	}
+
+	return nil
+}

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -289,6 +289,7 @@ func parentGoCommandFlags(ctx context.Context) (flags CommandFlags, err error) {
 	if err != nil {
 		return flags, fmt.Errorf("failed to resolve go command path: %w", err)
 	}
+	log.Trace().Str("go.bin", goBin).Msg("Resolved go command path")
 
 	p, err := process.NewProcess(int32(os.Getpid()))
 	if err != nil {
@@ -330,6 +331,8 @@ func parentGoCommandFlags(ctx context.Context) (flags CommandFlags, err error) {
 		if cmd == goBin {
 			break
 		}
+
+		log.Trace().Int32("process.pid", p.Pid).Strs("args", args).Msg("Not a go command process, continuing backtracking")
 	}
 
 	log.Trace().Int32("go.pid", p.Pid).Strs("arguments", args).Msg("Found parent go command process")

--- a/internal/jobserver/buildid/version.go
+++ b/internal/jobserver/buildid/version.go
@@ -35,13 +35,10 @@ type (
 	VersionSuffixResponse string
 )
 
-func (*VersionSuffixRequest) Subject() string {
-	return versionSubject
-}
+func (VersionSuffixRequest) Subject() string                  { return versionSubject }
+func (VersionSuffixRequest) ResponseIs(VersionSuffixResponse) {}
 
-func (VersionSuffixResponse) IsResponseTo(*VersionSuffixRequest) {}
-
-func (s *service) versionSuffix(ctx context.Context, _ *VersionSuffixRequest) (VersionSuffixResponse, error) {
+func (s *service) versionSuffix(ctx context.Context, _ VersionSuffixRequest) (VersionSuffixResponse, error) {
 	log := zerolog.Ctx(ctx)
 
 	s.mu.Lock()

--- a/internal/jobserver/client/client.go
+++ b/internal/jobserver/client/client.go
@@ -43,12 +43,13 @@ func (c *Client) Close() {
 }
 
 type (
-	request interface {
+	request[Res any] interface {
 		Subject() string
+		common.Request[Res]
 	}
 )
 
-func Request[Req request, Res common.ResponseTo[Req]](ctx context.Context, client *Client, req Req) (Res, error) {
+func Request[Res any, Req request[Res]](ctx context.Context, client *Client, req Req) (Res, error) {
 	reqData, err := json.Marshal(req)
 	if err != nil {
 		var zero Res

--- a/internal/jobserver/client/env.go
+++ b/internal/jobserver/client/env.go
@@ -67,7 +67,11 @@ func FromEnvironment(ctx context.Context, workDir string) (*Client, error) {
 
 	// Try to start a server. The server process is idempotent if the `-url-file` flag is used, so we do not check the
 	// command's exit status, because another process might act as our server down the line.
-	cmd := exec.Command(binpath.Orchestrion, "server", "-inactivity-timeout=15m", fmt.Sprintf("-url-file=%s", urlFilePath))
+	cmd := exec.Command(binpath.Orchestrion, "server",
+		"-inactivity-timeout=15m",
+		fmt.Sprintf("-url-file=%s", urlFilePath),
+		fmt.Sprintf("-parent-pid=%d", os.Getpid()),
+	)
 	cmd.SysProcAttr = &sysProcAttrDaemon                   // Make sure go doesn't wait for this to exit...
 	cmd.Env = append(os.Environ(), "TOOLEXEC_IMPORTPATH=") // Suppress the TOOLEXEC_IMPORTPATH variable if it's set.
 	cmd.Stdin = nil                                        // Connect to `os.DevNull`

--- a/internal/jobserver/nbt/nbt.go
+++ b/internal/jobserver/nbt/nbt.go
@@ -117,8 +117,8 @@ const (
 	LabelAsmhdr  Label = "go_asm.h"
 )
 
-func (StartRequest) Subject() string             { return startSubject }
-func (*StartResponse) IsResponseTo(StartRequest) {}
+func (StartRequest) Subject() string           { return startSubject }
+func (StartRequest) ResponseIs(*StartResponse) {}
 
 func (s *service) start(ctx context.Context, req StartRequest) (*StartResponse, error) {
 	if req.ImportPath == "" || req.BuildID == "" {
@@ -183,8 +183,8 @@ type (
 	}
 )
 
-func (FinishRequest) Subject() string              { return finishSubject }
-func (*FinishResponse) IsResponseTo(FinishRequest) {}
+func (FinishRequest) Subject() string            { return finishSubject }
+func (FinishRequest) ResponseIs(*FinishResponse) {}
 
 var errNoFilesNorError = errors.New("missing files, and no error reported")
 
@@ -214,7 +214,7 @@ func (s *service) finish(ctx context.Context, req FinishRequest) (*FinishRespons
 
 	if !state.isDone.CompareAndSwap(false, true) {
 		log.Info().Msg("Task was already completed (concurrent retry?)")
-		return &FinishResponse{}, nil
+		return nil, nil
 	}
 
 	defer state.onDone()

--- a/internal/jobserver/nbt/nbt.go
+++ b/internal/jobserver/nbt/nbt.go
@@ -1,0 +1,225 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package nbt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/DataDog/orchestrion/internal/files"
+	"github.com/DataDog/orchestrion/internal/jobserver/common"
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog"
+)
+
+const (
+	subjectPrefix = "never-build-twice."
+
+	startSubject  = subjectPrefix + "start"
+	finishSubject = subjectPrefix + "finish"
+)
+
+type (
+	service struct {
+		state sync.Map
+		dir   string
+	}
+	buildState struct {
+		initOnce sync.Once
+		token    string          // Finalization token
+		onDone   func()          // Called once the original task has completed
+		done     <-chan struct{} // Blocks until the original task has completed
+
+		isDone  atomic.Bool // Whether the original task has completed yet.
+		archive string      // Path to the archive produced by the original task. Available once done.
+		error   error       // Error from the original task. Available once done.
+	}
+)
+
+func Subscribe(ctx context.Context, conn *nats.Conn) (cleanup func(context.Context) error, resErr error) {
+	dir, err := os.MkdirTemp("", "orchestrion.nbt-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating storage directory: %w", err)
+	}
+	defer func() {
+		if resErr == nil {
+			return
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			resErr = errors.Join(resErr, err)
+		}
+	}()
+
+	s := &service{dir: dir}
+	_, err = conn.Subscribe(startSubject,
+		common.HandleRequest(
+			zerolog.Ctx(ctx).With().Str("nats.subject", startSubject).Logger().WithContext(ctx),
+			s.start,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = conn.Subscribe(finishSubject,
+		common.HandleRequest(
+			zerolog.Ctx(ctx).With().Str("nats.subject", finishSubject).Logger().WithContext(ctx),
+			s.finish,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup = func(context.Context) error { return os.RemoveAll(dir) }
+	return cleanup, nil
+}
+
+type (
+	// StartRequest informs the job server that the caller is starting a new
+	// compilation task for the specified [StartRequest.ImportPath].
+	StartRequest struct {
+		ImportPath string
+	}
+	// StartResponse informs the caller about what should be done with the
+	// compilation task. If a [*StartResponse.FinishToken] is present, the caller
+	// must proceed with the task, then send a [FinishRequest] using that token.
+	// If a [*StartResponse.ArchivePath] is present, the caller must skip the task
+	// and instead re-use the file at the specified path.
+	StartResponse struct {
+		// FinishToken is the token to be forwarded to the [FinishRequest] to inform
+		// the job server about the outcome of the build. It cannot be blank unless
+		// [*StartResponse.ArchivePath] is not blank.
+		FinishToken string `json:",omitempty"`
+		// ArchivePath is the path of the archive produced for the same
+		// [StartRequest.ImportPath] by another task. That archive must be re-used
+		// instead of creating a new one. It cannot be blank unless
+		// [*StartResponse.FinishToken] is not blank.
+		ArchivePath string `json:",omitempty"`
+	}
+)
+
+func (StartRequest) Subject() string             { return startSubject }
+func (*StartResponse) IsResponseTo(StartRequest) {}
+
+func (s *service) start(ctx context.Context, req StartRequest) (*StartResponse, error) {
+	rawState, reused := s.state.LoadOrStore(req.ImportPath, &buildState{})
+	state, _ := rawState.(*buildState)
+
+	// Initialize the build state.
+	state.initOnce.Do(func() {
+		state.token = uuid.NewString()
+		// We use a cancellable context as a barrier here...
+		ctx, isDone := context.WithCancel(ctx)
+		state.done = ctx.Done()
+		state.onDone = isDone
+	})
+
+	// If the build state is re-used, wait for the original to complete...
+	if reused {
+		<-state.done
+		if state.error != nil {
+			return nil, state.error
+		}
+		return &StartResponse{ArchivePath: state.archive}, nil
+	}
+
+	// Otherwise, return a finalization token, etc...
+	return &StartResponse{FinishToken: state.token}, nil
+}
+
+type (
+	// FinishRequest informs the job server about the result of a compilation
+	// task.
+	FinishRequest struct {
+		// ImportPath is the import path of the package that was built.
+		ImportPath string
+		// FinishToken is forwarded from [*StartResponse.FinishToken], and cannot be
+		// blank.
+		FinishToken string
+		// ArchivePath is the path to the archive produced by the compilation task.
+		// It must not be blank unless [FinishRequest.Error] is not nil. If present,
+		// the file must exist on disk, and will be hard-linked (or copied) into a
+		// temporary directory so it can be re-used by subsequent [StartRequest] for
+		// the same [FinishRequest.ImportPath].
+		ArchivePath string `json:",omitempty"`
+		// Error is the error that occurred as a result of this compilation task, if
+		// any.
+		Error *string `json:",omitempty"`
+	}
+	FinishResponse struct {
+		/* unused */
+	}
+)
+
+func (FinishRequest) Subject() string              { return finishSubject }
+func (*FinishResponse) IsResponseTo(FinishRequest) {}
+
+var errNoArchiveNorError = errors.New("missing archive path, and no error reported")
+
+func (s *service) finish(ctx context.Context, req FinishRequest) (*FinishResponse, error) {
+	rawState, found := s.state.Load(req.ImportPath)
+	if !found {
+		return nil, fmt.Errorf("no build started for %q", req.ImportPath)
+	}
+
+	log := zerolog.Ctx(ctx)
+
+	state, _ := rawState.(*buildState)
+	if state.token != req.FinishToken {
+		log.Warn().
+			Str("expected", state.token).
+			Str("actual", req.FinishToken).
+			Str("import-path", req.ImportPath).
+			Msg("Invalid finish token")
+		return nil, fmt.Errorf("invalid finish token for %q: %q", req.ImportPath, req.FinishToken)
+	}
+
+	if !state.isDone.CompareAndSwap(false, true) {
+		log.Info().
+			Str("import-path", req.ImportPath).
+			Msg("Task was already completed (concurrent retry?)")
+		return &FinishResponse{}, nil
+	}
+
+	defer state.onDone()
+
+	if req.Error != nil {
+		state.error = errors.New(*req.Error)
+	} else if req.ArchivePath == "" {
+		state.error = errNoArchiveNorError
+		return nil, state.error
+	} else if file, err := s.persist(ctx, req.ImportPath, req.ArchivePath); err != nil {
+		state.error = fmt.Errorf("persisting archive %q: %w", req.ArchivePath, err)
+		return nil, state.error
+	} else {
+		state.archive = file
+	}
+
+	return &FinishResponse{}, nil
+}
+
+var ns = uuid.New()
+
+func (s *service) persist(ctx context.Context, name string, path string) (string, error) {
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %q: %w", s.dir, err)
+	}
+
+	guid := uuid.NewSHA1(ns, []byte(name)).String()
+	res := filepath.Join(s.dir, guid)
+
+	if err := files.LinkOrCopy(ctx, path, res); err != nil {
+		return "", err
+	}
+	return res, nil
+}

--- a/internal/jobserver/nbt/nbt_test.go
+++ b/internal/jobserver/nbt/nbt_test.go
@@ -1,0 +1,196 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package nbt
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		var cancel func()
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+	}
+
+	t.Run("not-started", func(t *testing.T) {
+		subject := &service{dir: t.TempDir()}
+		res, err := subject.finish(ctx, FinishRequest{})
+		require.ErrorContains(t, err, "no build started")
+		require.Nil(t, res)
+	})
+
+	t.Run("start-reuse-finish", func(t *testing.T) {
+		const importPath = "github.com/DataDog/orchestrion.test"
+		subject := &service{dir: t.TempDir()}
+
+		start, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+		require.NoError(t, err)
+		require.NotEmpty(t, start.FinishToken)
+		assert.Empty(t, start.ArchivePath)
+
+		archiveContent := uuid.NewString()
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+				require.NoError(t, err)
+				assert.Empty(t, res.FinishToken)
+				require.NotEmpty(t, res.ArchivePath)
+
+				content, err := os.ReadFile(res.ArchivePath)
+				require.NoError(t, err)
+				assert.Equal(t, archiveContent, string(content))
+			}()
+		}
+
+		archive := filepath.Join(t.TempDir(), "_pkg_.a")
+		require.NoError(t, os.WriteFile(archive, []byte(archiveContent), 0o644))
+
+		res, err := subject.finish(ctx, FinishRequest{
+			ImportPath:  importPath,
+			FinishToken: start.FinishToken,
+			ArchivePath: archive,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("start-finish-finish", func(t *testing.T) {
+		const importPath = "github.com/DataDog/orchestrion.test"
+		subject := &service{dir: t.TempDir()}
+
+		start, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+		require.NoError(t, err)
+		require.NotEmpty(t, start.FinishToken)
+		assert.Empty(t, start.ArchivePath)
+
+		archiveContent := uuid.NewString()
+		archive := filepath.Join(t.TempDir(), "_pkg_.a")
+		require.NoError(t, os.WriteFile(archive, []byte(archiveContent), 0o644))
+
+		for range 10 {
+			res, err := subject.finish(ctx, FinishRequest{
+				ImportPath:  importPath,
+				FinishToken: start.FinishToken,
+				ArchivePath: archive,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, res)
+		}
+	})
+
+	t.Run("start-reuse-error", func(t *testing.T) {
+		const importPath = "github.com/DataDog/orchestrion.test"
+		subject := &service{dir: t.TempDir()}
+
+		start, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+		require.NoError(t, err)
+		require.NotEmpty(t, start.FinishToken)
+		assert.Empty(t, start.ArchivePath)
+
+		errorText := "simulated failure"
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+				require.ErrorContains(t, err, errorText)
+				assert.Nil(t, res)
+			}()
+		}
+
+		res, err := subject.finish(ctx, FinishRequest{
+			ImportPath:  importPath,
+			FinishToken: start.FinishToken,
+			Error:       &errorText,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("start-reuse-bad-response", func(t *testing.T) {
+		const importPath = "github.com/DataDog/orchestrion.test"
+		subject := &service{dir: t.TempDir()}
+
+		start, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+		require.NoError(t, err)
+		require.NotEmpty(t, start.FinishToken)
+		assert.Empty(t, start.ArchivePath)
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+				require.ErrorContains(t, err, errNoArchiveNorError.Error())
+				assert.Nil(t, res)
+			}()
+		}
+
+		res, err := subject.finish(ctx, FinishRequest{
+			ImportPath:  importPath,
+			FinishToken: start.FinishToken,
+		})
+		require.ErrorIs(t, err, errNoArchiveNorError)
+		require.Nil(t, res)
+	})
+
+	t.Run("start-reuse-fail", func(t *testing.T) {
+		const importPath = "github.com/DataDog/orchestrion.test"
+		subject := &service{dir: t.TempDir()}
+
+		start, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+		require.NoError(t, err)
+		require.NotEmpty(t, start.FinishToken)
+		assert.Empty(t, start.ArchivePath)
+
+		// Deliberately non-existent!
+		archive := filepath.Join(t.TempDir(), "deliberately-missing", "_pkg_.a")
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
+				require.ErrorContains(t, err, archive)
+				assert.Nil(t, res)
+			}()
+		}
+
+		res, err := subject.finish(ctx, FinishRequest{
+			ImportPath:  importPath,
+			FinishToken: start.FinishToken,
+			ArchivePath: archive,
+		})
+		require.ErrorContains(t, err, archive)
+		require.Nil(t, res)
+	})
+}

--- a/internal/jobserver/nbt/nbt_test.go
+++ b/internal/jobserver/nbt/nbt_test.go
@@ -51,12 +51,12 @@ func Test(t *testing.T) {
 				defer wg.Done()
 
 				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Empty(t, res.FinishToken)
-				require.NotEmpty(t, res.ArchivePath)
+				assert.NotEmpty(t, res.ArchivePath)
 
 				content, err := os.ReadFile(res.ArchivePath)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, archiveContent, string(content))
 			}()
 		}
@@ -116,7 +116,7 @@ func Test(t *testing.T) {
 				defer wg.Done()
 
 				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
-				require.ErrorContains(t, err, errorText)
+				assert.ErrorContains(t, err, errorText)
 				assert.Nil(t, res)
 			}()
 		}
@@ -147,7 +147,7 @@ func Test(t *testing.T) {
 				defer wg.Done()
 
 				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
-				require.ErrorContains(t, err, errNoArchiveNorError.Error())
+				assert.ErrorContains(t, err, errNoArchiveNorError.Error())
 				assert.Nil(t, res)
 			}()
 		}
@@ -180,7 +180,7 @@ func Test(t *testing.T) {
 				defer wg.Done()
 
 				res, err := subject.start(ctx, StartRequest{ImportPath: importPath})
-				require.ErrorContains(t, err, archive)
+				assert.ErrorContains(t, err, archive)
 				assert.Nil(t, res)
 			}()
 		}

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -60,19 +60,16 @@ type (
 	ResolveResponse map[string]string
 )
 
-func NewResolveRequest(dir string, pattern string) *ResolveRequest {
-	return &ResolveRequest{
+func NewResolveRequest(dir string, pattern string) ResolveRequest {
+	return ResolveRequest{
 		Dir:     dir,
 		Env:     os.Environ(),
 		Pattern: pattern,
 	}
 }
 
-func (*ResolveRequest) Subject() string {
-	return resolveSubject
-}
-
-func (ResolveResponse) IsResponseTo(*ResolveRequest) {}
+func (ResolveRequest) Subject() string            { return resolveSubject }
+func (ResolveRequest) ResponseIs(ResolveResponse) {}
 
 func (r *ResolveRequest) canonicalizeEnviron() {
 	named := make(map[string]string, len(r.Env))

--- a/internal/jobserver/pkgs/resolve_test.go
+++ b/internal/jobserver/pkgs/resolve_test.go
@@ -39,7 +39,7 @@ func Test(t *testing.T) {
 		env := os.Environ()
 
 		// First request is expected to always be a cache miss
-		resp, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+		resp, err := client.Request(
 			context.Background(),
 			conn,
 			&pkgs.ResolveRequest{
@@ -56,7 +56,7 @@ func Test(t *testing.T) {
 		// of entries in `env` is also shuffled, which should have no impact on the
 		// cache hitting or missing.
 		rand.Shuffle(len(env), func(i, j int) { env[i], env[j] = env[j], env[i] })
-		resp, err = client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+		resp, err = client.Request(
 			context.Background(),
 			conn,
 			&pkgs.ResolveRequest{
@@ -70,7 +70,7 @@ func Test(t *testing.T) {
 		assert.EqualValues(t, 1, server.CacheStats.Hits())
 
 		// Third request is different, should result in a cache miss again
-		resp, err = client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+		resp, err = client.Request(
 			context.Background(),
 			conn,
 			&pkgs.ResolveRequest{
@@ -93,7 +93,7 @@ func Test(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
-		resp, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+		resp, err := client.Request(
 			context.Background(),
 			conn,
 			&pkgs.ResolveRequest{Pattern: "definitely.not/a@valid\x01package"},

--- a/internal/jobserver/server.go
+++ b/internal/jobserver/server.go
@@ -164,11 +164,11 @@ func New(ctx context.Context, opts *Options) (srv *Server, err error) {
 	if err := pkgs.Subscribe(ctx, clientURL, conn, res.CacheStats); err != nil {
 		return nil, err
 	}
-	if cleanup, err := nbt.Subscribe(ctx, conn); err != nil {
+	cleanup, err := nbt.Subscribe(ctx, conn)
+	if err != nil {
 		return nil, err
-	} else {
-		res.onShutdown(cleanup)
 	}
+	res.onShutdown(cleanup)
 	if _, err := conn.Subscribe("clients", res.handleClients); err != nil {
 		return nil, err
 	}

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -85,7 +85,7 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (err e
 			if err := files.LinkOrCopy(ctx, res.ArchivePath, cmd.Flags.Output); err != nil {
 				return err
 			}
-			return proxy.SkipCommand
+			return proxy.ErrSkipCommand
 		}
 	}
 

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -76,7 +76,7 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resEr
 	if js, err := client.FromEnvironment(ctx, cmd.WorkDir); err != nil {
 		log.Debug().Str("work-dir", cmd.WorkDir).Err(err).Msg("Failed to obtain job server client")
 	} else {
-		res, err := client.Request[nbt.StartRequest, *nbt.StartResponse](ctx, js, nbt.StartRequest{ImportPath: w.ImportPath, BuildID: cmd.Flags.BuildID})
+		res, err := client.Request(ctx, js, nbt.StartRequest{ImportPath: w.ImportPath, BuildID: cmd.Flags.BuildID})
 		if err != nil {
 			log.Error().Err(err).Msg("Never-build-twice start request failed")
 			js.Close()
@@ -133,7 +133,7 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resEr
 					files[nbt.LabelAsmhdr] = asmhdr
 				}
 			}
-			_, err := client.Request[nbt.FinishRequest, *nbt.FinishResponse](ctx, js, nbt.FinishRequest{
+			_, err := client.Request(ctx, js, nbt.FinishRequest{
 				ImportPath:  w.ImportPath,
 				FinishToken: res.FinishToken,
 				Files:       files,

--- a/internal/toolexec/aspect/resolve.go
+++ b/internal/toolexec/aspect/resolve.go
@@ -35,7 +35,7 @@ func resolvePackageFiles(ctx context.Context, importPath string, workDir string)
 		// and the root work tree contains all child work trees involved in resolutions.
 		req.TempDir = filepath.Join(workDir, "__tmp__")
 	}
-	archives, err := client.Request[*pkgs.ResolveRequest, pkgs.ResolveResponse](
+	archives, err := client.Request(
 		context.Background(),
 		conn,
 		req,

--- a/internal/toolexec/aspect/resolve.go
+++ b/internal/toolexec/aspect/resolve.go
@@ -48,7 +48,7 @@ func resolvePackageFiles(ctx context.Context, importPath string, workDir string)
 	var found bool
 	for ip, arch := range archives {
 		if arch == "" {
-			return nil, fmt.Errorf("failed to resolve archive for %q", ip)
+			return nil, fmt.Errorf("no archive found for %q", ip)
 		}
 		if ip == importPath {
 			found = true

--- a/internal/toolexec/proxy/compile.flags.go
+++ b/internal/toolexec/proxy/compile.flags.go
@@ -31,7 +31,7 @@ func (f *compileFlagSet) parse(args []string) ([]string, error) {
 	flagSet.String("asmhdr", "", "write assembly header to file")
 	flagSet.String("bench", "", "append benchmark times to file")
 	flagSet.String("blockprofile", "", "write block profile to file")
-	flagSet.String("buildid", "", "record id as the build id in the export metadata")
+	flagSet.StringVar(&f.BuildID, "buildid", "", "record id as the build id in the export metadata")
 	flagSet.Int("c", 0, "concurrency during compilation (1 means no concurrency)")
 	flagSet.Bool("clobberdead", false, "clobber dead stack slots (for debugging)")
 	flagSet.Bool("clobberdeadreg", false, "clobber dead registers (for debugging)")

--- a/internal/toolexec/proxy/compile.flags.go
+++ b/internal/toolexec/proxy/compile.flags.go
@@ -28,7 +28,7 @@ func (f *compileFlagSet) parse(args []string) ([]string, error) {
 	})
 	flagSet.Bool("W", false, "debug parse tree after type checking")
 	flagSet.Bool("asan", false, "build code compatible with C/C++ address sanitizer")
-	flagSet.String("asmhdr", "", "write assembly header to file")
+	flagSet.StringVar(&f.Asmhdr, "asmhdr", "", "write assembly header to file")
 	flagSet.String("bench", "", "append benchmark times to file")
 	flagSet.String("blockprofile", "", "write block profile to file")
 	flagSet.StringVar(&f.BuildID, "buildid", "", "record id as the build id in the export metadata")

--- a/internal/toolexec/proxy/compile.go
+++ b/internal/toolexec/proxy/compile.go
@@ -17,6 +17,7 @@ import (
 
 type compileFlagSet struct {
 	Package     string `ddflag:"-p"`
+	BuildID     string `ddflag:"-buildid"`
 	ImportCfg   string `ddflag:"-importcfg"`
 	Output      string `ddflag:"-o"`
 	Lang        string `ddflag:"-lang"`

--- a/internal/toolexec/proxy/compile.go
+++ b/internal/toolexec/proxy/compile.go
@@ -16,11 +16,12 @@ import (
 //go:generate go run github.com/DataDog/orchestrion/internal/toolexec/proxy/generator -command=compile
 
 type compileFlagSet struct {
-	Package     string `ddflag:"-p"`
+	Asmhdr      string `ddflag:"-asmhdr"`
 	BuildID     string `ddflag:"-buildid"`
 	ImportCfg   string `ddflag:"-importcfg"`
-	Output      string `ddflag:"-o"`
 	Lang        string `ddflag:"-lang"`
+	Output      string `ddflag:"-o"`
+	Package     string `ddflag:"-p"`
 	ShowVersion bool   `ddflag:"-V"`
 }
 

--- a/internal/toolexec/proxy/compile_test.go
+++ b/internal/toolexec/proxy/compile_test.go
@@ -34,6 +34,17 @@ func TestParseCompile(t *testing.T) {
 				Lang:      "go1.42",
 			},
 		},
+		"buildid": {
+			input:   []string{"/path/compile", "-o", "$WORK/b019/_pkg_.a", "-trimpath", "$WORK=>", "-p", "internal/profilerecord", "-lang=go1.23", "-std", "-complete", "-buildid", "58eel3bXIltdLxQE0aV1/58eel3bXIltdLxQE0aV1", "-goversion", "go1.23.4", "-c=4", "-shared", "-nolocalimports", "-importcfg", "$WORK/b019/importcfg", "-pack", "/go/src/internal/profilerecord/profilerecord.go"},
+			goFiles: []string{"/go/src/internal/profilerecord/profilerecord.go"},
+			flags: compileFlagSet{
+				Package:   "internal/profilerecord",
+				ImportCfg: "$WORK/b019/importcfg",
+				Output:    "$WORK/b019/_pkg_.a",
+				Lang:      "go1.23",
+				BuildID:   "58eel3bXIltdLxQE0aV1/58eel3bXIltdLxQE0aV1",
+			},
+		},
 		"nats.go": {
 			input:   []string{"/path/compile", "-o", "/buildDir/b002/a.out", "-p", "github.com/nats-io/nats.go", "-complete", "/path/to/source/file.go"},
 			goFiles: []string{"/path/to/source/file.go"},
@@ -48,9 +59,6 @@ func TestParseCompile(t *testing.T) {
 			tc.goFiles = make([]string, 0)
 		}
 
-		if name != "nats.go" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			cmd, err := parseCompileCommand(tc.input)
 			require.NoError(t, err)

--- a/internal/toolexec/proxy/compile_test.go
+++ b/internal/toolexec/proxy/compile_test.go
@@ -6,6 +6,7 @@
 package proxy
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
@@ -60,7 +61,7 @@ func TestParseCompile(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			cmd, err := parseCompileCommand(tc.input)
+			cmd, err := parseCompileCommand(gocontext.Background(), tc.input)
 			require.NoError(t, err)
 			require.Equal(t, CommandTypeCompile, cmd.Type())
 			require.Equal(t, tc.flags, cmd.Flags)
@@ -71,7 +72,7 @@ func TestParseCompile(t *testing.T) {
 
 func TestSetLang(t *testing.T) {
 	t.Run("-lang go1.13", func(t *testing.T) {
-		cmd, err := parseCompileCommand([]string{
+		cmd, err := parseCompileCommand(gocontext.Background(), []string{
 			"/path/to/compile",
 			"-o", "/buildDir/b002/a.out",
 			"-lang", "go1.13",
@@ -88,7 +89,7 @@ func TestSetLang(t *testing.T) {
 	})
 
 	t.Run("-lang go1.23", func(t *testing.T) {
-		cmd, err := parseCompileCommand([]string{
+		cmd, err := parseCompileCommand(gocontext.Background(), []string{
 			"/path/to/compile",
 			"-o", "/buildDir/b002/a.out",
 			"-lang", "go1.23",
@@ -105,7 +106,7 @@ func TestSetLang(t *testing.T) {
 	})
 
 	t.Run("-lang=go1.13", func(t *testing.T) {
-		cmd, err := parseCompileCommand([]string{
+		cmd, err := parseCompileCommand(gocontext.Background(), []string{
 			"/path/to/compile",
 			"-o", "/buildDir/b002/a.out",
 			"-lang=go1.13",
@@ -127,7 +128,7 @@ func TestSetLang(t *testing.T) {
 			"source/file.go",
 		}
 
-		cmd, err := parseCompileCommand(args)
+		cmd, err := parseCompileCommand(gocontext.Background(), args)
 		require.NoError(t, err)
 
 		require.NoError(t, cmd.SetLang(context.GoLangVersion{}))

--- a/internal/toolexec/proxy/errors.go
+++ b/internal/toolexec/proxy/errors.go
@@ -1,0 +1,9 @@
+package proxy
+
+import "errors"
+
+var (
+	// SkipCommand is returned by command processors to indicate that the command
+	// should not be executed, and instead considered an idempotent success.
+	SkipCommand = errors.New("skip command")
+)

--- a/internal/toolexec/proxy/errors.go
+++ b/internal/toolexec/proxy/errors.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package proxy
 
 import "errors"

--- a/internal/toolexec/proxy/errors.go
+++ b/internal/toolexec/proxy/errors.go
@@ -3,7 +3,8 @@ package proxy
 import "errors"
 
 var (
-	// SkipCommand is returned by command processors to indicate that the command
-	// should not be executed, and instead considered an idempotent success.
-	SkipCommand = errors.New("skip command")
+	// ErrSkipCommand is returned by command processors to indicate that the
+	// command should not be executed, and instead considered an idempotent
+	// success.
+	ErrSkipCommand = errors.New("skip command")
 )

--- a/internal/toolexec/proxy/link.go
+++ b/internal/toolexec/proxy/link.go
@@ -6,6 +6,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 )
@@ -39,7 +40,7 @@ func (cmd *LinkCommand) Stage() string {
 	return filepath.Base(filepath.Dir(filepath.Dir(cmd.Flags.Output)))
 }
 
-func parseLinkCommand(args []string) (Command, error) {
+func parseLinkCommand(_ context.Context, args []string) (Command, error) {
 	if len(args) == 0 {
 		return nil, errors.New("unexpected number of command arguments")
 	}

--- a/internal/toolexec/proxy/link_test.go
+++ b/internal/toolexec/proxy/link_test.go
@@ -6,6 +6,7 @@
 package proxy
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestParseLink(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cmd, err := parseLinkCommand(tc.input)
+			cmd, err := parseLinkCommand(context.Background(), tc.input)
 			require.NoError(t, err)
 			require.Equal(t, CommandTypeLink, cmd.Type())
 			c := cmd.(*LinkCommand)

--- a/internal/toolexec/proxy/proxy.go
+++ b/internal/toolexec/proxy/proxy.go
@@ -91,7 +91,9 @@ func (cmd *command) OnClose(cb func(error) error) {
 }
 
 func (cmd *command) Close(err error) error {
-	for _, cb := range cmd.onClose {
+	// Run these in reverse order, so it behaves like "defer".
+	for idx := len(cmd.onClose) - 1; idx >= 0; idx-- {
+		cb := cmd.onClose[idx]
 		if err := cb(err); err != nil {
 			return err
 		}

--- a/internal/toolexec/proxy/proxy.go
+++ b/internal/toolexec/proxy/proxy.go
@@ -22,7 +22,7 @@ type (
 	Command interface {
 		// Close invokes all registered OnClose callbacks and releases any resources associated with the
 		// command.
-		Close() error
+		Close(error) error
 
 		// Args are all the command arguments, starting from the Go tool command
 		Args() []string
@@ -48,7 +48,7 @@ type (
 		args []string
 		// paramPos is the index in args of the *value* provided for the parameter stored in the key
 		paramPos map[string]int
-		onClose  []func() error
+		onClose  []func(error) error
 	}
 )
 
@@ -86,13 +86,13 @@ func NewCommand(args []string) command {
 
 // OnClose registers a callback to be invoked when the command is closed, usually after it has run,
 // unless skipping was requested by the integration.
-func (cmd *command) OnClose(cb func() error) {
+func (cmd *command) OnClose(cb func(error) error) {
 	cmd.onClose = append(cmd.onClose, cb)
 }
 
-func (cmd *command) Close() error {
+func (cmd *command) Close(err error) error {
 	for _, cb := range cmd.onClose {
-		if err := cb(); err != nil {
+		if err := cb(err); err != nil {
 			return err
 		}
 	}

--- a/internal/toolexec/proxy/proxy_test.go
+++ b/internal/toolexec/proxy/proxy_test.go
@@ -6,6 +6,7 @@
 package proxy_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestParseCommand(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cmd := proxy.MustParseCommand(tc.input)
+			cmd := proxy.MustParseCommand(context.Background(), tc.input)
 			require.Equal(t, tc.expectedType, cmd.Type())
 			require.True(t, reflect.DeepEqual(tc.input, cmd.Args()))
 		})

--- a/internal/toolexec/version.go
+++ b/internal/toolexec/version.go
@@ -53,7 +53,7 @@ func ComputeVersion(ctx context.Context, cmd proxy.Command) (string, error) {
 	}
 	defer conn.Close()
 
-	res, err := client.Request[*buildid.VersionSuffixRequest, buildid.VersionSuffixResponse](context.Background(), conn, nil)
+	res, err := client.Request(context.Background(), conn, buildid.VersionSuffixRequest{})
 	if err != nil {
 		return "", err
 	}

--- a/internal/toolexec/version_test.go
+++ b/internal/toolexec/version_test.go
@@ -48,7 +48,7 @@ func Test(t *testing.T) {
 	runGo(t, tmp, "mod", "tidy")
 
 	// "Fake" proxy command.
-	cmd, err := proxy.ParseCommand([]string{"go", "tool", "compile", "-V=full"})
+	cmd, err := proxy.ParseCommand(context.Background(), []string{"go", "tool", "compile", "-V=full"})
 	require.NoError(t, err)
 
 	// Compute the initial version string...

--- a/main.go
+++ b/main.go
@@ -192,7 +192,10 @@ func main() {
 	}
 }
 
-var logLevelSet bool
+var (
+	logLevelSet bool
+	logLevel    = zerolog.Disabled
+)
 
 func actionSetLogLevel(ctx *cli.Context, value string) error {
 	if err := os.Setenv(envVarOrchestrionLogLevel, value); err != nil {
@@ -208,6 +211,7 @@ func actionSetLogLevel(ctx *cli.Context, value string) error {
 	ctx.Context = logger.WithContext(ctx.Context)
 
 	logLevelSet = true
+	logLevel = level
 	return nil
 }
 
@@ -247,6 +251,8 @@ func actionSetLogFile(ctx *cli.Context, path string) error {
 	log.Logger = zerolog.New(file).With().Timestamp().Logger()
 	if !logLevelSet {
 		log.Logger = log.Logger.Level(zerolog.WarnLevel)
+	} else {
+		log.Logger = log.Logger.Level(logLevel)
 	}
 	log.Logger.UpdateContext(updateCommonContext)
 	ctx.Context = log.Logger.WithContext(ctx.Context)


### PR DESCRIPTION
Adds a new jobserver message to track ongoing compilation tasks, so that duplicates can be completely avoided by re-using the first build task's outcome. This allows de-duplicating builds even if an injected package is already present in the natural dependency closure of the package being built.

Fixes #430