### PR TITLE
feat(injector): Support generic join point types

### DIFF
--- a/internal/injector/aspect/join/join.go
+++ b/internal/injector/aspect/join/join.go
@@ -108,6 +108,12 @@ func (n TypeName) Matches(node dst.Expr) bool {
 	case *dst.StarExpr:
 		return n.pointer && (&TypeName{path: n.path, name: n.name}).Matches(node.X)
 
+	case *dst.IndexExpr:
+		return !n.pointer && n.Matches(node.X)
+
+	case *dst.IndexListExpr:
+		return !n.pointer && n.Matches(node.X)
+
 	case *dst.InterfaceType:
 		// We only match the empty interface (as "any")
 		if len(node.Methods.List) != 0 {

--- a/internal/injector/aspect/join/join_test.go
+++ b/internal/injector/aspect/join/join_test.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/dave/dst"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +39,281 @@ func TestTypeName(t *testing.T) {
 				}
 			}()
 			_ = MustTypeName(name)
+		})
+	}
+}
+
+func TestTypeName_Matches(t *testing.T) {
+	tests := []struct {
+		name     string
+		tn       TypeName
+		node     dst.Expr
+		expected bool
+	}{
+		// --- Ident Cases ---
+		{
+			name:     "MyType matches MyType",
+			tn:       MustTypeName("MyType"),
+			node:     dst.NewIdent("MyType"),
+			expected: true,
+		},
+		{
+			name:     "MyType does not match OtherType",
+			tn:       MustTypeName("MyType"),
+			node:     dst.NewIdent("OtherType"),
+			expected: false,
+		},
+		{
+			name:     "*MyType does not match MyType",
+			tn:       MustTypeName("*MyType"),
+			node:     dst.NewIdent("MyType"),
+			expected: false,
+		},
+		{
+			name:     "some/path.MyType does not match MyType",
+			tn:       MustTypeName("some/path.MyType"),
+			node:     dst.NewIdent("MyType"), // node.Path is ""
+			expected: false,
+		},
+		{
+			name:     "foo/bar.MyType matches foo/bar.MyType",
+			tn:       MustTypeName("foo/bar.MyType"),
+			node:     &dst.Ident{Name: "MyType", Path: "foo/bar"},
+			expected: true,
+		},
+		{
+			name:     "foo/bar.MyType does not match wrong/path.MyType",
+			tn:       MustTypeName("foo/bar.MyType"),
+			node:     &dst.Ident{Name: "MyType", Path: "wrong/path"},
+			expected: false,
+		},
+		{
+			name:     "*foo/bar.MyType does not match foo/bar.MyType",
+			tn:       MustTypeName("*foo/bar.MyType"),
+			node:     &dst.Ident{Name: "MyType", Path: "foo/bar"},
+			expected: false,
+		},
+
+		// --- StarExpr Cases (Pointers) ---
+		{
+			name:     "*MyType matches *MyType",
+			tn:       MustTypeName("*MyType"),
+			node:     &dst.StarExpr{X: dst.NewIdent("MyType")},
+			expected: true,
+		},
+		{
+			name:     "MyType does not match *MyType",
+			tn:       MustTypeName("MyType"),
+			node:     &dst.StarExpr{X: dst.NewIdent("MyType")},
+			expected: false,
+		},
+		{
+			name:     "*MyType does not match *OtherType",
+			tn:       MustTypeName("*MyType"),
+			node:     &dst.StarExpr{X: dst.NewIdent("OtherType")},
+			expected: false,
+		},
+		{
+			name:     "*foo/bar.MyType matches *foo/bar.MyType",
+			tn:       MustTypeName("*foo/bar.MyType"),
+			node:     &dst.StarExpr{X: &dst.Ident{Name: "MyType", Path: "foo/bar"}},
+			expected: true,
+		},
+		{
+			name:     "*foo/bar.MyType does not match *wrong/path.MyType",
+			tn:       MustTypeName("*foo/bar.MyType"),
+			node:     &dst.StarExpr{X: &dst.Ident{Name: "MyType", Path: "wrong/path"}},
+			expected: false,
+		},
+		{
+			name:     "*pkg.MyType matches *pkg.MyType",
+			tn:       MustTypeName("*pkg.MyType"),
+			node:     &dst.StarExpr{X: &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("MyType")}},
+			expected: true,
+		},
+		{
+			name: "*MyType matches *MyType[T]",
+			tn:   MustTypeName("*MyType"),
+			node: &dst.StarExpr{
+				X: &dst.IndexExpr{X: dst.NewIdent("MyType"), Index: dst.NewIdent("T")},
+			},
+			expected: true,
+		},
+		{
+			name: "*MyType matches *MyType[T1, T2]",
+			tn:   MustTypeName("*MyType"),
+			node: &dst.StarExpr{
+				X: &dst.IndexListExpr{X: dst.NewIdent("MyType"), Indices: []dst.Expr{dst.NewIdent("T1"), dst.NewIdent("T2")}},
+			},
+			expected: true,
+		},
+		{
+			name: "*OtherType does not match *MyType[T]",
+			tn:   MustTypeName("*OtherType"),
+			node: &dst.StarExpr{
+				X: &dst.IndexExpr{X: dst.NewIdent("MyType"), Index: dst.NewIdent("T")},
+			},
+			expected: false,
+		},
+
+		// --- SelectorExpr Cases (Qualified types like pkg.Type) ---
+		{
+			name:     "pkg.MyType matches pkg.MyType",
+			tn:       MustTypeName("pkg.MyType"),
+			node:     &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("MyType")},
+			expected: true,
+		},
+		{
+			name:     "full/import/path.MyType does not match pkg.MyType",
+			tn:       MustTypeName("full/import/path.MyType"),
+			node:     &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("MyType")},
+			expected: false,
+		},
+		{
+			name:     "*pkg.MyType does not match pkg.MyType",
+			tn:       MustTypeName("*pkg.MyType"),
+			node:     &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("MyType")},
+			expected: false,
+		},
+		{
+			name:     "pkg.MyType does not match otherpkg.MyType",
+			tn:       MustTypeName("pkg.MyType"),
+			node:     &dst.SelectorExpr{X: dst.NewIdent("otherpkg"), Sel: dst.NewIdent("MyType")},
+			expected: false,
+		},
+		{
+			name:     "pkg.MyType does not match pkg.OtherType",
+			tn:       MustTypeName("pkg.MyType"),
+			node:     &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("OtherType")},
+			expected: false,
+		},
+		{
+			name:     "MyType matches .MyType",
+			tn:       MustTypeName("MyType"),
+			node:     &dst.SelectorExpr{X: dst.NewIdent(""), Sel: dst.NewIdent("MyType")},
+			expected: true,
+		},
+
+		// --- InterfaceType Cases (any) ---
+		{
+			name:     "any matches any",
+			tn:       MustTypeName("any"),
+			node:     &dst.InterfaceType{Methods: &dst.FieldList{}},
+			expected: true,
+		},
+		{
+			name:     "foo.any does not match any",
+			tn:       MustTypeName("foo.any"),
+			node:     &dst.InterfaceType{Methods: &dst.FieldList{}},
+			expected: false,
+		},
+
+		// --- IndexExpr Cases (Generics with one type parameter, e.g., MyType[T]) ---
+		{
+			name:     "MyType matches MyType[T]",
+			tn:       MustTypeName("MyType"),
+			node:     &dst.IndexExpr{X: dst.NewIdent("MyType"), Index: dst.NewIdent("T")},
+			expected: true,
+		},
+		{
+			name:     "OtherType does not match MyType[T]",
+			tn:       MustTypeName("OtherType"),
+			node:     &dst.IndexExpr{X: dst.NewIdent("MyType"), Index: dst.NewIdent("T")},
+			expected: false,
+		},
+		{
+			name:     "*MyType does not match MyType[T]",
+			tn:       MustTypeName("*MyType"),
+			node:     &dst.IndexExpr{X: dst.NewIdent("MyType"), Index: dst.NewIdent("T")},
+			expected: false,
+		},
+		{
+			name:     "foo/bar.MyType matches foo/bar.MyType[T]",
+			tn:       MustTypeName("foo/bar.MyType"),
+			node:     &dst.IndexExpr{X: &dst.Ident{Name: "MyType", Path: "foo/bar"}, Index: dst.NewIdent("T")},
+			expected: true,
+		},
+		{
+			name:     "foo/bar.MyType does not match wrong/path.MyType[T]",
+			tn:       MustTypeName("foo/bar.MyType"),
+			node:     &dst.IndexExpr{X: &dst.Ident{Name: "MyType", Path: "wrong/path"}, Index: dst.NewIdent("T")},
+			expected: false,
+		},
+		{
+			name:     "pkg.MyType matches pkg.MyType[T]",
+			tn:       MustTypeName("pkg.MyType"),
+			node:     &dst.IndexExpr{X: &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("MyType")}, Index: dst.NewIdent("T")},
+			expected: true,
+		},
+		{
+			name:     "full/import/path.MyType does not match pkg.MyType[T]",
+			tn:       MustTypeName("full/import/path.MyType"),
+			node:     &dst.IndexExpr{X: &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("MyType")}, Index: dst.NewIdent("T")},
+			expected: false,
+		},
+		{
+			name:     "MyType does not match (*MyType)[T]",
+			tn:       MustTypeName("MyType"),
+			node:     &dst.IndexExpr{X: &dst.StarExpr{X: dst.NewIdent("MyType")}, Index: dst.NewIdent("T")},
+			expected: false,
+		},
+
+		// --- IndexListExpr Cases (Generics with 2+ type parameters, e.g., MyType[T1, T2]) ---
+		{
+			name:     "MyType matches MyType[T1, T2]",
+			tn:       MustTypeName("MyType"),
+			node:     &dst.IndexListExpr{X: dst.NewIdent("MyType"), Indices: []dst.Expr{dst.NewIdent("T1"), dst.NewIdent("T2")}},
+			expected: true,
+		},
+		{
+			name:     "OtherType does not match MyType[T1, T2]",
+			tn:       MustTypeName("OtherType"),
+			node:     &dst.IndexListExpr{X: dst.NewIdent("MyType"), Indices: []dst.Expr{dst.NewIdent("T1"), dst.NewIdent("T2")}},
+			expected: false,
+		},
+		{
+			name:     "*MyType does not match MyType[T1, T2]",
+			tn:       MustTypeName("*MyType"),
+			node:     &dst.IndexListExpr{X: dst.NewIdent("MyType"), Indices: []dst.Expr{dst.NewIdent("T1"), dst.NewIdent("T2")}},
+			expected: false,
+		},
+		{
+			name:     "foo/bar.MyType matches foo/bar.MyType[T1, T2]",
+			tn:       MustTypeName("foo/bar.MyType"),
+			node:     &dst.IndexListExpr{X: &dst.Ident{Name: "MyType", Path: "foo/bar"}, Indices: []dst.Expr{dst.NewIdent("T1"), dst.NewIdent("T2")}},
+			expected: true,
+		},
+		{
+			name:     "pkg.MyType matches pkg.MyType[T1, T2]",
+			tn:       MustTypeName("pkg.MyType"),
+			node:     &dst.IndexListExpr{X: &dst.SelectorExpr{X: dst.NewIdent("pkg"), Sel: dst.NewIdent("MyType")}, Indices: []dst.Expr{dst.NewIdent("T1"), dst.NewIdent("T2")}},
+			expected: true,
+		},
+		{
+			name:     "MyType does not match (*MyType)[T1, T2]",
+			tn:       MustTypeName("MyType"),
+			node:     &dst.IndexListExpr{X: &dst.StarExpr{X: dst.NewIdent("MyType")}, Indices: []dst.Expr{dst.NewIdent("T1"), dst.NewIdent("T2")}},
+			expected: false,
+		},
+
+		// --- Unhandled Type Case ---
+		{
+			name:     "MyType does not match <BasicLit>",
+			tn:       MustTypeName("MyType"),
+			node:     &dst.BasicLit{},
+			expected: false,
+		},
+		{
+			name:     "MyType does not match <nil>",
+			tn:       MustTypeName("MyType"),
+			node:     nil,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.tn.Matches(tc.node))
 		})
 	}
 }


### PR DESCRIPTION
This PR allows Orchestrion's `function` join point to correctly match methods on receivers that are instantiations of generic types (e.g., `*MyType[T]`).

## Problem

Currently, when a method receiver is a generic type like `*MyType[T]`, the Go AST structure is more complex than a simple identifier. For `github.com/dave/dst` nodes, it looks something like this:

```
*dst.StarExpr (represents the '*')
  └── X: *dst.IndexExpr (represents MyType[T])
        ├── X: *dst.Ident (represents MyType - the base generic type)
        └── Index: *dst.Ident (represents T - the type parameter)
```
(For multiple type parameters like `MyType[T, U]`, it would be `*dst.IndexListExpr` with multiple `Indices`).

However, the existing `join.TypeName.Matches` method lacked the necessary cases to handle the `*dst.IndexExpr` or `*dst.IndexListExpr`. It would therefore fail to match any user-specified base type like `MyType` to method receivers like `MyType[T]`, meaning that generic types could not be targeted.

## Solution

I've updated the `join.TypeName.Matches` method to include cases for `*dst.IndexExpr` and `*dst.IndexListExpr`. When these nodes are encountered (representing an instantiated generic type), the matching logic now correctly compares the user-provided type against the base type of the generic (e.g., `MyType`).