### PR TITLE
feat(injector): Add ability to find function results implementing an interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iml
 /bin
 /errors
+/tmp
 *.swp
 orchestrion
 coverage/

--- a/internal/injector/aspect/advice/code/dot_function.go
+++ b/internal/injector/aspect/advice/code/dot_function.go
@@ -42,10 +42,11 @@ type (
 		// ResultThatImplements returns the name of the first return value in this function that implements
 		// the provided interface type, or an empty string if none is found.
 		ResultThatImplements(string) (string, error)
-		// LastResultThatImplements returns the name of the last return value in this function that implements
+		// LastResultThatImplements returns the name of the last return value
+		// (may not be the last item in the function's return list) in this function that implements
 		// the provided interface type, or an empty string if none is found.
 		LastResultThatImplements(string) (string, error)
-		// FinalResultImplements returns whether the final result implements the provided interface type.
+		// FinalResultImplements returns whether the final (very last item that is returned) result implements the provided interface type.
 		FinalResultImplements(string) (bool, error)
 	}
 

--- a/internal/injector/aspect/advice/code/dot_function_test.go
+++ b/internal/injector/aspect/advice/code/dot_function_test.go
@@ -72,3 +72,70 @@ func TestResolveInterfaceTypeByName(t *testing.T) {
 		})
 	}
 }
+
+// TestSplitPackageAndName tests the SplitPackageAndName function with various package name formats.
+func TestSplitPackageAndName(t *testing.T) {
+	testCases := []struct {
+		name          string
+		fullName      string
+		expectedPkg   string
+		expectedLocal string
+	}{
+		{
+			name:          "standard library package",
+			fullName:      "io.Reader",
+			expectedPkg:   "io",
+			expectedLocal: "Reader",
+		},
+		{
+			name:          "built-in type",
+			fullName:      "error",
+			expectedPkg:   "",
+			expectedLocal: "error",
+		},
+		{
+			name:          "unqualified type",
+			fullName:      "MyType",
+			expectedPkg:   "",
+			expectedLocal: "MyType",
+		},
+		{
+			name:          "github import path",
+			fullName:      "github.com/user/pkg.Type",
+			expectedPkg:   "github.com/user/pkg",
+			expectedLocal: "Type",
+		},
+		{
+			name:          "versioned package",
+			fullName:      "gopkg.in/pkg.v1.Type",
+			expectedPkg:   "gopkg.in/pkg.v1",
+			expectedLocal: "Type",
+		},
+		{
+			name:          "complex domain with version and subpackage",
+			fullName:      "gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span",
+			expectedPkg:   "gopkg.in/DataDog/dd-trace-go.v1/ddtrace",
+			expectedLocal: "Span",
+		},
+		{
+			name:          "standard domain with version",
+			fullName:      "github.com/DataDog/dd-trace-go/v2.Tracer",
+			expectedPkg:   "github.com/DataDog/dd-trace-go/v2",
+			expectedLocal: "Tracer",
+		},
+		{
+			name:          "multiple dots in package name",
+			fullName:      "k8s.io/client-go/kubernetes.Clientset",
+			expectedPkg:   "k8s.io/client-go/kubernetes",
+			expectedLocal: "Clientset",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg, local := splitPackageAndName(tc.fullName)
+			assert.Equal(t, tc.expectedPkg, pkg, "Package path should match")
+			assert.Equal(t, tc.expectedLocal, local, "Local name should match")
+		})
+	}
+}

--- a/internal/injector/aspect/advice/code/dot_function_test.go
+++ b/internal/injector/aspect/advice/code/dot_function_test.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package code
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveInterfaceTypeByName tests the resolveInterfaceTypeByName function with various interface name formats.
+func TestResolveInterfaceTypeByName(t *testing.T) {
+	// Test cases for different interface types
+	testCases := []struct {
+		name           string
+		interfaceName  string
+		shouldSucceed  bool
+		expectedMethod string
+	}{
+		{
+			name:           "stdlib interface io.Reader",
+			interfaceName:  "io.Reader",
+			shouldSucceed:  true,
+			expectedMethod: "Read",
+		},
+		{
+			name:           "built-in error interface",
+			interfaceName:  "error",
+			shouldSucceed:  true,
+			expectedMethod: "Error",
+		},
+		{
+			name:          "invalid interface name",
+			interfaceName: "123invalid",
+			shouldSucceed: false,
+		},
+		{
+			name:          "nonexistent interface",
+			interfaceName: "nonexistent.Interface",
+			shouldSucceed: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iface, err := resolveInterfaceTypeByName(tc.interfaceName)
+
+			if !tc.shouldSucceed {
+				require.Error(t, err)
+				require.Nil(t, iface)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, iface)
+
+			if tc.expectedMethod != "" {
+				found := false
+				for i := 0; i < iface.NumMethods(); i++ {
+					if iface.Method(i).Name() == tc.expectedMethod {
+						found = true
+						break
+					}
+				}
+
+				assert.True(t, found, "Interface does not contain expected method %s", tc.expectedMethod)
+			}
+		})
+	}
+}

--- a/internal/injector/aspect/advice/code/template_test.go
+++ b/internal/injector/aspect/advice/code/template_test.go
@@ -38,60 +38,75 @@ func (mockAdviceContext) ParseSource(src []byte) (*dst.File, error) {
 }
 
 // The rest is not used by the tests as of now...
