### PR TITLE
release: v1.11.0-rc.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,56 +29,16 @@ jobs:
         id: version
         run: |-
           set -euo pipefail
-          # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string, with added v prefix.
-          VERSION_TAG_REGEX='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
-
-          echo "::group::Environment"
-          go version
-          echo "GOTOOLCHAIN=${GOTOOLCHAIN:-<unset>}"
-          echo "PWD=$(pwd)"
-          echo "::endgroup::"
-
-          echo "::group::Run 'go run . version -static'"
-          set +e
-          raw_output=$(go run . version -static)
-          rc=$?
-          set -e
-          echo "exit_code=${rc}"
-          echo "raw_output=[${raw_output}]"
-          if [ "${rc}" -ne 0 ]; then
-            echo "::error::go run . version -static failed with exit code ${rc}"
-            exit 1
-          fi
-          echo "::endgroup::"
-
-          echo "::group::Extract version field"
-          cut_output=$(echo "${raw_output}" | cut -d' ' -f 2)
-          echo "cut_output=[${cut_output}]"
-          echo "::endgroup::"
-
-          echo "::group::Validate semver regex"
-          if ! echo "${cut_output}" | grep -E "${VERSION_TAG_REGEX}"; then
-            echo "::error::Version [${cut_output}] does not match semver regex"
-            exit 1
-          fi
-          version="${cut_output}"
-          echo "version=${version}"
-          echo "::endgroup::"
-
+          # Adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string,
+          # with a v prefix and \d replaced by [0-9] since GNU grep -E does not support \d.
+          VERSION_TAG_REGEX='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          version=$(grep -E "${VERSION_TAG_REGEX}" <(go run . version -static | cut -d' ' -f 2))
           echo "tag=${version}" >> "${GITHUB_OUTPUT}"
-
-          echo "::group::Check whether release already exists"
-          set +e
-          gh release view "${version}" --json isDraft
-          gh_rc=$?
-          set -e
-          echo "gh release view exit_code=${gh_rc}"
-          if [ "${gh_rc}" -eq 0 ]; then
+          if gh release view "${version}" --json isDraft; then
             echo "exists=true" >> "${GITHUB_OUTPUT}"
           else
             echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
-          echo "::endgroup::"
         env:
           GH_TOKEN: ${{ github.token }}
       # If this is a pull request, and the release does not yet exist, the PR title must be "release: <tag>"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,54 @@ jobs:
           set -euo pipefail
           # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string, with added v prefix.
           VERSION_TAG_REGEX='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
-          version=$(grep -E "${VERSION_TAG_REGEX}" <(go run . version -static | cut -d' ' -f 2))
+
+          echo "::group::Environment"
+          go version
+          echo "GOTOOLCHAIN=${GOTOOLCHAIN:-<unset>}"
+          echo "PWD=$(pwd)"
+          echo "::endgroup::"
+
+          echo "::group::Run 'go run . version -static'"
+          set +e
+          raw_output=$(go run . version -static)
+          rc=$?
+          set -e
+          echo "exit_code=${rc}"
+          echo "raw_output=[${raw_output}]"
+          if [ "${rc}" -ne 0 ]; then
+            echo "::error::go run . version -static failed with exit code ${rc}"
+            exit 1
+          fi
+          echo "::endgroup::"
+
+          echo "::group::Extract version field"
+          cut_output=$(echo "${raw_output}" | cut -d' ' -f 2)
+          echo "cut_output=[${cut_output}]"
+          echo "::endgroup::"
+
+          echo "::group::Validate semver regex"
+          if ! echo "${cut_output}" | grep -E "${VERSION_TAG_REGEX}"; then
+            echo "::error::Version [${cut_output}] does not match semver regex"
+            exit 1
+          fi
+          version="${cut_output}"
+          echo "version=${version}"
+          echo "::endgroup::"
+
           echo "tag=${version}" >> "${GITHUB_OUTPUT}"
