### PR TITLE
chore(imports): Group local packages together

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,11 @@ linters:
     - testifylint
 
 linters-settings:
+  goimports:
+    # A comma-separated list of prefixes, which, if set, checks import paths
+    # with the given prefixes are grouped after 3rd-party packages.
+    # Default: ""
+    local-prefixes: github.com/DataDog/orchestrion
   revive:
     enable-all-rules: false
     rules:

--- a/internal/cmd/go.go
+++ b/internal/cmd/go.go
@@ -9,10 +9,11 @@ import (
 	"errors"
 	"os/exec"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/DataDog/orchestrion/internal/binpath"
 	"github.com/DataDog/orchestrion/internal/goproxy"
 	"github.com/DataDog/orchestrion/internal/pin"
-	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/internal/cmd/pin.go
+++ b/internal/cmd/pin.go
@@ -6,9 +6,10 @@
 package cmd
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/DataDog/orchestrion/internal/injector/config"
 	"github.com/DataDog/orchestrion/internal/pin"
-	"github.com/urfave/cli/v2"
 )
 
 var Pin = &cli.Command{

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -14,13 +14,14 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+	"github.com/rs/zerolog"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/filelock"
 	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/jobserver"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
-	"github.com/fsnotify/fsnotify"
-	"github.com/rs/zerolog"
-	"gopkg.in/yaml.v3"
 
 	"github.com/urfave/cli/v2"
 )

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -10,12 +10,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/rs/zerolog"
+	"github.com/urfave/cli/v2"
+
 	"github.com/DataDog/orchestrion/internal/pin"
 	"github.com/DataDog/orchestrion/internal/toolexec"
 	"github.com/DataDog/orchestrion/internal/toolexec/aspect"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
