### PR TITLE
release: v1.1.0

### DIFF
--- a/instrument/go.mod
+++ b/instrument/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 replace github.com/DataDog/orchestrion => ..
 
 require (
-	github.com/DataDog/orchestrion v1.1.0-rc.2
-	gopkg.in/DataDog/dd-trace-go.v1 v1.73.0-dev
+	github.com/DataDog/orchestrion v1.1.0-rc.3
+	gopkg.in/DataDog/dd-trace-go.v1 v1.72.1
 )
 
 require (

--- a/instrument/go.sum
+++ b/instrument/go.sum
@@ -1120,8 +1120,8 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
-gopkg.in/DataDog/dd-trace-go.v1 v1.73.0-dev h1:R59+DNRhg9j+hl5ObfZpwzXxRfc6z74Ot775pT7mw1Q=
-gopkg.in/DataDog/dd-trace-go.v1 v1.73.0-dev/go.mod h1:XqDhDqsLpThFnJc4z0FvAEItISIAUka+RHwmQ6EfN1U=
+gopkg.in/DataDog/dd-trace-go.v1 v1.72.1 h1:QG2HNpxe9H4WnztDYbdGQJL/5YIiiZ6xY1+wMuQ2c1w=
+gopkg.in/DataDog/dd-trace-go.v1 v1.72.1/go.mod h1:XqDhDqsLpThFnJc4z0FvAEItISIAUka+RHwmQ6EfN1U=
 gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183/go.mod h1:FvqrFXt+jCsyQibeRv4xxEJBL5iG2DDW5aeJwzDiq4A=
 gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
 gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=

--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -122,7 +122,7 @@ func PinOrchestrion(ctx context.Context, opts Options) error {
 
 	if ver, found := curMod.requires(datadogTracerV1); !found || semver.Compare(ver, "v1.72.0-rc.1") < 0 {
 		log.Info().Msg("Installing or upgrading " + datadogTracerV1)
-		if err := runGoGet(ctx, goMod, datadogTracerV1+"@>=v1.72.0-rc.1"); err != nil {
+		if err := runGoGet(ctx, goMod, datadogTracerV1+"@latest"); err != nil {
 			return fmt.Errorf("go get "+datadogTracerV1+": %w", err)
 		}
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "runtime/debug"
 
 const (
 	// tag specifies the current release tag. It needs to be manually updated.
-	tag       = "v1.1.0-rc.3"
+	tag       = "v1.1.0"
 	devSuffix = "+devel"
 )
 


### PR DESCRIPTION
This is the first `dd-trace-go@v2`-ready, vendor-neutral release of orchestrion.