+
 func (m mockAdviceContext) ResolveType(dst.Expr) types.Type {
 	assert.FailNow(m.t, "unexpected method call")
 	return nil
 }
+
 func (m mockAdviceContext) Release() {
 	assert.FailNow(m.t, "unexpected method call")
 }
+
 func (m mockAdviceContext) Chain() *context.NodeChain {
 	assert.FailNow(m.t, "unexpected method call")
 	return nil
 }
+
 func (m mockAdviceContext) Node() dst.Node {
 	assert.FailNow(m.t, "unexpected method call")
 	return nil
 }
+
 func (m mockAdviceContext) Parent() context.AspectContext {
 	assert.FailNow(m.t, "unexpected method call")
 	return nil
 }
+
 func (m mockAdviceContext) Config(string) (string, bool) {
 	assert.FailNow(m.t, "unexpected method call")
 	return "", false
 }
+
 func (m mockAdviceContext) File() *dst.File {
 	assert.FailNow(m.t, "unexpected method call")
 	return nil
 }
+
 func (m mockAdviceContext) ImportPath() string {
 	assert.FailNow(m.t, "unexpected method call")
 	return ""
 }
+
 func (m mockAdviceContext) Package() string {
 	assert.FailNow(m.t, "unexpected method call")
 	return ""
 }
+
 func (m mockAdviceContext) TestMain() bool {
 	assert.FailNow(m.t, "unexpected method call")
 	return false
 }
+
 func (m mockAdviceContext) Child(dst.Node, string, int) context.AdviceContext {
 	assert.FailNow(m.t, "unexpected method call")
 	return nil
 }
+
 func (m mockAdviceContext) ReplaceNode(dst.Node) {
 	assert.FailNow(m.t, "unexpected method call")
 }
+
 func (m mockAdviceContext) AddImport(string, string) bool {
 	assert.FailNow(m.t, "unexpected method call")
 	return false
 }
+
 func (m mockAdviceContext) AddLink(string) bool {
 	assert.FailNow(m.t, "unexpected method call")
 	return false
 }
+
 func (m mockAdviceContext) EnsureMinGoLang(context.GoLangVersion) {
 	assert.FailNow(m.t, "unexpected method call")
 }

