### PR TITLE
fix: narrow validate STS policy

### DIFF
--- a/.github/chainguard/self.github.validate.self-mutation.sts.yaml
+++ b/.github/chainguard/self.github.validate.self-mutation.sts.yaml
@@ -4,6 +4,8 @@ subject_pattern: repo:DataDog/orchestrion:pull_request
 
 claim_pattern:
   event_name: pull_request
+  job_workflow_ref: DataDog/orchestrion/\.github/workflows/validate\.yml@refs/heads/main
+  base_ref: main
   repository: DataDog/orchestrion
 
 permissions:


### PR DESCRIPTION
### Motivation
- The existing `.github/chainguard/self.github.validate.self-mutation.sts.yaml` policy matched any `pull_request` OIDC subject and granted `contents: write`, which could allow untrusted PR workflows to mint repository write tokens; the policy must be constrained to the intended validate self-mutation workflow and target branch.

### Description
- Added `job_workflow_ref: DataDog/orchestrion/\.github/workflows/validate\.yml@refs/heads/main` and `base_ref: main` to the `claim_pattern` in `.github/chainguard/self.github.validate.self-mutation.sts.yaml` so the policy only matches the default-branch `validate.yml` workflow and PRs targeting `main` while leaving the granted permission (`contents: write`) unchanged.

### Testing
- Parsed all Chainguard policy YAMLs with `ruby -e 'require "yaml"; Dir[".github/chainguard/*.yaml"].each{|f| YAML.load_file(f); puts "OK #{f}" }'`, which reported success for each file, and attempted a `python` `yaml.safe_load` check but it failed because `PyYAML` was not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3eb8bb5d68832aab819f2a1939164a)