### PR TITLE
fix(bench): fix traefik build

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -107,9 +107,16 @@ func benchmarkGithub(owner string, repo string, build string, testbuild bool) fu
 			// If there's a vendor dir, we need to update the `modules.txt` in there to reflect the replacement.
 			tc.exec(b, "go", "mod", "vendor")
 		}
-		// traefik fails to build if we don't upgrade the version go.opentelemetry.io/otel/sdk/log
+		// traefik needs a few tweaks in order to build successfully
 		if repo == "traefik" {
+			// it fails to build if we don't upgrade the version go.opentelemetry.io/otel/sdk/log
 			tc.exec(b, "go", "get", "go.opentelemetry.io/otel/sdk/log@latest")
+
+			// it fails to build if ./webui/static does not exist, so just create an empty folder
+			if stat, err := os.Stat(filepath.Join(tc.dir, "webui")); err == nil && stat.IsDir() {
+				tc.exec(b, "mkdir", "-p", "./webui/static")
+				tc.exec(b, "touch", "./webui/static/index.html")
+			}
 		}
 		tc.exec(b, buildOrchestrion(b), "pin")
 

--- a/main_test.go
+++ b/main_test.go
@@ -112,10 +112,17 @@ func benchmarkGithub(owner string, repo string, build string, testbuild bool) fu
 			// it fails to build if we don't upgrade the version go.opentelemetry.io/otel/sdk/log
 			tc.exec(b, "go", "get", "go.opentelemetry.io/otel/sdk/log@latest")
 
-			// it fails to build if ./webui/static does not exist, so just create an empty folder
-			if stat, err := os.Stat(filepath.Join(tc.dir, "webui")); err == nil && stat.IsDir() {
-				tc.exec(b, "mkdir", "-p", "./webui/static")
-				tc.exec(b, "touch", "./webui/static/index.html")
+			// it fails to build if ./webui/static does not exist, so just create a folder with mock content
+			webuiPath := filepath.Join(tc.dir, "webui")
+			if stat, err := os.Stat(webuiPath); err == nil && stat.IsDir() {
+				staticPath := filepath.Join(webuiPath, "static")
+				err := os.MkdirAll(staticPath, 0755)
+				require.NoError(b, err, "failed to create static directory for traefik build: %s", staticPath)
+
+				indexFile := filepath.Join(staticPath, "index.html")
+				f, err := os.Create(indexFile)
+				require.NoError(b, err, "failed to create mock content for traefik build: %s", indexFile)
+				require.NoError(b, f.Close())
 			}
 		}
 		tc.exec(b, buildOrchestrion(b), "pin")


### PR DESCRIPTION
Traefik fails to build with the following error:

```
webui/embed.go:10:12: pattern static: no matching files found
```

To fix it, before building, create a static folder with some mock content so go embed does not fail.