--- a/internal/injector/aspect/advice/code/template_test.go
+++ b/internal/injector/aspect/advice/code/template_test.go
@@ -6,15 +6,17 @@
 package code_test
 
 import (
+	"go/types"
 	"testing"
 
-	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
-	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect/advice/code"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 )
 
 func TestTemplate(t *testing.T) {
@@ -36,6 +38,10 @@ func (mockAdviceContext) ParseSource(src []byte) (*dst.File, error) {
 }
 
 // The rest is not used by the tests as of now...
+func (m mockAdviceContext) ResolveType(dst.Expr) types.Type {
+	assert.FailNow(m.t, "unexpected method call")
+	return nil
+}
 func (m mockAdviceContext) Release() {
 	assert.FailNow(m.t, "unexpected method call")
 }

--- a/internal/injector/aspect/context/context.go
+++ b/internal/injector/aspect/context/context.go
@@ -171,6 +171,8 @@ func (c *context) Release() {
 func (c *context) Child(node dst.Node, property string, index int) AdviceContext {
 	r, _ := contextPool.Get().(*context)
 	*r = context{
+		log: c.log,
+
 		NodeChain: &NodeChain{
 			parent: c.NodeChain,
 			node:   node,

--- a/internal/injector/aspect/context/context.go
+++ b/internal/injector/aspect/context/context.go
@@ -6,11 +6,14 @@
 package context
 
 import (
+	"go/ast"
+	"go/types"
 	"sync"
 
-	"github.com/DataDog/orchestrion/internal/injector/typed"
 	"github.com/dave/dst"
 	"github.com/dave/dst/dstutil"
+
+	"github.com/DataDog/orchestrion/internal/injector/typed"
 )
 
 type AspectContext interface {
@@ -71,6 +74,9 @@ type AdviceContext interface {
 	// EnsureMinGoLang ensures that the current compile unit uses at least the
 	// specified language level when passed to the compiler.
 	EnsureMinGoLang(GoLangVersion)
+
+	// ResolveType resolves a dst.Expr to its corresponding types.Type.
+	ResolveType(dst.Expr) types.Type
 }
 
 type (
@@ -85,6 +91,8 @@ type (
 		sourceParser SourceParser
 		importPath   string
 		testMain     bool
+		typeInfo     types.Info
+		nodeMap      map[dst.Node]ast.Node
 	}
 
 	SourceParser interface {
@@ -112,6 +120,10 @@ type ContextArgs struct {
 	MinGoLang *GoLangVersion
 	// TestMain is true when injecting into a synthetic main package.
 	TestMain bool
+	// TypeInfo contains type information about the AST.
+	TypeInfo types.Info
+	// NodeMap maps dst.Node to ast.Node.
+	NodeMap map[dst.Node]ast.Node
 }
 
 // Context returns a new [*context] instance that represents the ndoe at the
@@ -129,6 +141,8 @@ func (n *NodeChain) Context(args ContextArgs) *context {
 		sourceParser: args.SourceParser,
 		importPath:   args.ImportPath,
 		testMain:     args.TestMain,
+		typeInfo:     args.TypeInfo,
+		nodeMap:      args.NodeMap,
 	}
 
 	return c
@@ -163,6 +177,8 @@ func (c *context) Child(node dst.Node, property string, index int) AdviceContext
 		sourceParser: c.sourceParser,
 		importPath:   c.importPath,
 		testMain:     c.testMain,
+		typeInfo:     c.typeInfo,
+		nodeMap:      c.nodeMap,
 	}
 
 	return r
@@ -191,6 +207,8 @@ func (c *context) Parent() AspectContext {
 		file:       c.file,
 		refMap:     c.refMap,
 		importPath: c.importPath,
+		typeInfo:   c.typeInfo,
+		nodeMap:    c.nodeMap,
 	}
 
 	return p
@@ -239,4 +257,70 @@ func (c *context) AddLink(path string) bool {
 
 func (c *context) EnsureMinGoLang(lang GoLangVersion) {
 	c.minGoLang.SetAtLeast(lang)
+}
+
+// ResolveType resolves a dst.Expr to its corresponding types.Type within the
+// current context.
+func (c *context) ResolveType(expr dst.Expr) types.Type {
+	if expr == nil {
+		return nil
+	}
+
+	// Convert dst.Expr to ast.Expr using the nodeMap.
+	astNode, ok := c.nodeMap[expr]
+	if !ok {
+		return nil
+	}
+
+	// Convert ast.Node to ast.Expr.
+	astExpr, ok := astNode.(ast.Expr)
+	if !ok {
+		return nil
+	}
+
+	// Get the type from the typeInfo map.
+	if t, ok := c.typeInfo.Types[astExpr]; ok {
+		return t.Type
+	}
+
+	// For identifiers, try to get the type from Uses.
+	if astIdent, ok := astExpr.(*ast.Ident); ok {
+		if obj, ok := c.typeInfo.Uses[astIdent]; ok {
+			return obj.Type()
+		}
+	}
+
+	// For selector expressions (pkg.Type), try Uses on the selector.
+	if selExpr, ok := astExpr.(*ast.SelectorExpr); ok {
+		if obj, ok := c.typeInfo.Uses[selExpr.Sel]; ok {
+			return obj.Type()
+		}
+	}
+
+	// For star expressions (*Type), resolve the underlying type and return a pointer.
+	// Need to convert back from ast.Expr to dst.Expr to use nodeMap recursively.
+	if starExpr, ok := astExpr.(*ast.StarExpr); ok {
+		// Find the corresponding dst.Node for starExpr.X
+		var dstX dst.Expr
+		// Iterate through nodeMap to find the dst.Node corresponding to ast.Node starExpr.X
+		// This is inefficient but necessary as we don't have a direct reverse mapping.
+		// Consider optimizing if performance becomes an issue.
+		for dNode, aNode := range c.nodeMap {
+			if aNode == starExpr.X {
+				if dExpr, ok := dNode.(dst.Expr); ok {
+					dstX = dExpr
+					break
+				}
+			}
+		}
+
+		if dstX != nil {
+			underlyingType := c.ResolveType(dstX)
+			if underlyingType != nil {
+				return types.NewPointer(underlyingType)
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/injector/aspect/context/context_test.go
+++ b/internal/injector/aspect/context/context_test.go
@@ -1,0 +1,216 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package context
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveType tests the ResolveType method thoroughly, covering all code paths:
+// - nil expression
+// - unmapped expression
+// - mapping to a non-expression AST node
+// - basic types (int, string)
+// - custom types (named types)
+// - pointer types
+// - interface types (error)
+// - resolution via Types map
+// - resolution via Uses map
+func TestResolveType(t *testing.T) {
+	// Create a simple source file
+	src := `package test
+
+type MyInt int
+type MyStruct struct {
+	Field int
+}
+
+func TestFunc(i int, s string, m MyInt, ms *MyStruct) (int, error) {
+	return 0, nil
+}
+`
+
+	// Parse the source file.
+	fset := token.NewFileSet()
+	parsedFile, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	// Create the decorator.
+	dec := decorator.NewDecorator(fset)
+	f, err := dec.DecorateFile(parsedFile)
+	require.NoError(t, err)
+
+	// Create type information.
+	info := types.Info{
+		Types: make(map[ast.Expr]types.TypeAndValue),
+		Defs:  make(map[*ast.Ident]types.Object),
+		Uses:  make(map[*ast.Ident]types.Object),
+	}
+
+	// Create a minimal type-checker package to define types.
+	pkg := types.NewPackage("test", "test")
+
+	// Create the basic types we'll need for testing.
+	intType := types.Typ[types.Int]
+	stringType := types.Typ[types.String]
+	myIntType := types.NewNamed(types.NewTypeName(0, pkg, "MyInt", nil), intType, nil)
+	myStructType := types.NewNamed(types.NewTypeName(0, pkg, "MyStruct", nil),
+		types.NewStruct([]*types.Var{types.NewVar(0, pkg, "Field", intType)}, nil), nil)
+	myStructPtrType := types.NewPointer(myStructType)
+
+	// Create the error interface type.
+	errorType := types.Universe.Lookup("error").Type().Underlying().(*types.Interface)
+
+	// Get the AST nodes we need for the test.
+	var funcDecl *dst.FuncDecl
+	for _, decl := range f.Decls {
+		if fd, ok := decl.(*dst.FuncDecl); ok {
+			funcDecl = fd
+			break
+		}
+	}
+	require.NotNil(t, funcDecl, "FuncDecl not found")
+
+	// Get parameter expressions for testing.
+	params := funcDecl.Type.Params.List
+	require.Len(t, params, 4, "Expected 4 parameters")
+
+	// Get result expressions for testing.
+	results := funcDecl.Type.Results.List
+	require.Len(t, results, 2, "Expected 2 results")
+
+	// Create a mapping from dst nodes to ast nodes.
+	// Normally this would be populated by the decorator, but we'll create a minimal version for testing.
+	nodeMap := make(map[dst.Node]ast.Node)
+
+	// Create AST versions of our expressions for the nodeMap.
+	intParamAst := &ast.Ident{Name: "int"}
+	stringParamAst := &ast.Ident{Name: "string"}
+	myIntParamAst := &ast.Ident{Name: "MyInt"}
+	myStructPtrParamAst := &ast.StarExpr{X: &ast.Ident{Name: "MyStruct"}}
+	intResultAst := &ast.Ident{Name: "int"}
+	errorResultAst := &ast.Ident{Name: "error"}
+
+	// Create a non-expression node for testing the type assertion failure.
+	nonExpressionAst := &ast.BadStmt{}
+
+	// Populate the types map.
+	info.Types[intParamAst] = types.TypeAndValue{Type: intType}
+	info.Types[stringParamAst] = types.TypeAndValue{Type: stringType}
+	info.Types[myIntParamAst] = types.TypeAndValue{Type: myIntType}
+	info.Types[myStructPtrParamAst] = types.TypeAndValue{Type: myStructPtrType}
+	info.Types[intResultAst] = types.TypeAndValue{Type: intType}
+
+	// Set up the error type using the Uses map (simulating how it works in real code).
+	errorObj := types.Universe.Lookup("error")
+	info.Uses[errorResultAst] = errorObj
+
+	// Add the mapping from dst nodes to ast nodes.
+	nodeMap[params[0].Type] = intParamAst         // int
+	nodeMap[params[1].Type] = stringParamAst      // string
+	nodeMap[params[2].Type] = myIntParamAst       // MyInt
+	nodeMap[params[3].Type] = myStructPtrParamAst // *MyStruct
+	nodeMap[results[0].Type] = intResultAst       // int
+	nodeMap[results[1].Type] = errorResultAst     // error
+
+	// Map an expression to a non-expression ast node for testing the type assertion.
+	nodeMap[&dst.Ident{Name: "nonExprAst"}] = nonExpressionAst
+
+	// Create a minimal node chain for the context.
+	chain := &NodeChain{
+		node: funcDecl,
+	}
+
+	ctx := context{
+		NodeChain: chain,
+		typeInfo:  info,
+		nodeMap:   nodeMap,
+	}
+
+	testCases := []struct {
+		name     string
+		expr     dst.Expr
+		expected types.Type
+	}{
+		{
+			name:     "nil expression",
+			expr:     nil,
+			expected: nil,
+		},
+		{
+			name:     "unmapped expression",
+			expr:     &dst.Ident{Name: "nonexistent"},
+			expected: nil,
+		},
+		{
+			name:     "mapped to non-expression AST node",
+			expr:     &dst.Ident{Name: "nonExprAst"},
+			expected: nil,
+		},
+		{
+			name:     "int parameter",
+			expr:     params[0].Type,
+			expected: intType,
+		},
+		{
+			name:     "string parameter",
+			expr:     params[1].Type,
+			expected: stringType,
+		},
+		{
+			name:     "custom type parameter (MyInt)",
+			expr:     params[2].Type,
+			expected: myIntType,
+		},
+		{
+			name:     "pointer type parameter (*MyStruct)",
+			expr:     params[3].Type,
+			expected: myStructPtrType,
+		},
+		{
+			name:     "int result",
+			expr:     results[0].Type,
+			expected: intType,
+		},
+		{
+			name:     "error result using Uses map",
+			expr:     results[1].Type,
+			expected: errorType,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolvedType := ctx.ResolveType(tc.expr)
+
+			if tc.expected == nil {
+				assert.Nil(t, resolvedType)
+				return
+			}
+			require.NotNil(t, resolvedType, "Type should not be nil for %s", tc.name)
+
+			// Use types.Identical for robust type comparison, except for interfaces like error
+			// where assignability might be more appropriate depending on how the type is resolved.
+			if types.IsInterface(tc.expected) {
+				assert.True(t, types.AssignableTo(resolvedType, tc.expected.Underlying().(*types.Interface)),
+					"Expected resolved type %s to be assignable to %s", resolvedType, tc.expected)
+				return
+			}
+
+			assert.True(t, types.Identical(tc.expected, resolvedType),
+				"Expected type %s, but got %s", tc.expected, resolvedType)
+		})
+	}
+}

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -242,7 +242,7 @@ func (i *Injector) applyAspects(ctx gocontext.Context, params parameters) (resul
 		}()
 
 		var changed bool
-		ctx := chain.Context(context.ContextArgs{
+		ctx := chain.Context(ctx, context.ContextArgs{
 			Cursor:       csor,
 			ImportPath:   params.Decorator.Path,
 			File:         params.File,
@@ -254,6 +254,7 @@ func (i *Injector) applyAspects(ctx gocontext.Context, params parameters) (resul
 			NodeMap:      params.Decorator.Ast.Nodes,
 		})
 		defer ctx.Release()
+
 		changed, err = injectNode(ctx, params.Aspects)
 		modified = modified || changed
 

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -250,6 +250,8 @@ func (i *Injector) applyAspects(ctx gocontext.Context, params parameters) (resul
 			SourceParser: params.Decorator,
 			MinGoLang:    &minGoLang,
 			TestMain:     i.TestMain,
+			TypeInfo:     params.TypeInfo,
+			NodeMap:      params.Decorator.Ast.Nodes,
 		})
 		defer ctx.Release()
 		changed, err = injectNode(ctx, params.Aspects)
@@ -288,6 +290,7 @@ func injectNode(ctx context.AdviceContext, aspects []*aspect.Aspect) (mod bool, 
 		if !inj.JoinPoint.Matches(ctx) {
 			continue
 		}
+
 		for idx, act := range inj.Advice {
 			var changed bool
 			changed, err := act.Apply(ctx)

--- a/internal/injector/testdata/injector/result-implements/config.yml
+++ b/internal/injector/testdata/injector/result-implements/config.yml
@@ -51,6 +51,74 @@ aspects:
             fmt.Println("Failure: Cannot compare errors: At least one error position not found")
             {{ end }}
 
+  - id: "aspect-final-error-check"
+    join-point:
+      function-body:
+        function:
+          - name: returnsError
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing FinalResultImplements for error (single result)")
+            {{ if .Function.FinalResultImplements "error" }}
+            fmt.Println("Success: Final result implements error interface")
+            {{ else }}
+            fmt.Println("Failure: Final result does not implement error interface")
+            {{ end }}
+
+  - id: "aspect-final-multiple-errors"
+    join-point:
+      function-body:
+        function:
+          - name: returnsMultipleErrors
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing FinalResultImplements for error (multiple results)")
+            {{ if .Function.FinalResultImplements "error" }}
+            fmt.Println("Success: Final result implements error interface")
+            {{ else }}
+            fmt.Println("Failure: Final result does not implement error interface")
+            {{ end }}
+
+  - id: "aspect-final-reader"
+    join-point:
+      function-body:
+        function:
+          - name: returnsReader
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing FinalResultImplements for io.Reader")
+            {{ if .Function.FinalResultImplements "io.Reader" }}
+            fmt.Println("Success: Final result implements io.Reader interface")
+            {{ else }}
+            fmt.Println("Failure: Final result does not implement io.Reader interface")
+            {{ end }}
+
+  - id: "aspect-final-no-match"
+    join-point:
+      function-body:
+        function:
+          - name: returnsNoMatch
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing FinalResultImplements for error (no match)")
+            {{ if .Function.FinalResultImplements "error" }}
+            fmt.Println("Failure: Final result implements error interface")
+            {{ else }}
+            fmt.Println("Success: Final result does not implement error interface")
+            {{ end }}
+
   - id: "aspect-io-reader"
     join-point:
       function-body:
@@ -204,6 +272,26 @@ aspects:
             fmt.Println("Failure: No io.Reader found")
             {{ end }}
 
+  - id: "aspect-error-non-final-position"
+    join-point:
+      function-body:
+        function:
+          - name: returnsErrorButNotLast
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing distinction case: error in non-final position")
+            {{ $last := .Function.LastResultThatImplements "error" }}
+            {{ $implements := .Function.FinalResultImplements "error" }}
+            fmt.Printf("LastResultThatImplements 'error': %q\n", "{{ $last }}")
+            {{ if $implements }}
+            fmt.Println("FinalResultImplements 'error': true (INCORRECT!)")
+            {{ else }}
+            fmt.Println("FinalResultImplements 'error': false (CORRECT!)")
+            {{ end }}
+
 syntheticReferences:
   fmt: true
 
@@ -297,4 +385,9 @@ code: |-
   // Returns a value that doesn't implement error
   func returnsString() string {
     return "not an error"
+  }
+
+  // Function where the last result implementing an interface is NOT the final result
+  func returnsErrorButNotLast() (error, string) {
+    return errors.New("error not in final position"), "final result"
   }

--- a/internal/injector/testdata/injector/result-implements/config.yml
+++ b/internal/injector/testdata/injector/result-implements/config.yml
@@ -1,0 +1,300 @@
+%YAML 1.1
+---
+aspects:
+  - id: "aspect-error-implements"
+    join-point:
+      function-body:
+        function:
+          - name: returnsError
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for error")
+            {{ with .Function.ResultThatImplements "error" }}
+            fmt.Printf("Success: Found error at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No error found")
+            {{ end }}
+
+  - id: "aspect-multiple-errors"
+    join-point:
+      function-body:
+        function:
+          - name: returnsMultipleErrors
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing LastResultThatImplements for error")
+            {{ $first := .Function.ResultThatImplements "error" }}
+            {{ $last := .Function.LastResultThatImplements "error" }}
+            {{ with $first }}
+            fmt.Printf("Success: Found first error at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No first error found")
+            {{ end }}
+            {{ with $last }}
+            fmt.Printf("Success: Found last error at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No last error found")
+            {{ end }}
+            {{ if and $first $last }}
+              {{ if ne $first $last }}
+            fmt.Println("Success: First and last errors are different")
+              {{ else }}
+            fmt.Println("Failure: First and last errors are the same")
+              {{ end }}
+            {{ else }}
+            fmt.Println("Failure: Cannot compare errors: At least one error position not found")
+            {{ end }}
+
+  - id: "aspect-io-reader"
+    join-point:
+      function-body:
+        function:
+          - name: returnsReader
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for io.Reader")
+            {{ with .Function.ResultThatImplements "io.Reader" }}
+            fmt.Printf("Success: Found io.Reader at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No io.Reader found")
+            {{ end }}
+
+  - id: "aspect-strings-reader"
+    join-point:
+      function-body:
+        function:
+          - name: returnsStringReader
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for *strings.Reader")
+            {{ with .Function.ResultThatImplements "io.Reader" }}
+            fmt.Printf("Success: Found io.Reader at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No io.Reader found")
+            {{ end }}
+
+  - id: "aspect-no-match"
+    join-point:
+      function-body:
+        function:
+          - name: returnsNoMatch
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for error (no match)")
+            {{ with .Function.ResultThatImplements "error" }}
+            fmt.Printf("Failure: Found error at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Success: No error found")
+            {{ end }}
+
+  - id: "aspect-concrete-value-reader"
+    join-point:
+      function-body:
+        function:
+          - name: returnsConcreteValueReader
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for io.Reader (concrete value, value receiver)")
+            {{ with .Function.ResultThatImplements "io.Reader" }}
+            fmt.Printf("Success: Found io.Reader at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No io.Reader found")
+            {{ end }}
+
+  - id: "aspect-concrete-pointer-reader-value"
+    join-point:
+      function-body:
+        function:
+          - name: returnsConcretePointerReaderValue
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for io.Reader (concrete value, pointer receiver)")
+            {{ with .Function.ResultThatImplements "io.Reader" }}
+            fmt.Printf("Failure: Found io.Reader at: %q\n", "{{ . }}") // Should not find for value type
+            {{ else }}
+            fmt.Println("Success: No io.Reader found (correct for value type)")
+            {{ end }}
+
+  - id: "aspect-named-error"
+    join-point:
+      function-body:
+        function:
+          - name: returnsNamedError
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for error (named result)")
+            {{ with .Function.ResultThatImplements "error" }}
+            fmt.Printf("Success: Found error at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No error found")
+            {{ end }}
+
+  - id: "aspect-read-closer"
+    join-point:
+      function-body:
+        function:
+          - name: returnsReadCloser
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for io.Reader (embedded)")
+            {{ with .Function.ResultThatImplements "io.Reader" }}
+            fmt.Printf("Success: Found io.Reader at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No io.Reader found")
+            {{ end }}
+
+  - id: "aspect-string-reader-alias"
+    join-point:
+      function-body:
+        function:
+          - name: returnsMyStringReaderAlias
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for io.Reader (type alias concrete)")
+            {{ with .Function.ResultThatImplements "io.Reader" }}
+            fmt.Printf("Failure: Found io.Reader at: %q\n", "{{ . }}") // Should not find for alias
+            {{ else }}
+            fmt.Println("Success: No io.Reader found (correct for type alias)")
+            {{ end }}
+
+  - id: "aspect-reader-alias"
+    join-point:
+      function-body:
+        function:
+          - name: returnsMyReaderAlias
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ResultThatImplements for io.Reader (type alias interface)")
+            {{ with .Function.ResultThatImplements "io.Reader" }}
+            fmt.Printf("Success: Found io.Reader at: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No io.Reader found")
+            {{ end }}
+
+syntheticReferences:
+  fmt: true
+
+code: |-
+  package test
+
+  import (
+    "errors"
+    "io"
+    "strings"
+  )
+
+  // Returns a simple error
+  func returnsError() error {
+    return errors.New("some error")
+  }
+
+  // Returns multiple errors to test LastResultThatImplements
+  func returnsMultipleErrors() (error, string, error) {
+    return errors.New("first error"), "middle", errors.New("last error")
+  }
+
+  // Returns an io.Reader
+  func returnsReader() io.Reader {
+    return strings.NewReader("test")
+  }
+
+  // Returns a strings.Reader
+  func returnsStringReader() *strings.Reader {
+    return strings.NewReader("test")
+  }
+
+  // Returns values that don't implement error
+  func returnsNoMatch() (string, int) {
+    return "hello", 123
+  }
+
+  // Returns a concrete type that implements io.Reader via value receiver
+  type myValueReader struct { data string }
+  func (r myValueReader) Read(p []byte) (n int, err error) {
+    if len(r.data) == 0 {
+      return 0, io.EOF
+    }
+    n = copy(p, []byte(r.data))
+    return n, nil // Simplified
+  }
+  func returnsConcreteValueReader() myValueReader {
+    return myValueReader{data:"value"}
+  }
+
+  // Returns a concrete type whose pointer implements io.Reader
+  type myPointerReader struct { data string }
+  func (r *myPointerReader) Read(p []byte) (n int, err error) {
+    if len(r.data) == 0 {
+      return 0, io.EOF
+    }
+    n = copy(p, []byte(r.data))
+    return n, nil // Simplified
+  }
+  func returnsConcretePointerReaderValue() myPointerReader {
+    return myPointerReader{data:"pointer"}
+  }
+
+  // Returns a named error
+  func returnsNamedError() (err error) {
+    err = errors.New("named error")
+    return
+  }
+
+  // Returns a type embedding io.Reader (io.ReadCloser)
+  type myReadCloser struct { *strings.Reader }
+  func (rc myReadCloser) Close() error { return nil }
+  func returnsReadCloser() io.ReadCloser {
+    return myReadCloser{strings.NewReader("closer")}
+  }
+
+  // Returns a type alias for an implementing type
+  type MyStringReader strings.Reader
+  func returnsMyStringReaderAlias() *MyStringReader {
+    // Need to cast the result of strings.NewReader
+    r := strings.NewReader("alias")
+    return (*MyStringReader)(r)
+  }
+
+  // Returns a type alias for the interface
+  type MyReader io.Reader
+  func returnsMyReaderAlias() MyReader {
+    return strings.NewReader("interface alias")
+  }
+
+  // Returns a value that doesn't implement error
+  func returnsString() string {
+    return "not an error"
+  }

--- a/internal/injector/testdata/injector/result-implements/modified.go.snap
+++ b/internal/injector/testdata/injector/result-implements/modified.go.snap
@@ -1,0 +1,190 @@
+//line input.go:1:1
+package test
+
+import (
+  "errors"
+  "io"
+  "strings"
+//line <generated>:1
+  __orchestrion_fmt "fmt"
+)
+
+// Returns a simple error
+//
+//line input.go:10
+func returnsError() (__result__0 error) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for error")
+
+    __orchestrion_fmt.Printf("Success: Found error at: %q\n", "__result__0")
+
+  }
+//line input.go:11
+  return errors.New("some error")
+}
+
+// Returns multiple errors to test LastResultThatImplements
+func returnsMultipleErrors() (__result__0 error, _ string, __result__2 error) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing LastResultThatImplements for error")
+
+    __orchestrion_fmt.Printf("Success: Found first error at: %q\n", "__result__0")
+    __orchestrion_fmt.Printf("Success: Found last error at: %q\n", "__result__2")
+    __orchestrion_fmt.Println("Success: First and last errors are different")
+
+  }
+//line input.go:16
+  return errors.New("first error"), "middle", errors.New("last error")
+}
+
+// Returns an io.Reader
+func returnsReader() (__result__0 io.Reader) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for io.Reader")
+
+    __orchestrion_fmt.Printf("Success: Found io.Reader at: %q\n", "__result__0")
+
+  }
+//line input.go:21
+  return strings.NewReader("test")
+}
+
+// Returns a strings.Reader
+func returnsStringReader() (__result__0 *strings.Reader) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for *strings.Reader")
+
+    __orchestrion_fmt.Printf("Success: Found io.Reader at: %q\n", "__result__0")
+
+  }
+//line input.go:26
+  return strings.NewReader("test")
+}
+
+// Returns values that don't implement error
+func returnsNoMatch() (string, int) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for error (no match)")
+
+    __orchestrion_fmt.Println("Success: No error found")
+
+  }
+//line input.go:31
+  return "hello", 123
+}
+
+// Returns a concrete type that implements io.Reader via value receiver
+type myValueReader struct{ data string }
+
+func (r myValueReader) Read(p []byte) (n int, err error) {
+  if len(r.data) == 0 {
+    return 0, io.EOF
+  }
+  n = copy(p, []byte(r.data))
+  return n, nil // Simplified
+}
+func returnsConcreteValueReader() (__result__0 myValueReader) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for io.Reader (concrete value, value receiver)")
+
+    __orchestrion_fmt.Printf("Success: Found io.Reader at: %q\n", "__result__0")
+
+  }
+//line input.go:44
+  return myValueReader{data: "value"}
+}
+
+// Returns a concrete type whose pointer implements io.Reader
+type myPointerReader struct{ data string }
+
+func (r *myPointerReader) Read(p []byte) (n int, err error) {
+  if len(r.data) == 0 {
+    return 0, io.EOF
+  }
+  n = copy(p, []byte(r.data))
+  return n, nil // Simplified
+}
+func returnsConcretePointerReaderValue() myPointerReader {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for io.Reader (concrete value, pointer receiver)")
+
+    __orchestrion_fmt.Println("Success: No io.Reader found (correct for value type)")
+
+  }
+//line input.go:57
+  return myPointerReader{data: "pointer"}
+}
+
+// Returns a named error
+func returnsNamedError() (err error) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for error (named result)")
+
+    __orchestrion_fmt.Printf("Success: Found error at: %q\n", "err")
+
+  }
+//line input.go:62
+  err = errors.New("named error")
+  return
+}
+
+// Returns a type embedding io.Reader (io.ReadCloser)
+type myReadCloser struct{ *strings.Reader }
+
+func (rc myReadCloser) Close() error { return nil }
+func returnsReadCloser() (__result__0 io.ReadCloser) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for io.Reader (embedded)")
+
+    __orchestrion_fmt.Printf("Success: Found io.Reader at: %q\n", "__result__0")
+
+  }
+//line input.go:70
+  return myReadCloser{strings.NewReader("closer")}
+}
+
+// Returns a type alias for an implementing type
+type MyStringReader strings.Reader
+
+func returnsMyStringReaderAlias() *MyStringReader {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for io.Reader (type alias concrete)")
+
+    __orchestrion_fmt.Println("Success: No io.Reader found (correct for type alias)")
+
+  }
+  // Need to cast the result of strings.NewReader
+//line input.go:77
+  r := strings.NewReader("alias")
+  return (*MyStringReader)(r)
+}
+
+// Returns a type alias for the interface
+type MyReader io.Reader
+
+func returnsMyReaderAlias() (__result__0 MyReader) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing ResultThatImplements for io.Reader (type alias interface)")
+
+    __orchestrion_fmt.Printf("Success: Found io.Reader at: %q\n", "__result__0")
+
+  }
+//line input.go:84
+  return strings.NewReader("interface alias")
+}
+
+// Returns a value that doesn't implement error
+func returnsString() string {
+  return "not an error"
+}

