### PR TITLE
chore: restrict benchmark runner to trusted PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -297,6 +297,10 @@ jobs:
   # Run all benchmarks and generate report
   benchmark:
     needs: generate
+    # Benchmarks execute repository-controlled Go code on a custom runner. Only
+    # run them for merge queues or PRs from this repository, where the author
+    # already has write access, and never for fork pull requests.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: arm-8core-linux
     name: Benchmarks (run ${{ matrix.run_number }})
     strategy:


### PR DESCRIPTION
### Motivation

- The `benchmark` job runs `go test -bench=...` on the `arm-8core-linux` runner and therefore executes benchmark/TestMain/init code from the checked-out PR, which allows untrusted PR authors to run arbitrary code on that runner. 
- Preventing fork PRs or untrusted pull requests from executing repository-controlled code on a custom/self-hosted runner reduces the risk of credential or runner compromise.

### Description

- Added a job-level guard to the `benchmark` job in `.github/workflows/validate.yml` so the job only runs when `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`.
- Included a short comment explaining the rationale above the guard to make the restriction explicit.

### Testing

- Verified the workflow guard text is present with a Python assertion that reads `.github/workflows/validate.yml`, and the check succeeded.
- Ran `git diff --check` to ensure no whitespace or diff errors and it passed.
- Attempted to run `actionlint` via `go run github.com/rhysd/actionlint/...` against the workflow but it failed because the Go module proxy returned `Forbidden`, so `actionlint` validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ee2aea2fc832ab19105060cdbb739)