### PR TITLE
feat(injector): Add ArgumentThatImplements method for argument interface matching

### DIFF
--- a/internal/injector/aspect/advice/code/dot_function.go
+++ b/internal/injector/aspect/advice/code/dot_function.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/dave/dst"
 
+	"go/types"
+
 	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/typed"
 )
@@ -29,6 +31,9 @@ type (
 		// ArgumentOfType returns the name of the first argument in this function that has the provided
 		// type, or an empty string if none is found.
 		ArgumentOfType(string) (string, error)
+		// ArgumentThatImplements returns the name of the first argument in this function that implements
+		// the provided interface type, or an empty string if none is found.
+		ArgumentThatImplements(string) (string, error)
 
 		// Result returns the name of the return value at the given index in this function's type,
 		// returning an error if the index is out of bounds.
@@ -111,6 +116,10 @@ func (noFunc) ArgumentOfType(string) (string, error) {
 	return "", errNoFunction
 }
 
+func (noFunc) ArgumentThatImplements(string) (string, error) {
+	return "", errNoFunction
+}
+
 func (noFunc) Result(int) (string, error) {
 	return "", errNoFunction
 }
@@ -144,6 +153,10 @@ func (s signature) ArgumentOfType(name string) (string, error) {
 	return fieldOfType(s.Params, name, "argument")
 }
 
+func (s signature) ArgumentThatImplements(interfaceName string) (string, error) {
+	return findImplementingField(s.context, s.Params, interfaceName, "argument")
+}
+
 func (s signature) Result(index int) (name string, err error) {
 	return fieldAt(s.Results, index, "result")
 }
@@ -152,39 +165,8 @@ func (s signature) ResultOfType(name string) (string, error) {
 	return fieldOfType(s.Results, name, "result")
 }
 
-func (s signature) ResultThatImplements(name string) (string, error) {
-	// Return blank if there are no results.
-	if s.Results == nil {
-		return "", nil
-	}
-
-	// Optimization: First, check for an exact match using the helper.
-	if index, found := typed.FindMatchingTypeName(s.Results, name); found {
-		return fieldAt(s.Results, index, "result")
-	} // If not found, fall through to type resolution.
-
-	// Resolve the interface type.
-	iface, err := typed.ResolveInterfaceTypeByName(name)
-	if err != nil {
-		return "", fmt.Errorf("resolving interface type %q: %w", name, err)
-	}
-
-	// Check each result.
-	index := 0
-	for _, field := range s.Results.List {
-		if typed.ExprImplements(s.context, field.Type, iface) {
-			return fieldAt(s.Results, index, "result")
-		}
-
-		count := len(field.Names)
-		if count == 0 {
-			count = 1
-		}
-		index += count
-	}
-
-	// Not found.
-	return "", nil
+func (s signature) ResultThatImplements(interfaceName string) (string, error) {
+	return findImplementingField(s.context, s.Results, interfaceName, "result")
 }
 
 func (s signature) LastResultThatImplements(name string) (string, error) {
@@ -277,11 +259,19 @@ func fieldAt(fields *dst.FieldList, index int, use string) (string, error) {
 		}
 	}
 
-	if idx < index {
-		return "", fmt.Errorf("index out of bounds: %d (only %d items)", index, idx+1)
+	if idx <= index { // Use <= to catch index being exactly the number of items
+		return "", fmt.Errorf("index out of bounds: %d (only %d items)", index, idx)
 	}
 
-	return name, nil
+	// If anonymous, we should have assigned the synthetic name earlier.
+	// If named, it should have been returned immediately.
+	// If we reach here and it was anonymous, we return the generated name.
+	if anonymous {
+		return name, nil
+	}
+
+	// This path should ideally not be reached for named parameters if logic is correct.
+	return "", fmt.Errorf("fieldAt: failed to find field at index %d", index)
 }
 
 func fieldOfType(fields *dst.FieldList, typeName string, use string) (string, error) {
@@ -335,4 +325,43 @@ func (s signature) FinalResultImplements(interfaceName string) (bool, error) {
 
 	// Check if the last field type implements the interface.
 	return typed.ExprImplements(s.context, lastField.Type, iface), nil
+}
+
+// findImplementingField is a helper to find the first field in a list that matches
+// an interface, either by exact type name or by implementation.
+func findImplementingField(ctx context.AdviceContext, fields *dst.FieldList, interfaceName string, fieldKind string) (string, error) {
+	if fields == nil {
+		return "", nil // No fields, no match.
+	}
+
+	// 1. Check for exact type name match first.
+	if index, found := typed.FindMatchingTypeName(fields, interfaceName); found {
+		return fieldAt(fields, index, fieldKind)
+	}
+
+	// 2. If no exact name match, check for interface implementation.
+	iface, err := typed.ResolveInterfaceTypeByName(interfaceName)
+	if err != nil {
+		// Invalid interface name, cannot proceed with implementation check.
+		return "", fmt.Errorf("resolving interface type %q: %w", interfaceName, err)
+	}
+
+	// Iterate through fields to check for implementation.
+	currentIndex := 0
+	for _, field := range fields.List {
+		actualType := ctx.ResolveType(field.Type)
+		if actualType != nil && types.Implements(actualType, iface) {
+			return fieldAt(fields, currentIndex, fieldKind)
+		}
+
+		// Increment index based on field names.
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+		currentIndex += count
+	}
+
+	// 3. No match found.
+	return "", nil
 }

--- a/internal/injector/aspect/join/function.go
+++ b/internal/injector/aspect/join/function.go
@@ -394,39 +394,39 @@ func (_ *resultImplements) fileMayMatch(_ *may.FileContext) may.MatchType {
 	return may.Unknown
 }
 
-func (fo *resultImplements) evaluate(info functionInformation) bool {
-	if info.Type.Results == nil || len(info.Type.Results.List) == 0 {
-		// No return values, no match.
+// evaluateFieldListImplements checks if any field in the list matches the interfaceName,
+// either by exact type name or by interface implementation.
+func evaluateFieldListImplements(fields *dst.FieldList, interfaceName string, info functionInformation) bool {
+	if fields == nil || len(fields.List) == 0 {
 		return false
 	}
 
 	// Optimization: First, check for an exact match using the helper.
-	if _, found := typed.FindMatchingTypeName(info.Type.Results, fo.InterfaceName); found {
+	if _, found := typed.FindMatchingTypeName(fields, interfaceName); found {
 		return true // Found direct match
-	} // If not found, fall through to type resolution.
+	}
 
-	// Ensure the type resolver is available.
+	// If no exact match, check implementation (requires type resolver).
 	if info.typeResolver == nil {
-		return false
+		return false // Cannot check implementation without resolver.
 	}
 
-	// Resolve the target interface name (e.g., "io.Reader", "error") to a types.Interface.
-	targetInterface, err := typed.ResolveInterfaceTypeByName(fo.InterfaceName)
+	targetInterface, err := typed.ResolveInterfaceTypeByName(interfaceName)
 	if err != nil {
-		// If the interface name is invalid or cannot be resolved, we cannot match.
-		return false
+		return false // Invalid interface name.
 	}
 
-	for _, field := range info.Type.Results.List {
-		// For each return type (dst.Expr), resolve it to types.Type using the provided resolver
-		// and check if it implements the target interface.
+	for _, field := range fields.List {
 		if typed.ExprImplements(info.typeResolver, field.Type, targetInterface) {
-			return true // Found at least one implementing type, match!
+			return true // Found an implementing type.
 		}
 	}
 
-	// No return type matched.
-	return false
+	return false // No match found.
+}
+
+func (fo *resultImplements) evaluate(info functionInformation) bool {
+	return evaluateFieldListImplements(info.Type.Results, fo.InterfaceName, info)
 }
 
 func (fo *resultImplements) Hash(h *fingerprint.Hasher) error {
@@ -499,6 +499,47 @@ func (fo *finalResultImplements) evaluate(info functionInformation) bool {
 
 func (fo *finalResultImplements) Hash(h *fingerprint.Hasher) error {
 	return h.Named("final-result-implements", fingerprint.String(fo.InterfaceName))
+}
+
+// argumentImplements matches functions where at least one argument's type
+// implements the specified interface.
+type argumentImplements struct {
+	InterfaceName string
+}
+
+// ArgumentImplements creates a FunctionOption that matches functions where at least one
+// argument implements the named interface.
+func ArgumentImplements(interfaceName string) FunctionOption {
+	return &argumentImplements{InterfaceName: interfaceName}
+}
+
+func (fo *argumentImplements) impliesImported() []string {
+	pkgPath, _ := typed.SplitPackageAndName(fo.InterfaceName)
+	if pkgPath != "" {
+		return []string{pkgPath}
+	}
+	return nil
+}
+
+func (_ *argumentImplements) packageMayMatch(_ *may.PackageContext) may.MatchType {
+	// Cannot reliably determine possibility of match based on package imports
+	// due to structural typing. A type can implement an interface without
+	// importing the interface's package.
+	return may.Unknown
+}
+
+func (_ *argumentImplements) fileMayMatch(_ *may.FileContext) may.MatchType {
+	// Cannot reliably determine possibility of match based on file contents
+	// due to structural typing and type aliases.
+	return may.Unknown
+}
+
+func (fo *argumentImplements) evaluate(info functionInformation) bool {
+	return evaluateFieldListImplements(info.Type.Params, fo.InterfaceName, info)
+}
+
+func (fo *argumentImplements) Hash(h *fingerprint.Hasher) error {
+	return h.Named("argument-implements", fingerprint.String(fo.InterfaceName))
 }
 
 func init() {
@@ -626,6 +667,15 @@ func (o *unmarshalFuncDeclOption) UnmarshalYAML(ctx gocontext.Context, node ast.
 		}
 		// NOTE: Validation happens later during type resolution.
 		o.FunctionOption = FinalResultImplements(ifaceName)
+	case "argument-implements":
+		var ifaceName string
+		if err := yaml.NodeToValueContext(ctx, mapping.Values[0].Value, &ifaceName); err != nil {
+			return err
+		}
+		if ifaceName == "" {
+			return fmt.Errorf("line %d: 'argument-implements' cannot be empty", node.GetToken().Position.Line)
+		}
+		o.FunctionOption = ArgumentImplements(ifaceName)
 	default:
 		return fmt.Errorf("unknown FuncDeclOption name: %q", key)
 	}

--- a/internal/injector/testdata/injector/argument-implements-join/config.yml
+++ b/internal/injector/testdata/injector/argument-implements-join/config.yml
@@ -1,0 +1,144 @@
+%YAML 1.1
+---
+aspects:
+  - id: "match-context"
+    join-point:
+      function-body:
+        function:
+          - name: hasContext
+          - argument-implements: "context.Context"
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |
+            fmt.Println("Matched hasContext via argument-implements: context.Context")
+
+  - id: "match-io-reader"
+    join-point:
+      function-body:
+        function:
+          - name: hasIoReader
+          - argument-implements: "io.Reader"
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |
+            fmt.Println("Matched hasIoReader via argument-implements: io.Reader")
+
+  - id: "match-pointer-implementer"
+    join-point:
+      function-body:
+        function:
+          - name: hasPointerImplementer
+          - argument-implements: "io.Reader"
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |
+            fmt.Println("Matched hasPointerImplementer via argument-implements: io.Reader")
+
+  - id: "match-value-implementer-fail"
+    join-point:
+      function-body:
+        function:
+          - name: hasValueImplementer
+          - argument-implements: "io.Reader"
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |
+            fmt.Println("!!! INCORRECTLY Matched hasValueImplementer via argument-implements: io.Reader !!!")
+
+  - id: "match-interface-alias"
+    join-point:
+      function-body:
+        function:
+          - name: hasInterfaceAlias
+          - argument-implements: "io.Reader"
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |
+            fmt.Println("Matched hasInterfaceAlias via argument-implements: io.Reader")
+
+  - id: "match-concrete-alias-fail"
+    join-point:
+      function-body:
+        function:
+          - name: hasConcreteAlias
+          - argument-implements: "io.Reader"
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |
+            fmt.Println("!!! INCORRECTLY Matched hasConcreteAlias via argument-implements: io.Reader !!!")
+
+  - id: "no-match-string"
+    join-point:
+      function-body:
+        function:
+          - name: hasString
+          - argument-implements: "io.Reader"
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |
+            fmt.Println("!!! INCORRECTLY Matched hasString via argument-implements: io.Reader !!!")
+
+code: |-
+  package test
+
+  import (
+    "context"
+    "fmt"
+    "io"
+    "strings"
+  )
+
+  // Takes context.Context
+  func hasContext(ctx context.Context) {
+    fmt.Println("Executing hasContext")
+  }
+
+  // Takes io.Reader
+  func hasIoReader(r io.Reader) {
+    fmt.Println("Executing hasIoReader")
+  }
+
+  // Concrete type implementing via pointer receiver
+  type pointerImplementer struct{}
+  func (p *pointerImplementer) Read(b []byte) (int, error) { return 0, io.EOF }
+  func hasPointerImplementer(p *pointerImplementer) {
+    fmt.Println("Executing hasPointerImplementer")
+  }
+
+  // Concrete type implementing via value receiver
+  type valueImplementer struct{}
+  func (v valueImplementer) Read(b []byte) (int, error) { return 0, io.EOF }
+  func hasValueImplementer(v valueImplementer) {
+    fmt.Println("Executing hasValueImplementer")
+  }
+
+  // Type alias for interface
+  type MyReader io.Reader
+  func hasInterfaceAlias(mr MyReader) {
+    fmt.Println("Executing hasInterfaceAlias")
+  }
+
+  // Type alias for concrete type
+  type MyConcreteReader strings.Reader
+  func hasConcreteAlias(cr *MyConcreteReader) {
+    fmt.Println("Executing hasConcreteAlias")
+  }
+
+  // Takes a string
+  func hasString(s string) {
+    fmt.Println("Executing hasString")
+  }

--- a/internal/injector/testdata/injector/argument-implements-join/modified.go.snap
+++ b/internal/injector/testdata/injector/argument-implements-join/modified.go.snap
@@ -1,0 +1,84 @@
+//line input.go:1:1
+package test
+
+import (
+  "context"
+  "fmt"
+  "io"
+  "strings"
+)
+
+// Takes context.Context
+func hasContext(ctx context.Context) {
+//line <generated>:1
+  {
+    fmt.Println("Matched hasContext via argument-implements: context.Context")
+
+  }
+//line input.go:12
+  fmt.Println("Executing hasContext")
+}
+
+// Takes io.Reader
+func hasIoReader(r io.Reader) {
+//line <generated>:1
+  {
+    fmt.Println("Matched hasIoReader via argument-implements: io.Reader")
+
+  }
+//line input.go:17
+  fmt.Println("Executing hasIoReader")
+}
+
+// Concrete type implementing via pointer receiver
+type pointerImplementer struct{}
+
+func (p *pointerImplementer) Read(b []byte) (int, error) { return 0, io.EOF }
+func hasPointerImplementer(p *pointerImplementer) {
+//line <generated>:1
+  {
+    fmt.Println("Matched hasPointerImplementer via argument-implements: io.Reader")
+
+  }
+//line input.go:24
+  fmt.Println("Executing hasPointerImplementer")
+}
+
+// Concrete type implementing via value receiver
+type valueImplementer struct{}
+
+func (v valueImplementer) Read(b []byte) (int, error) { return 0, io.EOF }
+func hasValueImplementer(v valueImplementer) {
+//line <generated>:1
+  {
+    fmt.Println("!!! INCORRECTLY Matched hasValueImplementer via argument-implements: io.Reader !!!")
+
+  }
+//line input.go:31
+  fmt.Println("Executing hasValueImplementer")
+}
+
+// Type alias for interface
+type MyReader io.Reader
+
+func hasInterfaceAlias(mr MyReader) {
+//line <generated>:1
+  {
+    fmt.Println("Matched hasInterfaceAlias via argument-implements: io.Reader")
+
+  }
+//line input.go:37
+  fmt.Println("Executing hasInterfaceAlias")
+}
+
+// Type alias for concrete type
+type MyConcreteReader strings.Reader
+
+func hasConcreteAlias(cr *MyConcreteReader) {
+  fmt.Println("Executing hasConcreteAlias")
+}
+
+// Takes a string
+func hasString(s string) {
+  fmt.Println("Executing hasString")
+}

--- a/internal/injector/testdata/injector/argument-implements/config.yml
+++ b/internal/injector/testdata/injector/argument-implements/config.yml
@@ -1,0 +1,199 @@
+%YAML 1.1
+---
+aspects:
+  # - id: "aspect-with-reader"
+  #   join-point:
+  #     function-body:
+  #       function:
+  #         - name: WithReader
+  #   advice:
+  #     - prepend-statements:
+  #         imports:
+  #           fmt: fmt
+  #         template: |-
+  #           fmt.Println("Testing ArgumentThatImplements for io.Reader in WithReader")
+  #           {{ with .Function.ArgumentThatImplements "io.Reader" }}
+  #           fmt.Printf("Success: Found io.Reader argument: %q\n", "{{ . }}")
+  #           {{ else }}
+  #           fmt.Println("Failure: No io.Reader argument found.")
+  #           {{ end }}
+
+  - id: "aspect-with-unnamed-context"
+    join-point:
+      function-body:
+        function:
+          - name: WithUnnamedContext
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ArgumentThatImplements for context.Context in WithUnnamedContext")
+            {{ with .Function.ArgumentThatImplements "context.Context" }}
+            fmt.Printf("Success: Found context.Context argument: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No context.Context argument found.")
+            {{ end }}
+
+  - id: "aspect-with-mixed-params"
+    join-point:
+      function-body:
+        function:
+          - name: WithMixedParams
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ArgumentThatImplements in WithMixedParams")
+            {{ with $reader := .Function.ArgumentThatImplements "io.Reader" }}
+            fmt.Printf("Success: Found io.Reader argument: %q\n", "{{ $reader }}")
+            {{ else }}
+            fmt.Println("Failure: No io.Reader argument found.")
+            {{ end }}
+            {{ with $ctx := .Function.ArgumentThatImplements "context.Context" }}
+            fmt.Printf("Success: Found context.Context argument: %q\n", "{{ $ctx }}")
+            {{ else }}
+            fmt.Println("Failure: No context.Context argument found.")
+            {{ end }}
+
+  # - id: "aspect-with-multiple-readers"
+  #   join-point:
+  #     function-body:
+  #       function:
+  #         - name: WithMultipleReaders
+  #   advice:
+  #     - prepend-statements:
+  #         imports:
+  #           fmt: fmt
+  #         template: |-
+  #           fmt.Println("Testing ArgumentThatImplements with multiple readers")
+  #           {{ with .Function.ArgumentThatImplements "io.Reader" }}
+  #           fmt.Printf("Success: Found first io.Reader argument: %q\n", "{{ . }}")
+  #           {{ else }}
+  #           fmt.Println("Failure: No io.Reader argument found.")
+  #           {{ end }}
+
+  # - id: "aspect-with-local-implementer"
+  #   join-point:
+  #     function-body:
+  #       function:
+  #         - name: WithLocalImplementer
+  #   advice:
+  #     - prepend-statements:
+  #         imports:
+  #           fmt: fmt
+  #         template: |-
+  #           fmt.Println("Testing ArgumentThatImplements with local type that implements io.Reader")
+  #           {{ with .Function.ArgumentThatImplements "io.Reader" }}
+  #           fmt.Printf("Success: Found io.Reader argument: %q\n", "{{ . }}")
+  #           {{ else }}
+  #           fmt.Println("Failure: No io.Reader argument found.")
+  #           {{ end }}
+
+  # - id: "aspect-no-params"
+  #   join-point:
+  #     function-body:
+  #       function:
+  #         - name: NoParams
+  #   advice:
+  #     - prepend-statements:
+  #         imports:
+  #           fmt: fmt
+  #         template: |-
+  #           fmt.Println("Testing ArgumentThatImplements with no parameters")
+  #           {{ with .Function.ArgumentThatImplements "io.Reader" }}
+  #           fmt.Printf("Failure: Found io.Reader argument unexpectedly: %q\n", "{{ . }}")
+  #           {{ else }}
+  #           fmt.Println("Success: Correctly found no io.Reader argument.")
+  #           {{ end }}
+
+  # - id: "aspect-no-implementing-params"
+  #   join-point:
+  #     function-body:
+  #       function:
+  #         - name: NoImplementingParams
+  #   advice:
+  #     - prepend-statements:
+  #         imports:
+  #           fmt: fmt
+  #         template: |-
+  #           fmt.Println("Testing ArgumentThatImplements with parameters that don't implement interfaces")
+  #           {{ with .Function.ArgumentThatImplements "io.Reader" }}
+  #           fmt.Printf("Failure: Found io.Reader argument unexpectedly: %q\n", "{{ . }}")
+  #           {{ else }}
+  #           fmt.Println("Success: Correctly found no io.Reader argument.")
+  #           {{ end }}
+
+  - id: "aspect-simple-context"
+    join-point:
+      function-body:
+        function:
+          - name: SimpleContext
+    advice:
+      - prepend-statements:
+          imports:
+            fmt: fmt
+          template: |-
+            fmt.Println("Testing ArgumentThatImplements for context.Context in SimpleContext")
+            {{ with .Function.ArgumentThatImplements "context.Context" }}
+            fmt.Printf("Success: Found context.Context argument: %q\n", "{{ . }}")
+            {{ else }}
+            fmt.Println("Failure: No context.Context argument found.")
+            {{ end }}
+
+code: |-
+  package test
+
+  import (
+  	"context"
+  	"fmt"
+  	"io"
+  	"net/http"
+  )
+
+  // NoParams is a function with no parameters.
+  func NoParams() {
+  	fmt.Println("No parameters here.")
+  }
+
+  // WithReader takes a named parameter implementing io.Reader.
+  func WithReader(r io.Reader) {
+  	fmt.Printf("Got a reader: %T\n", r)
+  }
+
+  // WithUnnamedContext takes an unnamed parameter implementing context.Context.
+  func WithUnnamedContext(context.Context) {
+  	fmt.Println("Got an unnamed context.")
+  }
+
+  // WithMultipleReaders takes multiple named parameters of the same type (io.Reader).
+  func WithMultipleReaders(r1, r2 io.Reader) {
+  	fmt.Printf("Got two readers: %T, %T\n", r1, r2)
+  }
+
+  // WithMixedParams takes various parameters, including some implementing interfaces.
+  func WithMixedParams(w io.Writer, req *http.Request, ctx context.Context, data []byte, r io.Reader) error {
+  	fmt.Printf("Writer: %T, Request: %T, Context: %T, Data: %T, Reader: %T\n", w, req, ctx, data, r)
+  	return nil
+  }
+
+  // NoImplementingParams takes parameters that do not implement common interfaces used in tests.
+  func NoImplementingParams(name string, count int, active bool) {
+  	fmt.Printf("Name: %s, Count: %d, Active: %v\n", name, count, active)
+  }
+
+  // InterfaceImplementer is a local type that implements io.Reader.
+  type InterfaceImplementer struct{}
+
+  func (ii *InterfaceImplementer) Read(p []byte) (n int, err error) { return 0, io.EOF }
+
+  // WithLocalImplementer takes a parameter whose type implements io.Reader.
+  func WithLocalImplementer(impl *InterfaceImplementer) {
+  	fmt.Printf("Got local implementer: %T\n", impl)
+  }
+
+  // SimpleContext takes a named context.Context parameter.
+  func SimpleContext(ctx context.Context) {
+  	fmt.Println("Got a simple context.")
+  }

--- a/internal/injector/testdata/injector/argument-implements/modified.go.snap
+++ b/internal/injector/testdata/injector/argument-implements/modified.go.snap
@@ -1,0 +1,80 @@
+//line input.go:1:1
+package test
+
+import (
+  "context"
+  "fmt"
+  "io"
+  "net/http"
+)
+
+// NoParams is a function with no parameters.
+func NoParams() {
+  fmt.Println("No parameters here.")
+}
+
+// WithReader takes a named parameter implementing io.Reader.
+func WithReader(r io.Reader) {
+  fmt.Printf("Got a reader: %T\n", r)
+}
+
+// WithUnnamedContext takes an unnamed parameter implementing context.Context.
+func WithUnnamedContext(__argument__0 context.Context) {
+//line <generated>:1
+  {
+    fmt.Println("Testing ArgumentThatImplements for context.Context in WithUnnamedContext")
+
+    fmt.Printf("Success: Found context.Context argument: %q\n", "__argument__0")
+
+  }
+//line input.go:22
+  fmt.Println("Got an unnamed context.")
+}
+
+// WithMultipleReaders takes multiple named parameters of the same type (io.Reader).
+func WithMultipleReaders(r1, r2 io.Reader) {
+  fmt.Printf("Got two readers: %T, %T\n", r1, r2)
+}
+
+// WithMixedParams takes various parameters, including some implementing interfaces.
+func WithMixedParams(w io.Writer, req *http.Request, ctx context.Context, data []byte, r io.Reader) error {
+//line <generated>:1
+  {
+    fmt.Println("Testing ArgumentThatImplements in WithMixedParams")
+
+    fmt.Printf("Success: Found io.Reader argument: %q\n", "r")
+    fmt.Printf("Success: Found context.Context argument: %q\n", "ctx")
+
+  }
+//line input.go:32
+  fmt.Printf("Writer: %T, Request: %T, Context: %T, Data: %T, Reader: %T\n", w, req, ctx, data, r)
+  return nil
+}
+
+// NoImplementingParams takes parameters that do not implement common interfaces used in tests.
+func NoImplementingParams(name string, count int, active bool) {
+  fmt.Printf("Name: %s, Count: %d, Active: %v\n", name, count, active)
+}
+
+// InterfaceImplementer is a local type that implements io.Reader.
+type InterfaceImplementer struct{}
+
+func (ii *InterfaceImplementer) Read(p []byte) (n int, err error) { return 0, io.EOF }
+
+// WithLocalImplementer takes a parameter whose type implements io.Reader.
+func WithLocalImplementer(impl *InterfaceImplementer) {
+  fmt.Printf("Got local implementer: %T\n", impl)
+}
+
+// SimpleContext takes a named context.Context parameter.
+func SimpleContext(ctx context.Context) {
+//line <generated>:1
+  {
+    fmt.Println("Testing ArgumentThatImplements for context.Context in SimpleContext")
+
+    fmt.Printf("Success: Found context.Context argument: %q\n", "ctx")
+
+  }
+//line input.go:53
+  fmt.Println("Got a simple context.")
+}


### PR DESCRIPTION
This commit introduces the `ArgumentThatImplements` method to the function signature, allowing the retrieval of the first argument that implements a specified interface type. The implementation includes a new helper function, `findImplementingField`, which checks for both exact type matches and interface implementations.

Additionally, the `ResultThatImplements` method has been refactored to utilize the new helper for consistency. The changes enhance the injector's capability to handle argument interface checks, improving the overall functionality and maintainability of the code.

Configuration YAML files and test cases have been added to validate the new functionality across various scenarios, ensuring robust testing of the argument matching feature.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>