-	"github.com/rs/zerolog"
-	"github.com/urfave/cli/v2"
 )
 
 var Toolexec = &cli.Command{

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -9,8 +9,9 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/urfave/cli/v2"
+
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 var Version = &cli.Command{

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -12,10 +12,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/cmd"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
+
+	"github.com/DataDog/orchestrion/internal/cmd"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 func TestVersion(t *testing.T) {

--- a/internal/ensure/requiredversion.go
+++ b/internal/ensure/requiredversion.go
@@ -12,10 +12,11 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/DataDog/orchestrion/internal/goenv"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/rs/zerolog"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/DataDog/orchestrion/internal/goenv"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 const orchestrionPkgPath = "github.com/DataDog/orchestrion"

--- a/internal/ensure/requiredversion_test.go
+++ b/internal/ensure/requiredversion_test.go
@@ -16,10 +16,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/goenv"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/semver"
+
+	"github.com/DataDog/orchestrion/internal/goenv"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 func TestGoModVersion(t *testing.T) {

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -11,8 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/filelock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/filelock"
 )
 
 func Test(t *testing.T) {

--- a/internal/fingerprint/fingerprint_test.go
+++ b/internal/fingerprint/fingerprint_test.go
@@ -9,8 +9,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
 )
 
 func TestCast(t *testing.T) {

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/orchestrion/internal/goenv"
-	"github.com/DataDog/orchestrion/internal/goflags/quoted"
 	"github.com/rs/zerolog"
 	"github.com/shirou/gopsutil/v4/process"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/DataDog/orchestrion/internal/goenv"
+	"github.com/DataDog/orchestrion/internal/goflags/quoted"
 )
 
 // CommandFlags represents the flags provided to a go command invocation

--- a/internal/goproxy/proxy.go
+++ b/internal/goproxy/proxy.go
@@ -12,11 +12,12 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/goenv"
 	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/jobserver"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
-	"github.com/rs/zerolog"
 )
 
 type config struct {

--- a/internal/injector/aspect/advice/assign.go
+++ b/internal/injector/aspect/advice/assign.go
@@ -8,11 +8,12 @@ package advice
 import (
 	"fmt"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type assignValue struct {

--- a/internal/injector/aspect/advice/block.go
+++ b/internal/injector/aspect/advice/block.go
@@ -8,11 +8,12 @@ package advice
 import (
 	"fmt"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type prependStatements struct {

--- a/internal/injector/aspect/advice/call.go
+++ b/internal/injector/aspect/advice/call.go
@@ -10,12 +10,13 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/join"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type appendArgs struct {

--- a/internal/injector/aspect/advice/call_test.go
+++ b/internal/injector/aspect/advice/call_test.go
@@ -8,12 +8,13 @@ package advice_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/join"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAppendArgs(t *testing.T) {

--- a/internal/injector/aspect/advice/code/dot.go
+++ b/internal/injector/aspect/advice/code/dot.go
@@ -8,9 +8,10 @@ package code
 import (
 	"fmt"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 )
 
 // dot provides the `.` value to code templates, and is used to access various bits of

--- a/internal/injector/aspect/advice/code/dot_function.go
+++ b/internal/injector/aspect/advice/code/dot_function.go
@@ -9,8 +9,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect/join"
 	"github.com/dave/dst"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect/join"
 )
 
 type (

--- a/internal/injector/aspect/advice/code/template.go
+++ b/internal/injector/aspect/advice/code/template.go
@@ -14,12 +14,13 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/DataDog/orchestrion/internal/fingerprint"
-	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
 	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 type Template struct {

--- a/internal/injector/aspect/advice/code/template_test.go
+++ b/internal/injector/aspect/advice/code/template_test.go
@@ -8,13 +8,14 @@ package code_test
 import (
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
-	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 )
 
 func TestTemplate(t *testing.T) {

--- a/internal/injector/aspect/advice/import.go
+++ b/internal/injector/aspect/advice/import.go
@@ -8,9 +8,10 @@
 package advice
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"gopkg.in/yaml.v3"
 )
 
 type addBlankImport string

--- a/internal/injector/aspect/advice/inject.go
+++ b/internal/injector/aspect/advice/inject.go
@@ -8,10 +8,11 @@ package advice
 import (
 	"fmt"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"gopkg.in/yaml.v3"
 )
 
 type injectDeclarations struct {

--- a/internal/injector/aspect/advice/struct.go
+++ b/internal/injector/aspect/advice/struct.go
@@ -8,11 +8,12 @@ package advice
 import (
 	"fmt"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/join"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type addStructField struct {

--- a/internal/injector/aspect/advice/unmarshal.go
+++ b/internal/injector/aspect/advice/unmarshal.go
@@ -8,8 +8,9 @@ package advice
 import (
 	"fmt"
 
-	"github.com/DataDog/orchestrion/internal/injector/singleton"
 	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/orchestrion/internal/injector/singleton"
 )
 
 type unmarshalerFn func(*yaml.Node) (Advice, error)

--- a/internal/injector/aspect/advice/wrap.go
+++ b/internal/injector/aspect/advice/wrap.go
@@ -8,11 +8,12 @@ package advice
 import (
 	"fmt"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type wrapExpression struct {

--- a/internal/injector/aspect/aspect.go
+++ b/internal/injector/aspect/aspect.go
@@ -8,10 +8,11 @@ package aspect
 import (
 	"errors"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/advice"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/join"
-	"gopkg.in/yaml.v3"
 )
 
 // Aspect binds advice.Advice to a join.Point, effectively defining a complete

--- a/internal/injector/aspect/context/context.go
+++ b/internal/injector/aspect/context/context.go
@@ -8,9 +8,10 @@ package context
 import (
 	"sync"
 
-	"github.com/DataDog/orchestrion/internal/injector/typed"
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
+
+	"github.com/DataDog/orchestrion/internal/injector/typed"
 )
 
 type AspectContext interface {

--- a/internal/injector/aspect/context/golang.go
+++ b/internal/injector/aspect/context/golang.go
@@ -9,8 +9,9 @@ import (
 	"fmt"
 	"go/version"
 
-	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
 )
 
 // GoLangVersion represents a go language level. It's a string of the form "go1.18".

--- a/internal/injector/aspect/join/all-of.go
+++ b/internal/injector/aspect/join/all-of.go
@@ -6,10 +6,11 @@
 package join
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"gopkg.in/yaml.v3"
 )
 
 type allOf []Point

--- a/internal/injector/aspect/join/configuration.go
+++ b/internal/injector/aspect/join/configuration.go
@@ -6,10 +6,11 @@
 package join
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"gopkg.in/yaml.v3"
 
 	_ "embed" // For go:embed
 )

--- a/internal/injector/aspect/join/declaration.go
+++ b/internal/injector/aspect/join/declaration.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type declarationOf struct {

--- a/internal/injector/aspect/join/directive.go
+++ b/internal/injector/aspect/join/directive.go
@@ -11,11 +11,12 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type directive string

--- a/internal/injector/aspect/join/directive_test.go
+++ b/internal/injector/aspect/join/directive_test.go
@@ -13,12 +13,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/dave/dst/dstutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 )
 
 func TestDirectiveMatch(t *testing.T) {

--- a/internal/injector/aspect/join/expression.go
+++ b/internal/injector/aspect/join/expression.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type functionCall struct {

--- a/internal/injector/aspect/join/function.go
+++ b/internal/injector/aspect/join/function.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type (

--- a/internal/injector/aspect/join/join.go
+++ b/internal/injector/aspect/join/join.go
@@ -11,10 +11,11 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/dave/dst"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"github.com/dave/dst"
 )
 
 // Point is the interface that abstracts selection of nodes where to inject

--- a/internal/injector/aspect/join/not.go
+++ b/internal/injector/aspect/join/not.go
@@ -6,10 +6,11 @@
 package join
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"gopkg.in/yaml.v3"
 )
 
 type not struct {

--- a/internal/injector/aspect/join/one-of.go
+++ b/internal/injector/aspect/join/one-of.go
@@ -6,10 +6,11 @@
 package join
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"gopkg.in/yaml.v3"
 )
 
 type oneOf []Point

--- a/internal/injector/aspect/join/package.go
+++ b/internal/injector/aspect/join/package.go
@@ -6,10 +6,11 @@
 package join
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"gopkg.in/yaml.v3"
 )
 
 type importPath string

--- a/internal/injector/aspect/join/struct.go
+++ b/internal/injector/aspect/join/struct.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"go/token"
 
+	"github.com/dave/dst"
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"github.com/dave/dst"
-	"gopkg.in/yaml.v3"
 )
 
 type structDefinition struct {

--- a/internal/injector/aspect/join/testmain.go
+++ b/internal/injector/aspect/join/testmain.go
@@ -6,10 +6,11 @@
 package join
 
 import (
+	"gopkg.in/yaml.v3"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"gopkg.in/yaml.v3"
 )
 
 type testMain bool

--- a/internal/injector/aspect/join/unmarshal.go
+++ b/internal/injector/aspect/join/unmarshal.go
@@ -8,8 +8,9 @@ package join
 import (
 	"fmt"
 
-	"github.com/DataDog/orchestrion/internal/injector/singleton"
 	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/orchestrion/internal/injector/singleton"
 )
 
 type unmarshalerFn func(*yaml.Node) (Point, error)

--- a/internal/injector/check_test.go
+++ b/internal/injector/check_test.go
@@ -15,8 +15,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/injector/parse"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/injector/parse"
 )
 
 const goFile = `

--- a/internal/injector/config/config-go.go
+++ b/internal/injector/config/config-go.go
@@ -16,8 +16,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect"
 )
 
 const FilenameOrchestrionToolGo = "orchestrion.tool.go"

--- a/internal/injector/config/config-yml.go
+++ b/internal/injector/config/config-yml.go
@@ -12,8 +12,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect"
 	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect"
 )
 
 const FilenameOrchestrionYML = "orchestrion.yml"

--- a/internal/injector/config/config.go
+++ b/internal/injector/config/config.go
@@ -10,8 +10,9 @@ package config
 import (
 	"fmt"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect"
 )
 
 // Config represents an injector's configuration. It can be obtained using

--- a/internal/injector/imports.go
+++ b/internal/injector/imports.go
@@ -11,11 +11,12 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect"
-	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
 	"github.com/rs/zerolog"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
 )
 
 // packageFilterAspects filters out aspects that imply imports not present in the import map and return a copy

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -17,16 +17,17 @@ import (
 	"go/types"
 	"sync"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect"
-	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"github.com/DataDog/orchestrion/internal/injector/parse"
-	"github.com/DataDog/orchestrion/internal/injector/typed"
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/dave/dst/decorator/resolver"
 	"github.com/dave/dst/decorator/resolver/gotypes"
 	"github.com/dave/dst/dstutil"
 	"github.com/rs/zerolog"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
+	"github.com/DataDog/orchestrion/internal/injector/parse"
+	"github.com/DataDog/orchestrion/internal/injector/typed"
 )
 
 type (

--- a/internal/injector/injector_test.go
+++ b/internal/injector/injector_test.go
@@ -19,15 +19,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/injector"
-	"github.com/DataDog/orchestrion/internal/injector/aspect"
-	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
-	"github.com/DataDog/orchestrion/internal/injector/typed"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/go/packages"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/golden"
+
+	"github.com/DataDog/orchestrion/internal/injector"
+	"github.com/DataDog/orchestrion/internal/injector/aspect"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
+	"github.com/DataDog/orchestrion/internal/injector/typed"
 )
 
 type testConfig struct {

--- a/internal/injector/parse/parser.go
+++ b/internal/injector/parse/parser.go
@@ -15,9 +15,10 @@ import (
 	"slices"
 	"sync/atomic"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/DataDog/orchestrion/internal/injector/aspect"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
-	"golang.org/x/sync/errgroup"
 )
 
 // maxBytesEagerness is the maximum number of bytes the files of a certain package can have before

--- a/internal/injector/typed/refmap.go
+++ b/internal/injector/typed/refmap.go
@@ -13,8 +13,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/DataDog/orchestrion/internal/injector/basiclit"
 	"github.com/dave/dst"
+
+	"github.com/DataDog/orchestrion/internal/injector/basiclit"
 )
 
 type (

--- a/internal/injector/write.go
+++ b/internal/injector/write.go
@@ -13,10 +13,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataDog/orchestrion/internal/injector/lineinfo"
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/rs/zerolog"
+
+	"github.com/DataDog/orchestrion/internal/injector/lineinfo"
 )
 
 // writeModifiedFile writes the modified file to disk after having restored it to Go source code,

--- a/internal/jobserver/buildid/buildid.go
+++ b/internal/jobserver/buildid/buildid.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"sync"
 
-	"github.com/DataDog/orchestrion/internal/jobserver/common"
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog"
+
+	"github.com/DataDog/orchestrion/internal/jobserver/common"
 )
 
 const (

--- a/internal/jobserver/buildid/version.go
+++ b/internal/jobserver/buildid/version.go
@@ -20,14 +20,15 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/tools/go/packages"
+
 	"github.com/DataDog/orchestrion/internal/fingerprint"
 	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/injector/aspect"
 	"github.com/DataDog/orchestrion/internal/injector/config"
 	"github.com/DataDog/orchestrion/internal/version"
-	"github.com/rs/zerolog"
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/tools/go/packages"
 )
 
 type (

--- a/internal/jobserver/client/client.go
+++ b/internal/jobserver/client/client.go
@@ -11,8 +11,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/orchestrion/internal/jobserver/common"
 	"github.com/nats-io/nats.go"
+
+	"github.com/DataDog/orchestrion/internal/jobserver/common"
 )
 
 const (

--- a/internal/jobserver/client/env.go
+++ b/internal/jobserver/client/env.go
@@ -16,9 +16,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/binpath"
 	"github.com/DataDog/orchestrion/internal/filelock"
-	"github.com/rs/zerolog"
 )
 
 const (

--- a/internal/jobserver/common/graph_test.go
+++ b/internal/jobserver/common/graph_test.go
@@ -8,8 +8,9 @@ package common_test
 import (
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/jobserver/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/jobserver/common"
 )
 
 func Test(t *testing.T) {

--- a/internal/jobserver/nbt/nbt.go
+++ b/internal/jobserver/nbt/nbt.go
@@ -14,11 +14,12 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/DataDog/orchestrion/internal/files"
-	"github.com/DataDog/orchestrion/internal/jobserver/common"
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog"
+
+	"github.com/DataDog/orchestrion/internal/files"
+	"github.com/DataDog/orchestrion/internal/jobserver/common"
 )
 
 const (

--- a/internal/jobserver/pkgs/pkgs.go
+++ b/internal/jobserver/pkgs/pkgs.go
@@ -8,9 +8,10 @@ package pkgs
 import (
 	"context"
 
-	"github.com/DataDog/orchestrion/internal/jobserver/common"
 	"github.com/nats-io/nats.go"
 	"github.com/rs/zerolog"
+
+	"github.com/DataDog/orchestrion/internal/jobserver/common"
 )
 
 const (

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -16,11 +16,12 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/rs/zerolog"
+	"golang.org/x/tools/go/packages"
+
 	"github.com/DataDog/orchestrion/internal/binpath"
 	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
-	"github.com/rs/zerolog"
-	"golang.org/x/tools/go/packages"
 )
 
 const (

--- a/internal/jobserver/pkgs/resolve_test.go
+++ b/internal/jobserver/pkgs/resolve_test.go
@@ -13,12 +13,13 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/jobserver"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
 	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {

--- a/internal/jobserver/server.go
+++ b/internal/jobserver/server.go
@@ -14,14 +14,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/jobserver/buildid"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
 	"github.com/DataDog/orchestrion/internal/jobserver/common"
 	"github.com/DataDog/orchestrion/internal/jobserver/nbt"
 	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
-	"github.com/rs/zerolog"
 )
 
 const (

--- a/internal/pin/auto.go
+++ b/internal/pin/auto.go
@@ -13,12 +13,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/DataDog/orchestrion/internal/ensure"
-	"github.com/DataDog/orchestrion/internal/injector/config"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/rs/zerolog"
 	"golang.org/x/term"
+
+	"github.com/DataDog/orchestrion/internal/ensure"
+	"github.com/DataDog/orchestrion/internal/injector/config"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 const envVarCheckedGoMod = "DD_ORCHESTRION_IS_GOMOD_VERSION"

--- a/internal/pin/auto_test.go
+++ b/internal/pin/auto_test.go
@@ -12,10 +12,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/injector/config"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/injector/config"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 func TestAutoPin(t *testing.T) {

--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -20,15 +20,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/DataDog/orchestrion/internal/filelock"
-	"github.com/DataDog/orchestrion/internal/goenv"
-	"github.com/DataDog/orchestrion/internal/injector/config"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/rs/zerolog"
 	"golang.org/x/mod/semver"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/DataDog/orchestrion/internal/filelock"
+	"github.com/DataDog/orchestrion/internal/goenv"
+	"github.com/DataDog/orchestrion/internal/injector/config"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 const (

--- a/internal/pin/pin_test.go
+++ b/internal/pin/pin_test.go
@@ -14,10 +14,11 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/DataDog/orchestrion/internal/injector/config"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/injector/config"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 func TestPin(t *testing.T) {

--- a/internal/toolexec/aspect/linkdeps/linkdeps.go
+++ b/internal/toolexec/aspect/linkdeps/linkdeps.go
@@ -15,8 +15,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 	"github.com/rs/zerolog"
+
+	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 )
 
 const (

--- a/internal/toolexec/aspect/oncompile-main.go
+++ b/internal/toolexec/aspect/oncompile-main.go
@@ -17,10 +17,11 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/toolexec/aspect/linkdeps"
 	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
-	"github.com/rs/zerolog"
 )
 
 // OnCompileMain only performs changes when compiling the "main" package, adding blank imports for

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/goenv"
 	"github.com/DataDog/orchestrion/internal/injector"
 	"github.com/DataDog/orchestrion/internal/injector/aspect"
@@ -21,7 +23,6 @@ import (
 	"github.com/DataDog/orchestrion/internal/toolexec/aspect/linkdeps"
 	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
-	"github.com/rs/zerolog"
 )
 
 type (

--- a/internal/toolexec/aspect/onlink.go
+++ b/internal/toolexec/aspect/onlink.go
@@ -10,10 +10,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/toolexec/aspect/linkdeps"
 	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
-	"github.com/rs/zerolog"
 )
 
 func (Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) error {

--- a/internal/toolexec/proxy/compile.go
+++ b/internal/toolexec/proxy/compile.go
@@ -14,13 +14,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/files"
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
 	"github.com/DataDog/orchestrion/internal/jobserver/nbt"
 	"github.com/DataDog/orchestrion/internal/toolexec/aspect/linkdeps"
 	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
-	"github.com/rs/zerolog"
 )
 
 //go:generate go run github.com/DataDog/orchestrion/internal/toolexec/proxy/generator -command=compile

--- a/internal/toolexec/proxy/compile_test.go
+++ b/internal/toolexec/proxy/compile_test.go
@@ -11,10 +11,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/jobserver"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParseCompile(t *testing.T) {

--- a/internal/toolexec/version.go
+++ b/internal/toolexec/version.go
@@ -12,11 +12,12 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/rs/zerolog"
+
 	"github.com/DataDog/orchestrion/internal/jobserver"
 	"github.com/DataDog/orchestrion/internal/jobserver/buildid"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
-	"github.com/rs/zerolog"
 )
 
 // ComputeVersion returns the complete version string to be produced when the toolexec is invoked

--- a/internal/toolexec/version_test.go
+++ b/internal/toolexec/version_test.go
@@ -15,13 +15,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/otiai10/copy"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/orchestrion/internal/goflags"
 	"github.com/DataDog/orchestrion/internal/injector/config"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
-	"github.com/otiai10/copy"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/require"
 )
 
 var rootDir string

--- a/main.go
+++ b/main.go
@@ -20,12 +20,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/orchestrion/internal/cmd"
-	"github.com/DataDog/orchestrion/internal/jobserver/client"
-	"github.com/DataDog/orchestrion/internal/version"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
+
+	"github.com/DataDog/orchestrion/internal/cmd"
+	"github.com/DataDog/orchestrion/internal/jobserver/client"
+	"github.com/DataDog/orchestrion/internal/version"
 )
 
 const (


### PR DESCRIPTION
`goimports` has mode to group local imports together. Somehow this triggered my OCD 😅 
This is marked as draft to test the waters. Feel free to reject.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>
