### PR TITLE
fix(injector): resolve .AST.Fun.Name crash on SelectorExpr in wrap-expression templates

### DIFF
--- a/internal/injector/aspect/advice/code/dot_ast_extras.go
+++ b/internal/injector/aspect/advice/code/dot_ast_extras.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package code
+
+// Name returns the name of the selector's identifier (Sel.Name).
+//
+// This allows templates to use {{ .AST.Fun.Name }} on both *dst.Ident
+// (which exposes Name as a promoted field from the embedded *dst.Ident)
+// and *dst.SelectorExpr (which has Sel.Name but no direct Name field).
+//
+// For a qualified call like http.Get(...), the Fun field is a *dst.SelectorExpr
+// where Sel is the *dst.Ident for "Get". This method makes .Name resolve to
+// "Get" in that case, consistent with how .Name works on *proxyIdent.
+//
+// NOTE: This file is a hand-written companion to the auto-generated
+// dot_ast.proxies.go. Any future hand-written extensions to generated proxy
+// types should be added here to keep them separate from generated code.
+func (p *proxySelectorExpr) Name() string {
+	return p.SelectorExpr.Sel.Name
+}

--- a/internal/injector/testdata/injector/selector-expr-fun-name/config.yml
+++ b/internal/injector/testdata/injector/selector-expr-fun-name/config.yml
@@ -1,0 +1,45 @@
+%YAML 1.1
+---
+# Regression test for: https://github.com/DataDog/orchestrion/issues/APMS-19232
+# When a function-call join-point matches a qualified call like http.Get(...),
+# the Fun field is a *dst.SelectorExpr. Templates accessing {{ .AST.Fun.Name }}
+# must work for both *dst.Ident (dot-imported bare call) and *dst.SelectorExpr
+# (qualified call). This test exercises the SelectorExpr path by ensuring the
+# enclosing function has a context.Context parameter (so the {{ if $ctx }} branch
+# is taken and .AST.Fun.Name is evaluated).
+aspects:
+  - join-point:
+      all-of:
+        - not:
+            import-path: net/http
+        - function-call: net/http.Get
+    advice:
+      - wrap-expression:
+          imports:
+            client: github.com/DataDog/dd-trace-go/contrib/net/http/v2/client
+          template: |-
+            {{- $ctx := .Function.ArgumentOfType "context.Context" -}}
+            {{- if $ctx -}}
+              client.{{ .AST.Fun.Name }}(
+                {{ $ctx }},
+                {{ range .AST.Args }}{{ . }},
+                {{ end }}
+              )
+            {{- else -}}
+              {{ . }}
+            {{- end -}}
+
+syntheticReferences:
+  github.com/DataDog/dd-trace-go/contrib/net/http/v2/client: true
+
+code: |-
+  package example
+
+  import (
+      "context"
+      "net/http"
+  )
+
+  func DoRequest(ctx context.Context) (*http.Response, error) {
+      return http.Get("http://example.com")
+  }

--- a/internal/injector/testdata/injector/selector-expr-fun-name/config.yml
+++ b/internal/injector/testdata/injector/selector-expr-fun-name/config.yml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-# Regression test for: https://github.com/DataDog/orchestrion/issues/APMS-19232
+# Regression test for APMS-19232
 # When a function-call join-point matches a qualified call like http.Get(...),
 # the Fun field is a *dst.SelectorExpr. Templates accessing {{ .AST.Fun.Name }}
 # must work for both *dst.Ident (dot-imported bare call) and *dst.SelectorExpr

--- a/internal/injector/testdata/injector/selector-expr-fun-name/modified.go.snap
+++ b/internal/injector/testdata/injector/selector-expr-fun-name/modified.go.snap
@@ -1,0 +1,18 @@
+//line input.go:1:1
+package example
+
+import (
+  "context"
+  "net/http"
+//line <generated>:1
+  __orchestrion_client "github.com/DataDog/dd-trace-go/contrib/net/http/v2/client"
+)
+
+//line input.go:8
+func DoRequest(ctx context.Context) (*http.Response, error) {
+  return __orchestrion_client. //line <generated>:1
+          Get(
+      ctx,
+//line input.go:9
+      "http://example.com")
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a build crash (`can't evaluate field Name in type dst.Expr`) that occurs when a `function-call` join-point matches a qualified call like `http.Get(...)` and the advice template accesses `{{ .AST.Fun.Name }}`.

**Root cause:** `proxyCallExpr.Fun()` returns `dst.Expr` (interface). When the underlying node is a `*dst.SelectorExpr` (e.g., for `http.Get`), `proxySelectorExpr` had no `Name` field or method. Go's `text/template` could not resolve `.Name`, crashing with the error above. The same template works fine for bare/dot-imported calls (`Get(...)`) where `Fun` is a `*dst.Ident` with a promoted `Name` field.

**Fix:** Add a `Name() string` method to `proxySelectorExpr` in a hand-written companion file (`dot_ast_extras.go`) that returns `Sel.Name`. This makes `{{ .AST.Fun.Name }}` work transparently for both node types without any changes to dd-trace-go templates — fully backwards compatible.

### Motivation

Customer escalation APMS-19232: any user calling `http.Get(...)`, `http.Head(...)`, `http.Post(...)`, or `http.PostForm(...)` in a function with a `context.Context` parameter fails to build with orchestrion. The dd-trace-go `net/http` client aspect (`Get|Head|Post|PostForm`) triggers the crash.

### Describe how you validated your changes

- Added end-to-end injector regression test `selector-expr-fun-name/` that exercises exactly the failure path: a `function-call` join-point on `net/http.Get` with input code that has a `context.Context` parameter, forcing the template branch that evaluates `{{ .AST.Fun.Name }}` on a `*dst.SelectorExpr`
- All injector tests pass: `go test ./internal/injector/...` (14 packages, 51s)
- `golangci-lint` clean

### Additional Notes

The fix lives in `dot_ast_extras.go`, a hand-written companion to the auto-generated `dot_ast.proxies.go`. This separation keeps generated code untouched while allowing targeted extensions. A comment in the new file guides future maintainers to add similar extensions there.

The alternative (adding a new `FuncName()` template helper) was rejected because it would require dd-trace-go to depend on a minimum orchestrion version, breaking backwards compatibility.