### PR TITLE
fix: add-struct-field does not implicitly import the type's package

### DIFF
--- a/internal/injector/aspect/advice/struct.go
+++ b/internal/injector/aspect/advice/struct.go
@@ -45,6 +45,11 @@ func (a *addStructField) Apply(ctx context.AdviceContext) (bool, error) {
 		Type:  a.TypeName.AsNode(),
 	})
 
+	if importPath := a.TypeName.ImportPath(); importPath != "" {
+		// If the type name is qualified, we may need to import the package, too.
+		_ = ctx.AddImport(importPath, inferPkgName(importPath))
+	}
+
 	return true, nil
 }
 

--- a/internal/injector/testdata/injector/add-struct-field/config.yml
+++ b/internal/injector/testdata/injector/add-struct-field/config.yml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+aspects:
+  - join-point:
+      struct-definition: github.com/ACME/Example.Package.injectMe
+    advice:
+      - add-struct-field:
+          name: newField
+          type: time.Duration
+
+syntheticReferences:
+  time: true
+
+import-path: github.com/ACME/Example.Package
+
+code: |-
+  package example
+
+  type injectMe struct {
+    existingField string
+  }

--- a/internal/injector/testdata/injector/add-struct-field/modified.go.snap
+++ b/internal/injector/testdata/injector/add-struct-field/modified.go.snap
@@ -1,0 +1,12 @@
+//line input.go:1:1
+package example
+
+//line <generated>:1
+import __orchestrion_time "time"
+
+//line input.go:3
+type injectMe struct {
+  existingField string
+//line <generated>:1
+  newField __orchestrion_time.Duration
+}


### PR DESCRIPTION
Whena dding a new field to a struct, the package containing the type of the field may need importing, which was not previously done.