### PR TITLE
fix: OnCompileMain needs to register new `link.deps`

### DIFF
--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -30,7 +30,7 @@ var Toolexec = &cli.Command{
 		if err != nil {
 			return err
 		}
-		defer proxyCmd.Close()
+		defer proxyCmd.Close(ctx.Context)
 
 		if proxyCmd.Type() == proxy.CommandTypeOther {
 			// Immediately run the command if it's of the Other type, as we do not do

--- a/internal/toolexec/aspect/linkdeps/linkdeps.go
+++ b/internal/toolexec/aspect/linkdeps/linkdeps.go
@@ -205,8 +205,10 @@ func readArchiveData(archive string, entry string) (io.Reader, error) {
 	var list, data bytes.Buffer
 	cmd := exec.Command("go", "tool", "pack", "t", archive)
 	cmd.Stdout = &list
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("running `go tool pack t %q`: %w", archive, err)
+		return nil, fmt.Errorf("running `go tool pack t %q`: %w\n%s", archive, err, stderr.String())
 	}
 	for {
 		line, err := list.ReadString('\n')

--- a/internal/toolexec/proxy/proxy.go
+++ b/internal/toolexec/proxy/proxy.go
@@ -22,7 +22,7 @@ type (
 	Command interface {
 		// Close invokes all registered OnClose callbacks and releases any resources associated with the
 		// command.
-		Close() error
+		Close(context.Context) error
 
 		// Args are all the command arguments, starting from the Go tool command
 		Args() []string
@@ -48,7 +48,6 @@ type (
 		args []string
 		// paramPos is the index in args of the *value* provided for the parameter stored in the key
 		paramPos map[string]int
-		onClose  []func() error
 	}
 )
 
@@ -84,18 +83,7 @@ func NewCommand(args []string) command {
 	return cmd
 }
 
-// OnClose registers a callback to be invoked when the command is closed, usually after it has run,
-// unless skipping was requested by the integration.
-func (cmd *command) OnClose(cb func() error) {
-	cmd.onClose = append(cmd.onClose, cb)
-}
-
-func (cmd *command) Close() error {
-	for _, cb := range cmd.onClose {
-		if err := cb(); err != nil {
-			return err
-		}
-	}
+func (*command) Close(context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
The `OnCompile` hook cannot necessarily resolve the transitive dependencies of all link-time dependencies, as those are normally used to avoid creating dependency cycles.

The `OnCompileMain` hook however MUST resolve the transitive dependencies of everything, as it needs to introduce `import`s of all synthetic link-time dependencies so that they are correctly registered (their `init` functions get scheduled, and they get presented to the linker). This was previously not necessarily done, and could result in link-time failures.

---

This involved re-working the way the `link.deps` file is added to the `_pkg_.a` files so that both the `OnCompile` and `OnCompileMain` functions contribute to the same closure and it gets written & registered exactly once. As a result `Command.OnClose` was removed (no longer used).