### PR TITLE
chore: fix doc generation workflow

### DIFF
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -27,8 +27,8 @@ jobs:
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5
         with:
           cache-dependency-path: '**/go.mod'
-      - name: Run go generate (builtin)
-        run: go generate ./internal/injector/builtin
+      - name: Run doc generator
+        run: go -C _docs run ./generator
       - name: Build Site
         # Set environment to anything other than "production", as the theme we use adds SRI attributes to all CSS files,
         # but datadoghq.dev is behind CloudFlare with auto-minify enabled; which breaks SRI if its minification is not


### PR DESCRIPTION
The documentation generation workflow was failing because it still referred to the `go generate` task from the old built-ins package.