### PR TITLE
release: v1.3.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "runtime/debug"
 
 const (
 	// tag specifies the current release tag. It needs to be manually updated.
-	tag       = "v1.3.0"
+	tag       = "v1.3.1"
 	devSuffix = "+devel"
 )
 


### PR DESCRIPTION
This release fixes an issue with fingerprint mismatches when using a `go.work` file.