### PR TITLE
fix(ci): skip OIDC-enabled integration workflow for fork PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -364,6 +364,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     needs: generate
+    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     uses: DataDog/dd-trace-go/.github/workflows/orchestrion.yml@86ab9adbd32890387da2df932f59a59a1552f588 # ratchet:DataDog/dd-trace-go/.github/workflows/orchestrion.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
### Motivation
- Prevent untrusted forked pull requests from triggering the OIDC-enabled integration reusable workflow that grants `id-token: write` and is passed the PR merge SHA, which could allow exfiltration of OIDC tokens.

### Description
- Add a job-level guard to `.github/workflows/validate.yml` so the `integration-tests` job (the reusable `DataDog/dd-trace-go` workflow invocation) is skipped for forked pull requests by adding `if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork` above the `uses:` line.

### Testing
- Verified the change with `git diff --check` and successfully parsed the modified workflow using `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/validate.yml")'`, and noted a `python3` YAML parse attempt failed due to missing `PyYAML` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3eb86eac08832a8e44192cb8b2a4ce)