### PR TITLE
fix: fingerprint mismatch when using go.work files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # https://editorconfig.org/
 
-root = trrue
+root = true
 
 # Use unix-style newlines with a new line at EOF. No trailing whitespace.
 [*]

--- a/internal/jobserver/buildid/version.go
+++ b/internal/jobserver/buildid/version.go
@@ -151,8 +151,13 @@ func (m *moduleInfo) MarshalJSON() ([]byte, error) {
 		Files [][2]string `json:"files,omitempty"`
 	}{Module: m.Module}
 
-	// If this module is replaced by a directory; we'll hash the files as well...
-	if m.Replace != nil && m.Replace.Version == "" {
+	// If this module does not have a version, or is replaced by a module with no
+	// version, it means it has been replaced by some directory on the local
+	// machine (the [packages.Module.Replace] field is nil for replaced modules
+	// that belong to the current go.work workspace). In these cases, we need to
+	// hash the contents of all the files that contribute to the module's build to
+	// properly invalidate when a local file has changed.
+	if m.Version == "" || (m.Replace != nil && m.Replace.Version == "") {
 		toMarshal.Files = make([][2]string, 0, len(m.Files))
 
 		var (

--- a/internal/jobserver/buildid/version.go
+++ b/internal/jobserver/buildid/version.go
@@ -99,6 +99,7 @@ func (s *service) versionSuffix(ctx context.Context, _ VersionSuffixRequest) (Ve
 		if err != nil {
 			return "", err
 		}
+		log.Trace().RawJSON("module", jsonMod).Msg("Adding module to fingerprint...")
 		if err := fptr.Named(name, fingerprint.String(jsonMod)); err != nil {
 			return "", err
 		}

--- a/internal/toolexec/version_test.go
+++ b/internal/toolexec/version_test.go
@@ -34,14 +34,15 @@ func init() {
 func Test(t *testing.T) {
 	t.Setenv(client.EnvVarJobserverURL, "") // Make sure we don't accidentally connect to an external jobserver...
 
-	tmp := t.TempDir()
-	runGo(t, tmp, "mod", "init", "github.com/DataDog/phony/package")
-	runGo(t, tmp, "mod", "edit",
-		fmt.Sprintf("-replace=github.com/DataDog/orchestrion=%s", rootDir),
-		fmt.Sprintf("-replace=github.com/DataDog/orchestrion/instrument=%s", filepath.Join(rootDir, "instrument")),
-	)
+	t.Run("simple", func(t *testing.T) {
+		tmp := t.TempDir()
+		runGo(t, tmp, "mod", "init", "github.com/DataDog/phony/package")
+		runGo(t, tmp, "mod", "edit",
+			fmt.Sprintf("-replace=github.com/DataDog/orchestrion=%s", rootDir),
+			fmt.Sprintf("-replace=github.com/DataDog/orchestrion/instrument=%s", filepath.Join(rootDir, "instrument")),
+		)
 
-	require.NoError(t, os.WriteFile(filepath.Join(tmp, config.FilenameOrchestrionToolGo), []byte(`
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, config.FilenameOrchestrionToolGo), []byte(`
 		//go:build tools
 		package tools
 
@@ -50,66 +51,141 @@ func Test(t *testing.T) {
 			_ "github.com/DataDog/orchestrion/instrument"
 		)
 	`), 0o644))
-	runGo(t, tmp, "mod", "tidy")
+		runGo(t, tmp, "mod", "tidy")
 
-	// "Fake" proxy command.
-	cmd, err := proxy.ParseCommand(context.Background(), "github.com/DataDog/phony/package", []string{"go", "tool", "compile", "-V=full"})
-	require.NoError(t, err)
-
-	ctx := zerolog.New(zerolog.MultiLevelWriter(zerolog.NewTestWriter(t))).
-		Level(zerolog.InfoLevel).
-		WithContext(context.Background())
-
-	// Artificially set goflags as this is needed for the test to run....
-	goflags.SetFlags(ctx, tmp, []string{"test", "./..."})
-
-	// Compute the initial version string...
-	initial := inDir(t, tmp, func() string {
-		v, err := ComputeVersion(ctx, cmd)
+		// "Fake" proxy command.
+		cmd, err := proxy.ParseCommand(context.Background(), "github.com/DataDog/phony/package", []string{"go", "tool", "compile", "-V=full"})
 		require.NoError(t, err)
-		return v
+
+		ctx := zerolog.New(zerolog.MultiLevelWriter(zerolog.NewTestWriter(t))).
+			Level(zerolog.InfoLevel).
+			WithContext(context.Background())
+
+		// Artificially set goflags as this is needed for the test to run....
+		goflags.SetFlags(ctx, tmp, []string{"test", "./..."})
+
+		// Compute the initial version string...
+		initial := inDir(t, tmp, func() string {
+			v, err := ComputeVersion(ctx, cmd)
+			require.NoError(t, err)
+			return v
+		})
+		require.NotEmpty(t, initial)
+
+		copyDir := t.TempDir()
+		require.NoError(t, copy.Copy(rootDir, copyDir, copy.Options{
+			Skip: func(_ os.FileInfo, src string, _ string) (bool, error) {
+				return filepath.Base(src) == ".git", nil
+			},
+		}))
+		beaconFile := filepath.Join(copyDir, "instrument", "beacon___.go")
+		require.NoError(t, os.WriteFile(beaconFile, []byte("package instrument\nconst BEACON = 42"), 0o644))
+		// Add an aspect that looks like it may inject github.com/DataDog/orchestrion/instrument
+		require.NoError(t, os.WriteFile(
+			filepath.Join(copyDir, "instrument", config.FilenameOrchestrionYML),
+			[]byte(`aspects: [{join-point: {test-main: true}, advice: [{inject-declarations: {imports: {i: 'github.com/DataDog/orchestrion/instrument'}}}]}]`),
+			0o644,
+		))
+
+		// Replace the orchestrion package with the copy we just made...
+		runGo(t, tmp, "mod", "edit",
+			fmt.Sprintf("-replace=github.com/DataDog/orchestrion=%s", copyDir),
+			fmt.Sprintf("-replace=github.com/DataDog/orchestrion/instrument=%s", filepath.Join(copyDir, "instrument")),
+		)
+		runGo(t, tmp, "mod", "tidy") // The hash of the dependency has changed... go list would complain...
+		updated := inDir(t, tmp, func() string {
+			v, err := ComputeVersion(ctx, cmd)
+			require.NoError(t, err)
+			return v
+		})
+		require.NotEmpty(t, updated)
+		require.NotEqual(t, initial, updated)
+
+		// Modify the beacon
+		require.NoError(t, os.WriteFile(beaconFile, []byte("package instrument\nconst BEACON = 1337"), 0o644))
+		final := inDir(t, tmp, func() string {
+			v, err := ComputeVersion(ctx, cmd)
+			require.NoError(t, err)
+			return v
+		})
+		require.NotEmpty(t, final)
+		require.NotEqual(t, initial, final)
+		require.NotEqual(t, updated, final)
 	})
-	require.NotEmpty(t, initial)
 
-	copyDir := t.TempDir()
-	require.NoError(t, copy.Copy(rootDir, copyDir, copy.Options{
-		Skip: func(_ os.FileInfo, src string, _ string) (bool, error) {
-			return filepath.Base(src) == ".git", nil
-		},
-	}))
-	beaconFile := filepath.Join(copyDir, "instrument", "beacon___.go")
-	require.NoError(t, os.WriteFile(beaconFile, []byte("package instrument\nconst BEACON = 42"), 0o644))
-	// Add an aspect that looks like it may inject github.com/DataDog/orchestrion/instrument
-	require.NoError(t, os.WriteFile(
-		filepath.Join(copyDir, "instrument", config.FilenameOrchestrionYML),
-		[]byte(`aspects: [{join-point: {test-main: true}, advice: [{inject-declarations: {imports: {i: 'github.com/DataDog/orchestrion/instrument'}}}]}]`),
-		0o644,
-	))
+	t.Run("workspace", func(t *testing.T) {
+		tmp := t.TempDir()
 
-	// Replace the orchestrion package with the copy we just made...
-	runGo(t, tmp, "mod", "edit",
-		fmt.Sprintf("-replace=github.com/DataDog/orchestrion=%s", copyDir),
-		fmt.Sprintf("-replace=github.com/DataDog/orchestrion/instrument=%s", filepath.Join(copyDir, "instrument")),
-	)
-	runGo(t, tmp, "mod", "tidy") // The hash of the dependency has changed... go list would complain...
-	updated := inDir(t, tmp, func() string {
-		v, err := ComputeVersion(ctx, cmd)
+		// Initialize the workspace...
+		runGo(t, tmp, "work", "init")
+		runGo(t, tmp, "work", "edit",
+			fmt.Sprintf("-replace=github.com/DataDog/orchestrion=%s", rootDir),
+			fmt.Sprintf("-replace=github.com/DataDog/orchestrion/instrument=%s", filepath.Join(rootDir, "instrument")),
+		)
+
+		// Create the cmd/main package...
+		pkgMain := filepath.Join(tmp, "cmd", "main")
+		require.NoError(t, os.MkdirAll(pkgMain, 0o755))
+		runGo(t, pkgMain, "mod", "init", "github.com/DataDog/phony/cmd/main")
+		runGo(t, tmp, "work", "use", filepath.Join("cmd", "main"))
+		require.NoError(t, os.WriteFile(filepath.Join(pkgMain, config.FilenameOrchestrionToolGo), []byte(`
+		//go:build tools
+		package tools
+
+		import (
+			_ "github.com/DataDog/orchestrion"
+			_ "github.com/DataDog/phony/pkg/dep"
+		)
+		`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(pkgMain, config.FilenameOrchestrionYML),
+			[]byte(`aspects: [{join-point: {test-main: true}, advice: [{inject-declarations: {imports: {i: 'github.com/DataDog/phony/pkg/dep'}}}]}]`),
+			0o644,
+		))
+
+		// Create the pkg/dep package...
+		pkgDep := filepath.Join(tmp, "pkg", "dep")
+		require.NoError(t, os.MkdirAll(pkgDep, 0o755))
+		runGo(t, pkgDep, "mod", "init", "github.com/DataDog/phony/pkg/dep")
+		runGo(t, tmp, "work", "use", filepath.Join("pkg", "dep"))
+		require.NoError(t, os.WriteFile(filepath.Join(pkgDep, "dep.go"), []byte(`package dep
+		const BEACON = 1337
+		`), 0o644))
+		runGo(t, pkgMain, "mod", "edit", "-replace=github.com/DataDog/phony/pkg/dep=../../pkg/dep")
+
+		// Now let's get to business... Initialize a new context with a logger (for troubleshooting failures):
+		ctx := zerolog.New(zerolog.MultiLevelWriter(zerolog.NewTestWriter(t))).
+			Level(zerolog.InfoLevel).
+			WithContext(context.Background())
+		// "Fake" proxy command (input to ComputeVersion).
+		cmd, err := proxy.ParseCommand(context.Background(), "github.com/DataDog/phony/cmd/main", []string{"go", "tool", "compile", "-V=full"})
 		require.NoError(t, err)
-		return v
-	})
-	require.NotEmpty(t, updated)
-	require.NotEqual(t, initial, updated)
 
-	// Modify the beacon
-	require.NoError(t, os.WriteFile(beaconFile, []byte("package instrument\nconst BEACON = 1337"), 0o644))
-	final := inDir(t, tmp, func() string {
-		v, err := ComputeVersion(ctx, cmd)
-		require.NoError(t, err)
-		return v
+		// Artificially set goflags as this is needed for the test to run....
+		goflags.SetFlags(ctx, pkgMain, []string{"test", "./..."})
+
+		// Compute the initial version string...
+		initial := inDir(t, pkgMain, func() string {
+			v, err := ComputeVersion(ctx, cmd)
+			require.NoError(t, err)
+			return v
+		})
+		require.NotEmpty(t, initial)
+
+		// Now modify the injected dependency...
+		require.NoError(t, os.WriteFile(filepath.Join(pkgDep, "dep.go"), []byte(`package dep
+		const BEACON = 42
+		`), 0o644))
+
+		// Compute the updated version string...
+		updated := inDir(t, pkgMain, func() string {
+			v, err := ComputeVersion(ctx, cmd)
+			require.NoError(t, err)
+			return v
+		})
+		require.NotEmpty(t, updated)
+
+		require.NotEqual(t, initial, updated)
 	})
-	require.NotEmpty(t, final)
-	require.NotEqual(t, initial, final)
-	require.NotEqual(t, updated, final)
 }
 
 func inDir[T any](t *testing.T, wd string, cb func() T) T {


### PR DESCRIPTION
When a `go.mod` file contains a `replace` directive for a module that is part of the current workspace (and directing to the in-workspace directory), the `go list` command does not return a `Replace` field for that module; instead it returns a blank `Version` field.

This commit fixes the file fingerprinting decision so that it hashes the modules' content when the `Version` field is blank or when the module is replaced by a local directory.

Also added a unit test to validate things work as expected in this case.