### PR TITLE
fix(injector): preserve negated may matches

### DIFF
--- a/internal/injector/aspect/may/match.go
+++ b/internal/injector/aspect/may/match.go
@@ -21,18 +21,19 @@ const (
 	NeverMatch MatchType = 'N'
 )
 
-// Not returns the logical NOT of a MatchType value
+// Not returns the conservative logical NOT of a MatchType value.
+// A Match only proves that some node may match, so its negation remains unknown.
 // Truth table:
 //
 // | A | NOT A |
 // |---|-------|
 // | N | Y     |
 // | ? | ?     |
-// | Y | N     |
+// | Y | ?     |
 func (m MatchType) Not() MatchType {
 	switch m {
 	case Match:
-		return NeverMatch
+		return Unknown
 	case NeverMatch:
 		return Match
 	case Unknown:

--- a/internal/injector/testdata/injector/function-body-negated-receiver/config.yml
+++ b/internal/injector/testdata/injector/function-body-negated-receiver/config.yml
@@ -1,0 +1,32 @@
+%YAML 1.1
+---
+aspects:
+  - id: crypto/sha1.Sum
+    join-point:
+      all-of:
+        - import-path: crypto/sha1
+        - function-body:
+            all-of:
+              - function:
+                  - name: Sum
+              - not:
+                  function:
+                    - receiver: "*crypto/sha1.digest"
+    advice:
+      - prepend-statements:
+          template: print("should trigger")
+
+import-path: crypto/sha1
+
+code: |-
+  package sha1
+
+  type digest struct{}
+
+  func Sum(data []byte) [20]byte {
+    return [20]byte{}
+  }
+
+  func (d *digest) Sum(data []byte) []byte {
+    return data
+  }

--- a/internal/injector/testdata/injector/function-body-negated-receiver/modified.go.snap
+++ b/internal/injector/testdata/injector/function-body-negated-receiver/modified.go.snap
@@ -1,0 +1,17 @@
+//line input.go:1:1
+package sha1
+
+type digest struct{}
+
+func Sum(data []byte) [20]byte {
+//line <generated>:1
+  {
+    print("should trigger")
+  }
+//line input.go:6
+  return [20]byte{}
+}
+
+func (d *digest) Sum(data []byte) []byte {
+  return data
+}


### PR DESCRIPTION
## Summary

- make `MatchType.Not` conservative for existential may-match results
- prevent negated receiver constraints from filtering an aspect before AST matching
- add an injector regression fixture for `crypto/sha1.Sum` versus `(*digest).Sum`

## Root cause

`may.Match` means that at least one node may match. Negating that result as `NeverMatch` was unsound: a package can contain both a matching receiver method and another function that satisfies the complete join point. The early package filter therefore discarded the aspect before node-level matching could distinguish them.

## Testing

- `go test -count=1 -run 'Test/function-body-negated-receiver$' -v ./internal/injector`\n- `GOPROXY=https://proxy.golang.org,direct go test -race -shuffle=on -count=1 ./internal/injector/...`\n- `golangci-lint run ./internal/injector/aspect/may/... ./internal/injector/aspect/join/... ./internal/injector/parse/...`\n- `GOPROXY=https://proxy.golang.org,direct go build ./...`