### PR TITLE
feat: new //orchestrion:version pragma

### DIFF
--- a/internal/injector/config/builtin.go
+++ b/internal/injector/config/builtin.go
@@ -34,11 +34,26 @@ var builtIn = configGo{
 					),
 				},
 			},
+			{
+				ID: "built.WithOrchestrionVersion",
+				JoinPoint: join.AllOf(
+					join.ValueDeclaration(join.MustTypeName("string")),
+					join.OneOf(
+						join.DeclarationOf("github.com/DataDog/orchestrion/runtime/built", "WithOrchestrionVersion"),
+						join.Directive("orchestrion:version"),
+					),
+				),
+				Advice: []advice.Advice{
+					advice.AssignValue(
+						code.MustTemplate(`{{Version | printf "%q"}}`, nil, context.GoLangVersion{}),
+					),
+				},
+			},
 		},
 		name: "<built-in>",
 		meta: configYMLMeta{
-			name:        "built.WithOrchestrion & //orchestrion:enabled",
-			description: "Flip a boolean to true if Orchestrion is enabled.",
+			name:        "github.com/DataDog/orchestrion/built & //orchestrion: pragmas",
+			description: "Provide runtime visibility into whether orchestrion built an application or not",
 			icon:        "cog",
 			caveats: "This aspect allows introducing conditional logic based on whether" +
 				"Orchestrion has been used to instrument an application or not. This should" +

--- a/internal/injector/config/builtin.go
+++ b/internal/injector/config/builtin.go
@@ -35,7 +35,8 @@ var builtIn = configGo{
 				},
 			},
 			{
-				ID: "built.WithOrchestrionVersion",
+				ID:             "built.WithOrchestrionVersion",
+				TracerInternal: true, // This is safe to apply in the tracer itself
 				JoinPoint: join.AllOf(
 					join.ValueDeclaration(join.MustTypeName("string")),
 					join.OneOf(

--- a/internal/injector/config/config_test.go
+++ b/internal/injector/config/config_test.go
@@ -195,7 +195,7 @@ func TestLoad(t *testing.T) {
 		enc.SetIndent(2)
 		require.NoError(t, enc.Encode(cfg))
 
-		assert.Len(t, cfg.Aspects(), 1) // Just the orchestrion:enabled aspect
+		assert.Len(t, cfg.Aspects(), len(builtIn.yaml.aspects)) // Just the orchestrion:... aspects
 		golden.Assert(t, buf.String(), "required.snap.yml")
 	})
 
@@ -210,7 +210,7 @@ func TestLoad(t *testing.T) {
 		enc.SetIndent(2)
 		require.NoError(t, enc.Encode(cfg))
 
-		assert.Len(t, cfg.Aspects(), 116)
+		assert.Len(t, cfg.Aspects(), 115+len(builtIn.yaml.aspects))
 		golden.Assert(t, buf.String(), "instrument.snap.yml")
 	})
 
@@ -241,7 +241,7 @@ func TestLoad(t *testing.T) {
 		loader := NewLoader(tmp, false)
 		cfg, err := loader.Load()
 		require.NoError(t, err)
-		require.Len(t, cfg.Aspects(), 2)
+		require.Len(t, cfg.Aspects(), len(builtIn.yaml.aspects)+1)
 	})
 }
 

--- a/internal/injector/config/testdata/instrument.snap.yml
+++ b/internal/injector/config/testdata/instrument.snap.yml
@@ -5,6 +5,7 @@ imports:
       name: <built-in>
       aspects:
         - built.WithOrchestrion
+        - built.WithOrchestrionVersion
   - pkgpath: gopkg.in/DataDog/dd-trace-go.v1
     imports:
       - pkgpath: gopkg.in/DataDog/dd-trace-go.v1/contrib/99designs/gqlgen

--- a/internal/injector/config/testdata/required.snap.yml
+++ b/internal/injector/config/testdata/required.snap.yml
@@ -3,3 +3,4 @@ yaml:
   name: <built-in>
   aspects:
     - built.WithOrchestrion
+    - built.WithOrchestrionVersion

--- a/runtime/built/built.go
+++ b/runtime/built/built.go
@@ -17,3 +17,9 @@ package built
 // avoid double-instrumentation, or to guarantee the application runs with
 // automatic instrumentation. Most users should not need to use this variable.
 const WithOrchestrion = false
+
+// WithOrchestrionVersion is the version of orchestrion used to build the
+// library, if the application was built by it. It is a blank string otherwise.
+// This can be useful context to include in logs when the use of orchestrion is
+// relevant. Most users should not need to use this variable.
+const WithOrchestrionVersion = ""

--- a/runtime/built/built_test.go
+++ b/runtime/built/built_test.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package built_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/DataDog/orchestrion/internal/injector/config"
+	"github.com/DataDog/orchestrion/internal/version"
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	tmp := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "main.go"), []byte(testProgram), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, config.FilenameOrchestrionToolGo), []byte(orchestrionToolGo), 0o644))
+
+	cmd := exec.Command("go", "mod", "init", "dummy.test")
+	cmd.Dir = tmp
+	require.NoError(t, cmd.Run())
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	rootDir := filepath.Join(thisFile, "..", "..", "..")
+	cmd = exec.Command("go", "mod", "edit", fmt.Sprintf("-replace=github.com/DataDog/orchestrion=%s", rootDir))
+	cmd.Dir = tmp
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.Command("go", "mod", "tidy")
+	cmd.Dir = tmp
+	require.NoError(t, cmd.Run())
+
+	var stdout bytes.Buffer
+	cmd = exec.Command("go", "run", "github.com/DataDog/orchestrion", "go", "run", ".")
+	cmd.Dir = tmp
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	require.Equal(t, version.Tag(), stdout.String())
+}
+
+const testProgram = `package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/orchestrion/runtime/built"
+)
+
+func main() {
+	if !built.WithOrchestrion {
+		os.Exit(42)
+	}
+
+	fmt.Print(built.WithOrchestrionVersion)
+}
+`
+
+const orchestrionToolGo = `//go:build tools
+
+package tools
+
+import (
+	_ "github.com/DataDog/orchestrion"
+)
+`


### PR DESCRIPTION
Introduce a new //orchestrion:version pragma to
allow run-time determination of the orchestrion
version that built a given binary.

This would be useful to implement telemetry directly
in the tracer so it is reliably sent even when the
tracer is not started by orchestrion itself.