### PR TITLE
fix: build fails with "sending never-build-twice request failed"

### DIFF
--- a/internal/jobserver/nbt/nbt_test.go
+++ b/internal/jobserver/nbt/nbt_test.go
@@ -30,7 +30,7 @@ func Test(t *testing.T) {
 
 	t.Run("not-started", func(t *testing.T) {
 		subject := &service{dir: t.TempDir()}
-		res, err := subject.finish(ctx, FinishRequest{ImportPath: importPath, FinishToken: "bazinga"})
+		res, err := subject.finish(ctx, FinishRequest{ImportPath: importPath, BuildID: buildID, FinishToken: "bazinga"})
 		require.ErrorContains(t, err, "no build started")
 		require.Nil(t, res)
 	})
@@ -82,43 +82,9 @@ func Test(t *testing.T) {
 
 		res, err := subject.finish(ctx, FinishRequest{
 			ImportPath:  importPath,
+			BuildID:     buildID,
 			FinishToken: start.FinishToken,
 			Files:       map[Label]string{LabelArchive: archive, label: extraFile},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, res)
-	})
-
-	t.Run("start-conflict-finish", func(t *testing.T) {
-		subject := &service{dir: t.TempDir()}
-
-		start, err := subject.start(ctx, StartRequest{ImportPath: importPath, BuildID: buildID})
-		require.NoError(t, err)
-		require.NotEmpty(t, start.FinishToken)
-		assert.Empty(t, start.Files)
-
-		archiveContent := uuid.NewString()
-
-		var wg sync.WaitGroup
-		defer wg.Wait()
-		for range 10 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
-				res, err := subject.start(ctx, StartRequest{ImportPath: importPath, BuildID: buildID + "-alt"})
-				assert.ErrorContains(t, err, buildID)
-				assert.Nil(t, res)
-			}()
-		}
-
-		archive := filepath.Join(t.TempDir(), "_pkg_.a")
-		require.NoError(t, os.WriteFile(archive, []byte(archiveContent), 0o644))
-
-		res, err := subject.finish(ctx, FinishRequest{
-			ImportPath:  importPath,
-			FinishToken: start.FinishToken,
-			Files:       map[Label]string{LabelArchive: archive},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, res)
@@ -140,6 +106,7 @@ func Test(t *testing.T) {
 		for range 10 {
 			res, err := subject.finish(ctx, FinishRequest{
 				ImportPath:  importPath,
+				BuildID:     buildID,
 				FinishToken: start.FinishToken,
 				Files:       map[Label]string{LabelArchive: archive},
 			})
@@ -164,6 +131,7 @@ func Test(t *testing.T) {
 		for range 10 {
 			res, err := subject.finish(ctx, FinishRequest{
 				ImportPath:  importPath,
+				BuildID:     buildID,
 				FinishToken: uuid.NewString(),
 				Files:       map[Label]string{LabelArchive: archive},
 			})
@@ -173,6 +141,7 @@ func Test(t *testing.T) {
 
 		res, err := subject.finish(ctx, FinishRequest{
 			ImportPath:  importPath,
+			BuildID:     buildID,
 			FinishToken: start.FinishToken,
 			Files:       map[Label]string{LabelArchive: archive},
 		})
@@ -206,6 +175,7 @@ func Test(t *testing.T) {
 
 		res, err := subject.finish(ctx, FinishRequest{
 			ImportPath:  importPath,
+			BuildID:     buildID,
 			FinishToken: start.FinishToken,
 			Error:       &errorText,
 		})
@@ -237,6 +207,7 @@ func Test(t *testing.T) {
 
 		res, err := subject.finish(ctx, FinishRequest{
 			ImportPath:  importPath,
+			BuildID:     buildID,
 			FinishToken: start.FinishToken,
 		})
 		require.ErrorIs(t, err, errNoFilesNorError)
@@ -270,6 +241,7 @@ func Test(t *testing.T) {
 
 		res, err := subject.finish(ctx, FinishRequest{
 			ImportPath:  importPath,
+			BuildID:     buildID,
 			FinishToken: start.FinishToken,
 			Files:       map[Label]string{LabelArchive: archive},
 		})
@@ -308,6 +280,7 @@ func Test(t *testing.T) {
 
 		res, err := subject.finish(ctx, FinishRequest{
 			ImportPath:  importPath,
+			BuildID:     buildID,
 			FinishToken: start.FinishToken,
 			Files:       map[Label]string{LabelArchive: archive, label: extraFile},
 		})

--- a/internal/toolexec/proxy/compile.go
+++ b/internal/toolexec/proxy/compile.go
@@ -201,6 +201,7 @@ func (cmd *CompileCommand) notifyJobServer(ctx gocontext.Context, cmdErr error) 
 
 	_, err = client.Request(ctx, jobs, nbt.FinishRequest{
 		ImportPath:  cmd.importPath,
+		BuildID:     cmd.Flags.BuildID,
 		FinishToken: cmd.finishToken,
 		Files:       files,
 		Error:       errorMessage,


### PR DESCRIPTION
The never-build-twice feature assumed that it is not, ever, possible for a single build to result in multiple different builds of the same package with different build IDs. #507 suggest this might actually be a valid outcome (the exact details of why/how are not clear yet).

This PR removes that assumption and keeps separate cache entries for each individual build ID in order to reduce the risk of breaking the build.

Fixes #507