### PR TITLE
fix: restrict self-mutation OIDC token scope

### DIFF
--- a/.github/chainguard/self.github.validate.self-mutation.sts.yaml
+++ b/.github/chainguard/self.github.validate.self-mutation.sts.yaml
@@ -4,6 +4,7 @@ subject_pattern: repo:DataDog/orchestrion:pull_request
 
 claim_pattern:
   event_name: pull_request
+  job_workflow_ref: DataDog/orchestrion/\.github/workflows/validate\.yml@refs/heads/.*
   repository: DataDog/orchestrion
 
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -105,7 +105,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    if: always() && needs.generate.outputs.has-patch == 'true' && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository || github.event.pull_request.maintainer_can_modify)
+    if: always() && needs.generate.outputs.has-patch == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4


### PR DESCRIPTION
### Motivation
- The self-mutation workflow could be reached from `pull_request` runs that allow `maintainer_can_modify`, and the STS policy granted `contents: write` for any `repo:DataDog/orchestrion:pull_request`, exposing a repository-write token to untrusted PR contexts. 
- The change limits the attack surface by ensuring only same-repository PRs and tokens issued for the specific `validate.yml` workflow can mint the write-capable STS token.

### Description
- Tighten the `self-mutation` job condition in `.github/workflows/validate.yml` to only run for same-repository pull requests by replacing the `if` expression that allowed `maintainer_can_modify` with a check that `github.event.pull_request.head.repo.full_name == github.repository`.
- Constrain the STS trust policy in `.github/chainguard/self.github.validate.self-mutation.sts.yaml` by adding a `job_workflow_ref` claim requiring the OIDC token to originate from `DataDog/orchestrion/.github/workflows/validate.yml@refs/heads/.*` while preserving the `pull_request` event and repository checks.

### Testing
- Validated both modified YAML files parse successfully with Ruby using `require "yaml"` and reported `OK` for each file. (succeeded)
- Ran `git diff --check` to ensure no whitespace or diff issues are present. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3eb858cb48832a99936ed4fa474224)