--- a/internal/injector/testdata/injector/result-implements/modified.go.snap
+++ b/internal/injector/testdata/injector/result-implements/modified.go.snap
@@ -15,6 +15,12 @@ import (
 func returnsError() (__result__0 error) {
 //line <generated>:1
   {
+    __orchestrion_fmt.Println("Testing FinalResultImplements for error (single result)")
+
+    __orchestrion_fmt.Println("Success: Final result implements error interface")
+
+  }
+  {
     __orchestrion_fmt.Println("Testing ResultThatImplements for error")
 
     __orchestrion_fmt.Printf("Success: Found error at: %q\n", "__result__0")
@@ -27,6 +33,12 @@ func returnsError() (__result__0 error) {
 // Returns multiple errors to test LastResultThatImplements
 func returnsMultipleErrors() (__result__0 error, _ string, __result__2 error) {
 //line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing FinalResultImplements for error (multiple results)")
+
+    __orchestrion_fmt.Println("Success: Final result implements error interface")
+
+  }
   {
     __orchestrion_fmt.Println("Testing LastResultThatImplements for error")
 
@@ -46,6 +58,12 @@ func returnsReader() (__result__0 io.Reader) {
     __orchestrion_fmt.Println("Testing ResultThatImplements for io.Reader")
 
     __orchestrion_fmt.Printf("Success: Found io.Reader at: %q\n", "__result__0")
+
+  }
+  {
+    __orchestrion_fmt.Println("Testing FinalResultImplements for io.Reader")
+
+    __orchestrion_fmt.Println("Success: Final result implements io.Reader interface")
 
   }
 //line input.go:21
@@ -72,6 +90,12 @@ func returnsNoMatch() (string, int) {
     __orchestrion_fmt.Println("Testing ResultThatImplements for error (no match)")
 
     __orchestrion_fmt.Println("Success: No error found")
+
+  }
+  {
+    __orchestrion_fmt.Println("Testing FinalResultImplements for error (no match)")
+
+    __orchestrion_fmt.Println("Success: Final result does not implement error interface")
 
   }
 //line input.go:31
@@ -187,4 +211,18 @@ func returnsMyReaderAlias() (__result__0 MyReader) {
 // Returns a value that doesn't implement error
 func returnsString() string {
   return "not an error"
+}
+
+// Function where the last result implementing an interface is NOT the final result
+func returnsErrorButNotLast() (__result__0 error, _ string) {
+//line <generated>:1
+  {
+    __orchestrion_fmt.Println("Testing distinction case: error in non-final position")
+    __orchestrion_fmt.Printf("LastResultThatImplements 'error': %q\n", "__result__0")
+
+    __orchestrion_fmt.Println("FinalResultImplements 'error': false (CORRECT!)")
+
+  }
+//line input.go:94
+  return errors.New("error not in final position"), "final result"
 }


### PR DESCRIPTION
This commit introduces the capability to identify function return values that implement a specific interface within the code injection framework.

**Key Changes:**

*   **`AdviceContext.ResolveType`:** Added a new method to `AdviceContext` (`internal/injector/aspect/context/context.go`) that resolves a `dst.Expr` to its corresponding `go/types.Type`. This leverages the `types.Info` provided during analysis and handles identifiers, selectors, and pointer types.
*   **`code.ResultThatImplements` / `code.LastResultThatImplements`:** Added new functions to the `code` package (`internal/injector/aspect/advice/code/dot_function.go`) that allow advice templates to query for the first or last result parameter of the current function context that implements a given interface (specified by its string name, e.g., "error", "io.Reader").
*   **Interface Resolution:** Implemented helper functions (`resolveInterfaceTypeByName`, `typeImplements`) to look up interface types from strings and perform the implementation checks using `go/types`.
*   **Tests:** Added unit tests (`internal/injector/aspect/advice/code/dot_function_test.go`) to verify the interface resolution logic.

**Motivation:**

This enhancement enables more sophisticated and type-safe advice logic. Aspects can now reliably target function results based on behavior (interface implementation) rather than just exact type names, improving flexibility and robustness. For example, advice can now easily find *any* result that satisfies the `error` interface.

**Next Steps:**

A subsequent pull request will introduce a new join point that utilizes this functionality to allow aspects to target functions based on the interfaces their results implement.

--

partially fixes: https://github.com/DataDog/orchestrion/issues/538

ref: https://github.com/DataDog/orchestrion/discussions/537
xref: https://github.com/DataDog/dd-trace-go/issues/3168
xref: [LANGPLAT-159]

[LANGPLAT-159]: https://datadoghq.atlassian.net/browse/LANGPLAT-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