### PR TITLE
refactor(injector/typed): Refactor ResolveInterfaceTypeByName for improved clarity and error handling

### DIFF
--- a/internal/injector/typed/typecheck.go
+++ b/internal/injector/typed/typecheck.go
@@ -112,12 +112,6 @@ func validateTypeNameIsInterface(obj types.Object, fullName string, pkgPath stri
 		return nil, fmt.Errorf("type %s is not an interface", fullName)
 	}
 
-	// Use .Underlying() to get the *types.Interface.
-	iface, ok := typ.Underlying().(*types.Interface)
-	if !ok {
-		// This should ideally not happen if types.IsInterface passed, but check defensively.
-		return nil, fmt.Errorf("type %s is an interface but failed to get underlying *types.Interface", fullName)
-	}
-
-	return iface, nil
+	// Since types.IsInterface passed, we can safely cast typ.Underlying() to *types.Interface
+	return typ.Underlying().(*types.Interface), nil
 }

--- a/internal/injector/typed/typecheck.go
+++ b/internal/injector/typed/typecheck.go
@@ -113,5 +113,9 @@ func validateTypeNameIsInterface(obj types.Object, fullName string, pkgPath stri
 	}
 
 	// Since types.IsInterface passed, we can safely cast typ.Underlying() to *types.Interface
-	return typ.Underlying().(*types.Interface), nil
+	t, ok := typ.Underlying().(*types.Interface)
+	if !ok {
+		return nil, fmt.Errorf("type %s is not an interface", fullName)
+	}
+	return t, nil
 }


### PR DESCRIPTION
This update refactors the `ResolveInterfaceTypeByName` function to enhance its structure and error reporting. The function now separates the logic for handling built-in types and package-qualified types, improving readability. A new helper function, `validateTypeNameIsInterface`, has been introduced to encapsulate the validation of interface types, ensuring consistent error messages and reducing code duplication.

Additionally, specific error messages have been added for import failures and type lookups, providing clearer context for users.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>