### PR TITLE
fix: build ID mismatch when using `-covermode` without `-cover`

### DIFF
--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -243,11 +243,11 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalA
 
 		for idx, pattern := range strings.Split(val, ",") {
 			if idx > 0 {
-				newValBuf.WriteByte(',')
+				_ = newValBuf.WriteByte(',')
 			}
 			if !strings.HasPrefix(pattern, "./") && !strings.HasPrefix(pattern, ".\\") {
 				// If the pattern is not relative, so we're good.
-				newValBuf.WriteString(pattern)
+				_, _ = newValBuf.WriteString(pattern)
 				continue
 			}
 
@@ -277,9 +277,9 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalA
 				}
 
 				if idx > 0 {
-					newValBuf.WriteByte(',')
+					_ = newValBuf.WriteByte(',')
 				}
-				newValBuf.WriteString(pkg.PkgPath)
+				_, _ = newValBuf.WriteString(pkg.PkgPath)
 			}
 		}
 

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -219,7 +219,71 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 // inferCoverpkg will add the necessary `-coverpkg` argument if the `-cover` flags is present and `-coverpkg` is not, as
 // otherwise, sub-commands triggered with these flags will not apply coverage to the intended packages.
 func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalArgs []string) error {
-	if _, hasCoverpkg := f.Long["-coverpkg"]; hasCoverpkg {
+	log := zerolog.Ctx(ctx)
+
+	// Make sure we satisfy the same build constraints; but don't run -toolexec
+	childBuildFlags := append(f.Slice(), "-toolexec=")
+	childBuildLogf := func(format string, args ...any) {
+		log.Trace().Str("operation", "packages.Load").Msgf(format, args...)
+	}
+
+	if val, hasCoverpkg := f.Long["-coverpkg"]; hasCoverpkg {
+		if val == "" {
+			// Blank specified, not trying to expand it...
+			return nil
+		}
+
+		// We have patterns, we need to make sure they are expressed in absolute terms.
+		var newValBuf strings.Builder
+		newValBuf.Grow(len(val))
+
+		for idx, pattern := range strings.Split(val, ",") {
+			if idx > 0 {
+				newValBuf.WriteByte(',')
+			}
+			if !strings.HasPrefix(pattern, "./") && !strings.HasPrefix(pattern, ".\\") {
+				// If the pattern is not relative, so we're good.
+				newValBuf.WriteString(pattern)
+				continue
+			}
+
+			log.Debug().
+				Str("-coverpkg.entry", pattern).
+				Msg("Resolving relative -coverpkg entry")
+			pkgs, err := packages.Load(&packages.Config{
+				Mode:       packages.NeedName,
+				Dir:        wd,
+				BuildFlags: childBuildFlags,
+				Logf:       childBuildLogf,
+			}, pattern)
+			if err != nil {
+				return fmt.Errorf("resolving -coverpkg entry %q: %w", pattern, err)
+			}
+			for idx, pkg := range pkgs {
+				if len(pkg.Errors) != 0 {
+					var err error
+					for _, pkgErr := range pkg.Errors {
+						err = errors.Join(err, pkgErr)
+					}
+					log.Warn().
+						Err(err).
+						Str("pkg.ID", pkg.ID).
+						Str("-coverpkg.entry", pattern).
+						Msg("Error when resolving -coverpkg entry")
+				}
+
+				if idx > 0 {
+					newValBuf.WriteByte(',')
+				}
+				newValBuf.WriteString(pkg.PkgPath)
+			}
+		}
+
+		newVal := newValBuf.String()
+		f.Long["-coverpkg"] = newVal
+		log.Debug().
+			Str("-coverpkg", newVal).
+			Msg("Finalized -coverpkg value")
 		return nil
 	}
 
@@ -232,13 +296,12 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalA
 		return nil
 	}
 
-	log := zerolog.Ctx(ctx)
 	pkgs, err := packages.Load(
 		&packages.Config{
 			Mode:       packages.NeedName,
 			Dir:        wd,
-			BuildFlags: append(f.Slice(), "-toolexec"), // Make sure we satisfy the same build constraints; but don't run -toolexec
-			Logf:       func(format string, args ...any) { log.Trace().Str("operation", "packages.Load").Msgf(format, args...) },
+			BuildFlags: childBuildFlags,
+			Logf:       childBuildLogf,
 		},
 		positionalArgs...,
 	)

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -216,8 +216,12 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 	return flags, nil
 }
 
