### PR TITLE
feat(join): match functions by receiver presence

### DIFF
--- a/internal/injector/aspect/join/function.go
+++ b/internal/injector/aspect/join/function.go
@@ -313,31 +313,36 @@ func (fo *receiver) Hash(h *fingerprint.Hasher) error {
 	return h.Named("receiver", fo.TypeName)
 }
 
-type noReceiver struct{}
+type hasReceiver bool
 
 // NoReceiver matches functions and function literal expressions without a receiver.
 func NoReceiver() FunctionOption {
-	return &noReceiver{}
+	return hasReceiver(false)
 }
 
-func (fo *noReceiver) packageMayMatch(_ *may.PackageContext) may.MatchType {
+// AnyReceiver matches methods with any receiver type.
+func AnyReceiver() FunctionOption {
+	return hasReceiver(true)
+}
+
+func (hasReceiver) packageMayMatch(_ *may.PackageContext) may.MatchType {
 	return may.Match
 }
 
-func (fo *noReceiver) fileMayMatch(_ *may.FileContext) may.MatchType {
+func (hasReceiver) fileMayMatch(_ *may.FileContext) may.MatchType {
 	return may.Match
 }
 
-func (fo *noReceiver) evaluate(info functionInformation) bool {
-	return info.Receiver == nil
+func (fo hasReceiver) evaluate(info functionInformation) bool {
+	return (info.Receiver != nil) == bool(fo)
 }
 
-func (fo *noReceiver) impliesImported() []string {
+func (hasReceiver) impliesImported() []string {
 	return nil
 }
 
-func (fo *noReceiver) Hash(h *fingerprint.Hasher) error {
-	return h.Named("receiver", fingerprint.Bool(false))
+func (fo hasReceiver) Hash(h *fingerprint.Hasher) error {
+	return h.Named("receiver", fingerprint.Bool(fo))
 }
 
 type functionBody struct {
@@ -626,12 +631,9 @@ func (o *unmarshalFuncDeclOption) UnmarshalYAML(ctx gocontext.Context, node ast.
 			}
 			o.FunctionOption = Receiver(tn)
 		case bool:
-			if arg {
-				return fmt.Errorf("cannot unmarshal into a FuncDeclOption: 'receiver' can only be false or a string, got true")
-			}
-			o.FunctionOption = NoReceiver()
+			o.FunctionOption = hasReceiver(arg)
 		default:
-			return fmt.Errorf("cannot unmarshal into a FuncDeclOption: 'receiver' can only be false or a string, got %T", arg)
+			return fmt.Errorf("cannot unmarshal into a FuncDeclOption: 'receiver' can only be a boolean or a string, got %T", arg)
 		}
 	case "signature", "signature-contains":
 		var sig struct {

--- a/internal/injector/aspect/join/function.go
+++ b/internal/injector/aspect/join/function.go
@@ -284,6 +284,7 @@ type receiver struct {
 	TypeName typed.TypeName
 }
 
+// Receiver matches only methods declared to the provided receiver type.
 func Receiver(typeName typed.TypeName) FunctionOption {
 	return &receiver{typeName}
 }
@@ -310,6 +311,33 @@ func (fo *receiver) impliesImported() []string {
 
 func (fo *receiver) Hash(h *fingerprint.Hasher) error {
 	return h.Named("receiver", fo.TypeName)
+}
+
+type noReceiver struct{}
+
+// NoReceiver matches functions and function literal expressions without a receiver.
+func NoReceiver() FunctionOption {
+	return &noReceiver{}
+}
+
+func (fo *noReceiver) packageMayMatch(_ *may.PackageContext) may.MatchType {
+	return may.Match
+}
+
+func (fo *noReceiver) fileMayMatch(_ *may.FileContext) may.MatchType {
+	return may.Match
+}
+
+func (fo *noReceiver) evaluate(info functionInformation) bool {
+	return info.Receiver == nil
+}
+
+func (fo *noReceiver) impliesImported() []string {
+	return nil
+}
+
+func (fo *noReceiver) Hash(h *fingerprint.Hasher) error {
+	return h.Named("receiver", fingerprint.Bool(false))
 }
 
 type functionBody struct {
@@ -586,15 +614,25 @@ func (o *unmarshalFuncDeclOption) UnmarshalYAML(ctx gocontext.Context, node ast.
 		}
 		o.FunctionOption = Name(name)
 	case "receiver":
-		var arg string
+		var arg any
 		if err := yaml.NodeToValueContext(ctx, mapping.Values[0].Value, &arg); err != nil {
 			return err
 		}
-		tn, err := typed.NewTypeName(arg)
-		if err != nil {
-			return err
+		switch arg := arg.(type) {
+		case string:
+			tn, err := typed.NewTypeName(arg)
+			if err != nil {
+				return err
+			}
+			o.FunctionOption = Receiver(tn)
+		case bool:
+			if arg {
+				return fmt.Errorf("cannot unmarshal into a FuncDeclOption: 'receiver' can only be false or a string, got true")
+			}
+			o.FunctionOption = NoReceiver()
+		default:
+			return fmt.Errorf("cannot unmarshal into a FuncDeclOption: 'receiver' can only be false or a string, got %T", arg)
 		}
-		o.FunctionOption = Receiver(tn)
 	case "signature", "signature-contains":
 		var sig struct {
 			Args  []string            `yaml:"args"`

--- a/internal/injector/aspect/join/function.go
+++ b/internal/injector/aspect/join/function.go
@@ -326,11 +326,11 @@ func AnyReceiver() FunctionOption {
 }
 
 func (hasReceiver) packageMayMatch(_ *may.PackageContext) may.MatchType {
-	return may.Match
+	return may.Unknown
 }
 
 func (hasReceiver) fileMayMatch(_ *may.FileContext) may.MatchType {
-	return may.Match
+	return may.Unknown
 }
 
 func (fo hasReceiver) evaluate(info functionInformation) bool {

--- a/internal/injector/aspect/join/function_test.go
+++ b/internal/injector/aspect/join/function_test.go
@@ -241,9 +241,9 @@ func TestUnmarshalYAMLReceiver(t *testing.T) {
 			want: Receiver(typed.TypeName{Name: "false"}),
 		},
 		{
-			name:    "true is rejected",
-			yaml:    `receiver: true`,
-			wantErr: true,
+			name: "any receiver",
+			yaml: `receiver: true`,
+			want: AnyReceiver(),
 		},
 		{
 			name:    "non-string is rejected",
@@ -266,16 +266,18 @@ func TestUnmarshalYAMLReceiver(t *testing.T) {
 	}
 }
 
-func TestNoReceiverMatches(t *testing.T) {
+func TestHasReceiverMatches(t *testing.T) {
 	tests := []struct {
-		name string
-		node dst.Node
-		want bool
+		name            string
+		node            dst.Node
+		wantNoReceiver  bool
+		wantAnyReceiver bool
 	}{
 		{
-			name: "function declaration",
-			node: &dst.FuncDecl{Name: dst.NewIdent("function")},
-			want: true,
+			name:            "function declaration",
+			node:            &dst.FuncDecl{Name: dst.NewIdent("function")},
+			wantNoReceiver:  true,
+			wantAnyReceiver: false,
 		},
 		{
 			name: "method declaration",
@@ -283,7 +285,8 @@ func TestNoReceiverMatches(t *testing.T) {
 				Recv: &dst.FieldList{List: []*dst.Field{{Type: dst.NewIdent("receiver")}}},
 				Name: dst.NewIdent("method"),
 			},
-			want: false,
+			wantNoReceiver:  false,
+			wantAnyReceiver: true,
 		},
 		{
 			name: "pointer method declaration",
@@ -291,25 +294,30 @@ func TestNoReceiverMatches(t *testing.T) {
 				Recv: &dst.FieldList{List: []*dst.Field{{Type: &dst.StarExpr{X: dst.NewIdent("receiver")}}}},
 				Name: dst.NewIdent("method"),
 			},
-			want: false,
+			wantNoReceiver:  false,
+			wantAnyReceiver: true,
 		},
 		{
-			name: "function literal",
-			node: &dst.FuncLit{Type: &dst.FuncType{}},
-			want: true,
+			name:            "function literal",
+			node:            &dst.FuncLit{Type: &dst.FuncType{}},
+			wantNoReceiver:  true,
+			wantAnyReceiver: false,
 		},
 		{
-			name: "non-function node",
-			node: &dst.GenDecl{},
-			want: false,
+			name:            "non-function node",
+			node:            &dst.GenDecl{},
+			wantNoReceiver:  false,
+			wantAnyReceiver: false,
 		},
 	}
 
-	matcher := Function(NoReceiver())
+	noReceiver := Function(NoReceiver())
+	anyReceiver := Function(AnyReceiver())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := functionTestContext{node: tt.node}
-			assert.Equal(t, tt.want, matcher.Matches(ctx))
+			assert.Equal(t, tt.wantNoReceiver, noReceiver.Matches(ctx))
+			assert.Equal(t, tt.wantAnyReceiver, anyReceiver.Matches(ctx))
 		})
 	}
 }

--- a/internal/injector/aspect/join/function_test.go
+++ b/internal/injector/aspect/join/function_test.go
@@ -6,6 +6,7 @@
 package join
 
 import (
+	"go/types"
 	"testing"
 
 	"github.com/dave/dst"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/orchestrion/internal/fingerprint"
+	aspectcontext "github.com/DataDog/orchestrion/internal/injector/aspect/context"
 	"github.com/DataDog/orchestrion/internal/injector/typed"
 )
 
@@ -212,6 +214,120 @@ func TestSignatureContainsHash(t *testing.T) {
 
 	assert.NotEqual(t, fp1, fp3, "Hash() gave same result for different signatures")
 }
+
+func TestUnmarshalYAMLReceiver(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		want    FunctionOption
+		wantErr bool
+	}{
+		{
+			name: "receiver type",
+			yaml: `receiver: net/http.Server`,
+			want: Receiver(typed.TypeName{
+				ImportPath: "net/http",
+				Name:       "Server",
+			}),
+		},
+		{
+			name: "no receiver",
+			yaml: `receiver: false`,
+			want: NoReceiver(),
+		},
+		{
+			name: "quoted false is a receiver type",
+			yaml: `receiver: "false"`,
+			want: Receiver(typed.TypeName{Name: "false"}),
+		},
+		{
+			name:    "true is rejected",
+			yaml:    `receiver: true`,
+			wantErr: true,
+		},
+		{
+			name:    "non-string is rejected",
+			yaml:    `receiver: 42`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var option unmarshalFuncDeclOption
+			err := yaml.Unmarshal([]byte(tt.yaml), &option)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, option.FunctionOption)
+		})
+	}
+}
+
+func TestNoReceiverMatches(t *testing.T) {
+	tests := []struct {
+		name string
+		node dst.Node
+		want bool
+	}{
+		{
+			name: "function declaration",
+			node: &dst.FuncDecl{Name: dst.NewIdent("function")},
+			want: true,
+		},
+		{
+			name: "method declaration",
+			node: &dst.FuncDecl{
+				Recv: &dst.FieldList{List: []*dst.Field{{Type: dst.NewIdent("receiver")}}},
+				Name: dst.NewIdent("method"),
+			},
+			want: false,
+		},
+		{
+			name: "pointer method declaration",
+			node: &dst.FuncDecl{
+				Recv: &dst.FieldList{List: []*dst.Field{{Type: &dst.StarExpr{X: dst.NewIdent("receiver")}}}},
+				Name: dst.NewIdent("method"),
+			},
+			want: false,
+		},
+		{
+			name: "function literal",
+			node: &dst.FuncLit{Type: &dst.FuncType{}},
+			want: true,
+		},
+		{
+			name: "non-function node",
+			node: &dst.GenDecl{},
+			want: false,
+		},
+	}
+
+	matcher := Function(NoReceiver())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := functionTestContext{node: tt.node}
+			assert.Equal(t, tt.want, matcher.Matches(ctx))
+		})
+	}
+}
+
+type functionTestContext struct {
+	node dst.Node
+}
+
+func (functionTestContext) Chain() *aspectcontext.NodeChain     { return nil }
+func (ctx functionTestContext) Node() dst.Node                  { return ctx.node }
+func (functionTestContext) Parent() aspectcontext.AspectContext { return nil }
+func (functionTestContext) Config(string) (string, bool)        { return "", false }
+func (functionTestContext) File() *dst.File                     { return nil }
+func (functionTestContext) ImportPath() string                  { return "example.com/test" }
+func (functionTestContext) Package() string                     { return "test" }
+func (functionTestContext) TestMain() bool                      { return false }
+func (functionTestContext) Release()                            {}
+func (functionTestContext) ResolveType(dst.Expr) types.Type     { return nil }
 
 func TestUnmarshalYAMLSignatureContains(t *testing.T) {
 	yamlStr := `

--- a/internal/injector/config/schema.json
+++ b/internal/injector/config/schema.json
@@ -485,6 +485,8 @@
         },
         "examples": [
           { "function": [{ "name": "main" }, { "signature": {} }] },
+          { "function": [{ "receiver": true }] },
+          { "function": [{ "receiver": false }] },
           { "function": [{ "signature-contains": { "args": ["context.Context"], "returns": ["error"] } }] },
           { "function": [{ "result-implements": "io.Reader" }] },
           { "function": [{ "final-result-implements": "error" }] },
@@ -513,10 +515,10 @@
                 "unevaluatedProperties": false,
                 "properties": {
                   "receiver": {
-                    "description": "Matches only method declarations for the provided receiver type, or non-method functions and function literal expressions if `false` is provided.",
+                    "description": "Matches only method declarations for the provided receiver type. A boolean matches any function based on receiver presence: `true` selects methods with any receiver type, while `false` selects non-method functions and function literal expressions.",
                     "oneOf": [
                       { "$ref": "#/$defs/go/qualified-identifier" },
-                      { "const": false }
+                      { "type": "boolean" }
                     ]
                   }
                 }

--- a/internal/injector/config/schema.json
+++ b/internal/injector/config/schema.json
@@ -513,8 +513,11 @@
                 "unevaluatedProperties": false,
                 "properties": {
                   "receiver": {
-                    "description": "Matches only method declarations for the provided receiver type.",
-                    "$ref": "#/$defs/go/qualified-identifier"
+                    "description": "Matches only method declarations for the provided receiver type, or non-method functions and function literal expressions if `false` is provided.",
+                    "oneOf": [
+                      { "$ref": "#/$defs/go/qualified-identifier" },
+                      { "const": false }
+                    ]
                   }
                 }
               },


### PR DESCRIPTION
- allow the function join point's `receiver` option to accept booleans
- interpret `receiver: true` as matching methods with any receiver type
- interpret `receiver: false` as matching non-method functions and function literals
- preserve receiver type strings for matching methods with a specific receiver type
- update the JSON schema and cover parsing and AST filtering behavior
