### PR TITLE
fix(injector: config): better error message when orchestrion.tool.go is missing

### DIFF
--- a/internal/injector/config/config-go.go
+++ b/internal/injector/config/config-go.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/orchestrion/internal/injector/aspect"
 	"golang.org/x/tools/go/packages"
@@ -39,7 +40,11 @@ func (l *Loader) loadGoPackage(pkg *packages.Package) (*configGo, error) {
 		if pkg.Errors != nil {
 			var err error
 			for _, e := range pkg.Errors {
-				err = errors.Join(err, e)
+				var innerErr error = e
+				if e.Kind == packages.ListError && strings.Contains(e.Msg, "no Go files in") { // Workaround poor error typing in packages.Load
+					innerErr = fmt.Errorf("no Go files found, was expecting at least orchestrion.tool.go: %w", e)
+				}
+				err = errors.Join(err, innerErr)
 			}
 			return nil, fmt.Errorf("in %q: %w", pkg.ID, err)
 		}

--- a/internal/injector/config/config_test.go
+++ b/internal/injector/config/config_test.go
@@ -175,6 +175,15 @@ func TestLoad(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	repoRoot := filepath.Join(thisFile, "..", "..", "..", "..")
 
+	t.Run("no go files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		goMod := filepath.Join(tmpDir, "go.mod")
+		require.NoError(t, os.WriteFile(goMod, []byte("module test\n"), 0o644))
+		loader := NewLoader(tmpDir, true)
+		_, err := loader.Load()
+		require.ErrorContains(t, err, "no Go files found, was expecting at least orchestrion.tool.go")
+	})
+
 	t.Run("required.yml", func(t *testing.T) {
 		loader := NewLoader(repoRoot, true)
 		cfg, err := loader.Load()

--- a/internal/jobserver/buildid/version.go
+++ b/internal/jobserver/buildid/version.go
@@ -59,7 +59,7 @@ func (s *service) versionSuffix(ctx context.Context, _ VersionSuffixRequest) (Ve
 	fptr := fingerprint.New()
 	defer fptr.Close()
 	if err := fptr.Named("aspects", fingerprint.List[*aspect.Aspect](aspects)); err != nil {
-		return "", fmt.Errorf("compiting injector configuration fingerprint: %w", err)
+		return "", fmt.Errorf("computing injector configuration fingerprint: %w", err)
 	}
 
 	var pkgs []*packages.Package


### PR DESCRIPTION
Better error messages for cases like #535 