-// inferCoverpkg will add the necessary `-coverpkg` argument if the `-cover` flags is present and `-coverpkg` is not, as
-// otherwise, sub-commands triggered with these flags will not apply coverage to the intended packages.
+// inferCoverpkg will add the necessary `-coverpkg` argument if the `-cover` flags is present and
+// `-coverpkg` is not, as otherwise, sub-commands triggered with these flags will not apply coverage
+// to the intended packages.
+// If `-coverpkg` is present, it will expand any relative paths (recognized by a `./` prefix) into
+// absolute package names, so that child builds do not interpret these relative to a different
+// package root.
 func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalArgs []string) error {
 	log := zerolog.Ctx(ctx)
 

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -226,7 +226,7 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalA
 	_, isCover := f.Short["-cover"]
 	if !isCover {
 		// -covermode implies -cover
-		_, isCover = f.Short["-covermode"]
+		_, isCover = f.Long["-covermode"]
 	}
 	if !isCover {
 		return nil

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -222,7 +222,13 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalA
 	if _, hasCoverpkg := f.Long["-coverpkg"]; hasCoverpkg {
 		return nil
 	}
-	if _, isCover := f.Short["-cover"]; !isCover {
+
+	_, isCover := f.Short["-cover"]
+	if !isCover {
+		// -covermode implies -cover
+		_, isCover = f.Short["-covermode"]
+	}
+	if !isCover {
 		return nil
 	}
 

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -98,6 +98,13 @@ func TestParse(t *testing.T) {
 				Short: map[string]struct{}{"-cover": {}},
 			},
 		},
+		"covermode": {
+			flags: []string{"run", "-covermode=count"},
+			expected: CommandFlags{
+				Long:  map[string]string{"-covermode": "count", "-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short: map[string]struct{}{},
+			},
+		},
 		"cover-with-coverpkg": {
 			flags:   []string{"run", "-cover", "-covermode=atomic", "--", "-some.go"},
 			goflags: "-coverpkg=std",

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -102,7 +102,7 @@ func TestParse(t *testing.T) {
 			flags: []string{"run", "-covermode=count"},
 			expected: CommandFlags{
 				Long:  map[string]string{"-covermode": "count", "-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
-				Short: map[string]struct{}{},
+				Short: nil,
 			},
 		},
 		"cover-with-coverpkg": {

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -107,9 +107,9 @@ func TestParse(t *testing.T) {
 		},
 		"cover-with-coverpkg": {
 			flags:   []string{"run", "-cover", "-covermode=atomic", "--", "-some.go"},
-			goflags: "-coverpkg=std",
+			goflags: "-coverpkg=std,./...",
 			expected: CommandFlags{
-				Long:  map[string]string{"-covermode": "atomic", "-coverpkg": "std"},
+				Long:  map[string]string{"-covermode": "atomic", "-coverpkg": "std,github.com/DataDog/orchestrion/internal/goflags,github.com/DataDog/orchestrion/internal/goflags/quoted"},
 				Short: map[string]struct{}{"-cover": {}},
 			},
 		},

--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -34,9 +34,10 @@ const (
 )
 
 type Options struct {
-	// Writer is the writer to send output of the command to.
+	// Writer is the writer to send output of the command to. Defaults to
+	// [os.Stdout].
 	Writer io.Writer
-	// ErrWriter is the writer to send error messages to.
+	// ErrWriter is the writer to send error messages to. Defaults to [os.Stderr].
 	ErrWriter io.Writer
 
 	// Validate checks the contents of all [orchestrionDotYML] files encountered
@@ -55,6 +56,14 @@ type Options struct {
 // PinOrchestrion applies or update the orchestrion pin file in the current
 // working directory, according to the supplied [Options].
 func PinOrchestrion(ctx context.Context, opts Options) error {
+	// Ensure we have an [Options.Writer] and [Options.ErrWriter] set.
+	if opts.Writer == nil {
+		opts.Writer = os.Stdout
+	}
+	if opts.ErrWriter == nil {
+		opts.ErrWriter = os.Stderr
+	}
+
 	log := zerolog.Ctx(ctx)
 
 	goMod, err := goenv.GOMOD("")


### PR DESCRIPTION
The value of `-coverpkg` is only inferred when `-cover` is passed, but passing `-covermode` implies `-cover`. This change checks both `-cover` and `-covermode` presence to decide whether to infer `-coverpkg` or not.

Fixes #526