-          if gh release view "${version}" --json isDraft; then
+
+          echo "::group::Check whether release already exists"
+          set +e
+          gh release view "${version}" --json isDraft
+          gh_rc=$?
+          set -e
+          echo "gh release view exit_code=${gh_rc}"
+          if [ "${gh_rc}" -eq 0 ]; then
             echo "exists=true" >> "${GITHUB_OUTPUT}"
           else
             echo "exists=false" >> "${GITHUB_OUTPUT}"
           fi
+          echo "::endgroup::"
         env:
           GH_TOKEN: ${{ github.token }}
       # If this is a pull request, and the release does not yet exist, the PR title must be "release: <tag>"

--- a/_docs/go.mod
+++ b/_docs/go.mod
@@ -12,7 +12,7 @@ require (
 	cloud.google.com/go/pubsub v1.50.2
 	github.com/99designs/gqlgen v0.17.90
 	github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.8.1
-	github.com/DataDog/orchestrion v1.10.0
+	github.com/DataDog/orchestrion v1.11.0-rc.1
 	github.com/DataDog/orchestrion/instrument v1.8.0
 	github.com/IBM/sarama v1.48.1
 	github.com/Shopify/sarama v1.38.1
@@ -132,7 +132,7 @@ require (
 	github.com/DataDog/dd-trace-go/contrib/twmb/franz-go/v2 v2.8.1 // indirect
 	github.com/DataDog/dd-trace-go/contrib/valkey-io/valkey-go/v2 v2.8.1 // indirect
 	github.com/DataDog/dd-trace-go/contrib/valyala/fasthttp/v2 v2.8.1 // indirect
-	github.com/DataDog/dd-trace-go/v2 v2.8.1 // indirect
+	github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1 // indirect
 	github.com/DataDog/go-libddwaf/v4 v4.9.0 // indirect
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d // indirect
 	github.com/DataDog/go-sqllexer v0.2.2 // indirect

--- a/_docs/go.sum
+++ b/_docs/go.sum
@@ -222,8 +222,8 @@ github.com/DataDog/dd-trace-go/instrumentation/testutils/grpc/v2 v2.8.1 h1:pEFXS
 github.com/DataDog/dd-trace-go/instrumentation/testutils/grpc/v2 v2.8.1/go.mod h1:MXL8YTlBBAQ0WsG3abpki0tjZZ56wIT9uTYe1mdEwL0=
 github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.8.1 h1:CuKWtmLL2TUJ+rWEAQih4SFy2ieuuaUw6u4vEuM/He0=
 github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.8.1/go.mod h1:WjlOE3k9hcpgxr3vh6w8tRV2zyWDfmLzTdFF5OEc0mU=
-github.com/DataDog/dd-trace-go/v2 v2.8.1 h1:O/lPXXcJof4hqfcBGsL6p/PiVa5xTfvYzv5iv/4S66U=
-github.com/DataDog/dd-trace-go/v2 v2.8.1/go.mod h1:IVkBpsq66Cw/YIRM/Te3pl2F0M9n4zguAB2ReGczWeo=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1 h1:r4cyHL4ujAfCBmaiXK9B+z33aXnoWhHwgR/FckfAtFA=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1/go.mod h1:ZFJoP0mJs9DJcUteQYmNApyDb6duhUTZBPlpvA1itF8=
 github.com/DataDog/go-libddwaf/v4 v4.9.0 h1:a788e37iuH7sR9uIYHkulvTnp2FkXTiZ3yY/kuaHgZE=
 github.com/DataDog/go-libddwaf/v4 v4.9.0/go.mod h1:/AZqP6zw3qGJK5mLrA0PkfK3UQDk1zCI2fUNCt4xftE=
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d h1:cH9Bm0tJ8FEQbA4FRi0iRm7Zr/5Lata/Or31c+Dth0E=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/orchestrion
 go 1.25.0
 
 require (
-	github.com/DataDog/dd-trace-go/v2 v2.8.1
+	github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dave/dst v0.27.4

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/DataDog/datadog-agent/pkg/version v0.78.3 h1:OK1kP1AXu3ELKhbh8w6w5gYc
 github.com/DataDog/datadog-agent/pkg/version v0.78.3/go.mod h1:cOWF+29ZahL6qcC3KAntJEupdMdteiOGaLmIMz8zYBg=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/dd-trace-go/v2 v2.8.1 h1:O/lPXXcJof4hqfcBGsL6p/PiVa5xTfvYzv5iv/4S66U=
-github.com/DataDog/dd-trace-go/v2 v2.8.1/go.mod h1:IVkBpsq66Cw/YIRM/Te3pl2F0M9n4zguAB2ReGczWeo=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1 h1:r4cyHL4ujAfCBmaiXK9B+z33aXnoWhHwgR/FckfAtFA=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1/go.mod h1:ZFJoP0mJs9DJcUteQYmNApyDb6duhUTZBPlpvA1itF8=
 github.com/DataDog/go-libddwaf/v4 v4.9.0 h1:a788e37iuH7sR9uIYHkulvTnp2FkXTiZ3yY/kuaHgZE=
 github.com/DataDog/go-libddwaf/v4 v4.9.0/go.mod h1:/AZqP6zw3qGJK5mLrA0PkfK3UQDk1zCI2fUNCt4xftE=
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d h1:cH9Bm0tJ8FEQbA4FRi0iRm7Zr/5Lata/Or31c+Dth0E=

--- a/instrument/go.mod
+++ b/instrument/go.mod
@@ -6,7 +6,7 @@ replace github.com/DataDog/orchestrion => ..
 
 require (
 	github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.5.0
-	github.com/DataDog/orchestrion v1.10.0
+	github.com/DataDog/orchestrion v1.11.0-rc.1
 )
 
 require (
@@ -74,7 +74,7 @@ require (
 	github.com/DataDog/dd-trace-go/contrib/twitchtv/twirp/v2 v2.5.0 // indirect
 	github.com/DataDog/dd-trace-go/contrib/valkey-io/valkey-go/v2 v2.5.0 // indirect
 	github.com/DataDog/dd-trace-go/contrib/valyala/fasthttp/v2 v2.5.0 // indirect
-	github.com/DataDog/dd-trace-go/v2 v2.8.1 // indirect
+	github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1 // indirect
 	github.com/DataDog/go-libddwaf/v4 v4.9.0 // indirect
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d // indirect
 	github.com/DataDog/go-sqllexer v0.2.2 // indirect

--- a/instrument/go.sum
+++ b/instrument/go.sum
@@ -145,8 +145,8 @@ github.com/DataDog/dd-trace-go/instrumentation/testutils/grpc/v2 v2.5.0 h1:XsLiW
 github.com/DataDog/dd-trace-go/instrumentation/testutils/grpc/v2 v2.5.0/go.mod h1:zXdh5AVUY2U0O8jMi20foSdn8k4AAYgY4/l/0DEwg7c=
 github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.5.0 h1:ZYbE3TIPlkG26Xwc4obJdoi6ZUybofmiIAhjVpJlCtk=
 github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.5.0/go.mod h1:5BPHXB3ojLN0CgnXEHhhBxpBBE2TpNhT0jj9qxaXXxQ=
-github.com/DataDog/dd-trace-go/v2 v2.8.1 h1:O/lPXXcJof4hqfcBGsL6p/PiVa5xTfvYzv5iv/4S66U=
-github.com/DataDog/dd-trace-go/v2 v2.8.1/go.mod h1:IVkBpsq66Cw/YIRM/Te3pl2F0M9n4zguAB2ReGczWeo=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1 h1:r4cyHL4ujAfCBmaiXK9B+z33aXnoWhHwgR/FckfAtFA=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1/go.mod h1:ZFJoP0mJs9DJcUteQYmNApyDb6duhUTZBPlpvA1itF8=
 github.com/DataDog/go-libddwaf/v4 v4.9.0 h1:a788e37iuH7sR9uIYHkulvTnp2FkXTiZ3yY/kuaHgZE=
 github.com/DataDog/go-libddwaf/v4 v4.9.0/go.mod h1:/AZqP6zw3qGJK5mLrA0PkfK3UQDk1zCI2fUNCt4xftE=
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d h1:cH9Bm0tJ8FEQbA4FRi0iRm7Zr/5Lata/Or31c+Dth0E=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "runtime/debug"
 
 const (
 	// tag specifies the current release tag. It needs to be manually updated.
-	tag       = "v1.10.0"
+	tag       = "v1.11.0-rc.1"
 	devSuffix = "+dev"
 )
 

--- a/samples/go.mod
+++ b/samples/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/99designs/gqlgen v0.17.90
-	github.com/DataDog/orchestrion v1.10.0
+	github.com/DataDog/orchestrion v1.11.0-rc.1
 	github.com/DataDog/orchestrion/instrument v1.8.0
 	github.com/IBM/sarama v1.48.1
 	github.com/Shopify/sarama v1.38.1
@@ -110,7 +110,7 @@ require (
 	github.com/DataDog/dd-trace-go/contrib/valkey-io/valkey-go/v2 v2.8.1 // indirect
 	github.com/DataDog/dd-trace-go/contrib/valyala/fasthttp/v2 v2.8.1 // indirect
 	github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.8.1 // indirect
-	github.com/DataDog/dd-trace-go/v2 v2.8.1 // indirect
+	github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1 // indirect
 	github.com/DataDog/go-libddwaf/v4 v4.9.0 // indirect
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d // indirect
 	github.com/DataDog/go-sqllexer v0.2.2 // indirect

--- a/samples/go.sum
+++ b/samples/go.sum
@@ -149,8 +149,8 @@ github.com/DataDog/dd-trace-go/instrumentation/testutils/grpc/v2 v2.8.1 h1:pEFXS
 github.com/DataDog/dd-trace-go/instrumentation/testutils/grpc/v2 v2.8.1/go.mod h1:MXL8YTlBBAQ0WsG3abpki0tjZZ56wIT9uTYe1mdEwL0=
 github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.8.1 h1:CuKWtmLL2TUJ+rWEAQih4SFy2ieuuaUw6u4vEuM/He0=
 github.com/DataDog/dd-trace-go/orchestrion/all/v2 v2.8.1/go.mod h1:WjlOE3k9hcpgxr3vh6w8tRV2zyWDfmLzTdFF5OEc0mU=
-github.com/DataDog/dd-trace-go/v2 v2.8.1 h1:O/lPXXcJof4hqfcBGsL6p/PiVa5xTfvYzv5iv/4S66U=
-github.com/DataDog/dd-trace-go/v2 v2.8.1/go.mod h1:IVkBpsq66Cw/YIRM/Te3pl2F0M9n4zguAB2ReGczWeo=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1 h1:r4cyHL4ujAfCBmaiXK9B+z33aXnoWhHwgR/FckfAtFA=
+github.com/DataDog/dd-trace-go/v2 v2.9.0-rc.1/go.mod h1:ZFJoP0mJs9DJcUteQYmNApyDb6duhUTZBPlpvA1itF8=
 github.com/DataDog/go-libddwaf/v4 v4.9.0 h1:a788e37iuH7sR9uIYHkulvTnp2FkXTiZ3yY/kuaHgZE=
 github.com/DataDog/go-libddwaf/v4 v4.9.0/go.mod h1:/AZqP6zw3qGJK5mLrA0PkfK3UQDk1zCI2fUNCt4xftE=
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20260217080614-b0f4edc38a6d h1:cH9Bm0tJ8FEQbA4FRi0iRm7Zr/5Lata/Or31c+Dth0E=


### PR DESCRIPTION
Bumps `dd-trace-go/v2` to `v2.9.0-rc.1` and tags orchestrion `v1.11.0-rc.1` as a release candidate.