### PR TITLE
fix: flags only partially processed

### DIFF
--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -166,15 +166,14 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 
 		// Any argument after "--" is a positional argument, so we are done parsing.
 		if arg == "--" {
-			positional = args[i+1:]
+			positional = append(positional, args[i+1:]...)
 			break
 		}
 
-		// Any argument without a leading "-" is a positional argument, and the go CLI demands all flags are placed before
-		// positional arguments, so we are done parsing.
+		// Any argument without a leading "-" is a positional argument (until proven otherwise).
 		if !strings.HasPrefix(arg, "-") {
-			positional = args[i:]
-			break
+			positional = append(positional, arg)
+			continue
 		}
 
 		normArg := arg


### PR DESCRIPTION
When using `go test` and providing the test package set before some flag, the subsequent flags were not correctly processed, resulting in particular in the `-coverpkg` flag not being appropriately expanded when necessary. This resulted in relative patterns being passed to child builds which is the cause of some build ID mismatch errors.

This was caused by an incorrect assumption that all `go` building commands demand flags are presented before any positional argument, which is at least not true for `go test` (and likely also for `go run`).