### PR TITLE
fix: orchestrion pin fails in projects using a Go workspace

### DIFF
--- a/internal/ensure/requiredintegrations.go
+++ b/internal/ensure/requiredintegrations.go
@@ -128,29 +128,43 @@ func resolveIntegrationVersion(ver *versions) (bool, string) {
 	return shouldUpgrade, targetVersion
 }
 
+// latestVersionEnv builds the environment used to query the Go module registry for
+// the latest version of a module, starting from base (typically [os.Environ]).
+//
+// Registry lookups must not depend on the target project's module configuration, so
+// this normalizes three variables:
+//   - GOTOOLCHAIN=local avoids spurious toolchain switches during the query.
+//   - GOFLAGS=-mod=mod overrides any inherited -mod=vendor, which would otherwise
+//     prevent querying the registry for @latest versions.
+//   - GOWORK=off disables workspace mode. When the target project uses a go.work file
+//     (e.g. etcd-style monorepos), the go command rejects -mod=mod with
+//     "-mod may only be set to readonly or vendor when in workspace mode".
+//
+// Any inherited value of these three variables is dropped so the canonical values win.
+func latestVersionEnv(base []string) []string {
+	cleanEnv := make([]string, 0, len(base)+3)
+	for _, e := range base {
+		if strings.HasPrefix(e, "GOFLAGS=") ||
+			strings.HasPrefix(e, "GOWORK=") ||
+			strings.HasPrefix(e, "GOTOOLCHAIN=") {
+			continue
+		}
+		cleanEnv = append(cleanEnv, e)
+	}
+	return append(cleanEnv,
+		"GOTOOLCHAIN=local",
+		"GOFLAGS=-mod=mod",
+		"GOWORK=off",
+	)
+}
+
 // fetchLatestVersion queries the Go module registry to get the actual latest version
 // of the specified module path.
 func fetchLatestVersion(ctx context.Context, modPath string) (string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "go", "list", "-m", "-json", modPath+"@latest")
 
-	// Build environment with GOTOOLCHAIN=local and explicit -mod=mod
-	// This is necessary because GOFLAGS might contain -mod=vendor which prevents
-	// querying the module registry for @latest versions.
-	env := os.Environ()
-	env = append(env, "GOTOOLCHAIN=local")
-
-	// Remove any existing GOFLAGS that might contain -mod=vendor
-	var cleanEnv []string
-	for _, e := range env {
-		if !strings.HasPrefix(e, "GOFLAGS=") {
-			cleanEnv = append(cleanEnv, e)
-		}
-	}
-	// Set GOFLAGS with -mod=mod to ensure we can query the registry
-	cleanEnv = append(cleanEnv, "GOFLAGS=-mod=mod")
-
-	cmd.Env = cleanEnv
+	cmd.Env = latestVersionEnv(os.Environ())
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 

--- a/internal/ensure/requiredintegrations_test.go
+++ b/internal/ensure/requiredintegrations_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/orchestrion/internal/gomod"
@@ -114,6 +115,62 @@ func TestFetchLatestVersion(t *testing.T) {
 		assert.NotEmpty(t, version)
 		assert.True(t, semver.IsValid(version), "version %q should be valid semver", version)
 	})
+
+	t.Run("workspace-mode-compatibility", func(t *testing.T) {
+		// Simulate a target project that uses a Go workspace (e.g. etcd-style
+		// monorepos). Under workspace mode the go command rejects -mod=mod with
+		// "-mod may only be set to readonly or vendor when in workspace mode",
+		// so fetchLatestVersion must disable workspace mode when querying the registry.
+		workDir := t.TempDir()
+		modDir := filepath.Join(workDir, "mod-a")
+		require.NoError(t, os.MkdirAll(modDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, "go.mod"),
+			[]byte("module example.com/mod-a\n\ngo 1.23\n"), 0644))
+		goWork := filepath.Join(workDir, "go.work")
+		require.NoError(t, os.WriteFile(goWork,
+			[]byte("go 1.23\n\nuse ./mod-a\n"), 0644))
+
+		t.Setenv("GOWORK", goWork)
+
+		version, err := fetchLatestVersion(ctx, "golang.org/x/mod")
+		require.NoError(t, err, "fetchLatestVersion should work even when GOWORK is set")
+		assert.NotEmpty(t, version)
+		assert.True(t, semver.IsValid(version), "version %q should be valid semver", version)
+	})
+}
+
+func TestLatestVersionEnv(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"GOFLAGS=-mod=vendor",
+		"GOWORK=/some/path/go.work",
+		"GOTOOLCHAIN=go1.99",
+	}
+
+	env := latestVersionEnv(base)
+
+	// Unrelated variables are preserved.
+	assert.Contains(t, env, "PATH=/usr/bin")
+
+	// Canonical overrides are present.
+	assert.Contains(t, env, "GOTOOLCHAIN=local")
+	assert.Contains(t, env, "GOFLAGS=-mod=mod")
+	// GOWORK=off is what allows -mod=mod queries to succeed under workspace mode.
+	assert.Contains(t, env, "GOWORK=off")
+
+	// Inherited conflicting values must be dropped, not just shadowed: each of the
+	// three normalized variables appears exactly once.
+	counts := map[string]int{}
+	for _, e := range env {
+		key, _, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		counts[key]++
+	}
+	assert.Equal(t, 1, counts["GOFLAGS"], "GOFLAGS should appear exactly once")
+	assert.Equal(t, 1, counts["GOWORK"], "GOWORK should appear exactly once")
+	assert.Equal(t, 1, counts["GOTOOLCHAIN"], "GOTOOLCHAIN should appear exactly once")
 }
 
 func TestFetchVersions(t *testing.T) {

--- a/internal/ensure/requiredintegrations_test.go
+++ b/internal/ensure/requiredintegrations_test.go
@@ -160,7 +160,7 @@ func TestLatestVersionEnv(t *testing.T) {
 
 	// Inherited conflicting values must be dropped, not just shadowed: each of the
 	// three normalized variables appears exactly once.
-	counts := map[string]int{}
+	counts := make(map[string]int)
 	for _, e := range env {
 		key, _, ok := strings.Cut(e, "=")
 		if !ok {

--- a/internal/gomod/gomod.go
+++ b/internal/gomod/gomod.go
@@ -85,12 +85,27 @@ func (m *File) Requires(path string) (string, bool) {
 	return "", false
 }
 
+// commandEnv returns the environment for go subcommands that operate on an
+// explicit `-modfile`, starting from base (typically [os.Environ]).
+//
+// Every command run by this package targets a single module via `-modfile`, which
+// the go command rejects in workspace mode with "go: -modfile cannot be used in
+// workspace mode". A project can enter workspace mode simply by having a go.work
+// file (e.g. etcd-style monorepos), so workspace mode is disabled here to keep
+// these single-module operations working:
+//   - GOTOOLCHAIN=local avoids spurious toolchain switches during the command.
+//   - GOWORK=off disables workspace mode; it is appended last so it wins over any
+//     inherited GOWORK value.
+func commandEnv(base []string) []string {
+	return append(base, "GOTOOLCHAIN=local", "GOWORK=off")
+}
+
 // RunGet executes the `go get <modSpecs...>` subcommand with the provided
 // module specifications on the designated `go.mod` file.
 func RunGet(ctx context.Context, modfile string, modSpecs ...string) error {
 	cmd := exec.CommandContext(ctx, "go", "get", "-modfile", modfile)
 	cmd.Args = append(cmd.Args, modSpecs...)
-	cmd.Env = append(os.Environ(), "GOTOOLCHAIN=local")
+	cmd.Env = commandEnv(os.Environ())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -103,7 +118,7 @@ func RunGet(ctx context.Context, modfile string, modSpecs ...string) error {
 func Run(ctx context.Context, command string, modfile string, stdout io.Writer, args ...string) error {
 	cmd := exec.CommandContext(ctx, "go", "mod", command, "-modfile", modfile)
 	cmd.Args = append(cmd.Args, args...)
-	cmd.Env = append(os.Environ(), "GOTOOLCHAIN=local")
+	cmd.Env = commandEnv(os.Environ())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr

--- a/internal/gomod/gomod_test.go
+++ b/internal/gomod/gomod_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package gomod
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandEnv(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"GOWORK=/some/path/go.work",
+		"GOTOOLCHAIN=go1.99",
+	}
+
+	env := commandEnv(base)
+
+	// Unrelated variables are preserved.
+	assert.Contains(t, env, "PATH=/usr/bin")
+
+	// GOWORK=off is required so that -modfile commands are not rejected in
+	// workspace mode ("go: -modfile cannot be used in workspace mode").
+	assert.Contains(t, env, "GOWORK=off")
+	assert.Contains(t, env, "GOTOOLCHAIN=local")
+
+	// The overrides are appended last so they win over any inherited value.
+	last := make(map[string]string)
+	for _, e := range env {
+		key, val, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		last[key] = val
+	}
+	assert.Equal(t, "off", last["GOWORK"], "GOWORK=off must win over inherited GOWORK")
+	assert.Equal(t, "local", last["GOTOOLCHAIN"], "GOTOOLCHAIN=local must win over inherited GOTOOLCHAIN")
+}


### PR DESCRIPTION
## Why is the change being made?

The `benchmark` job in CI has been failing on **every PR**. The failing case is
`Benchmark/repo=etcd-io:etcd`, with:

```
command failed: .../bin/orchestrion.exe pin
  ensuring required integrations in ".../server/go.mod":
  fetching versions for github.com/DataDog/dd-trace-go/v2:
  fetching latest version for github.com/DataDog/dd-trace-go/v2:
  go list -m -json github.com/DataDog/dd-trace-go/v2@latest: exit status 1
  (stderr: go: -mod may only be set to readonly or vendor when in workspace mode,
   but it is set to "mod"
   Remove the -mod flag to use the default readonly value,
   or set GOWORK=off to disable workspace mode.)
```

### Root cause

When ensuring the required dd-trace-go integrations, `orchestrion pin` queries the
module registry for the latest version via `go list -m -json <mod>@latest`. To do so
it sets `GOFLAGS=-mod=mod`, which overrides any inherited `-mod=vendor` that would
otherwise prevent registry lookups.

However, when the target project uses a **Go workspace** (a `go.work` file), the go
command rejects `-mod=mod` outright — `-mod` may only be `readonly` or `vendor` in
workspace mode. So `orchestrion pin` fails for **any** workspace-based project.

The benchmark suite pins the latest `etcd` release; `etcd v3.7.0` introduced a
`go.work`, which is why this started failing across all PRs.

## What is the change?

A registry lookup for an `@latest` version should not depend on the target project's
workspace configuration at all. The `go list -m -json <mod>@latest` query now runs with
`GOWORK=off`, which disables workspace mode and makes `-mod=mod` valid again.

The environment construction for this query is extracted into a small
`latestVersionEnv` helper so the behavior (drops inherited `GOFLAGS`/`GOWORK`, sets
`GOTOOLCHAIN=local`, `GOFLAGS=-mod=mod`, `GOWORK=off`) can be unit-tested
deterministically, plus a `workspace-mode-compatibility` integration test that runs the
real query with `GOWORK` set.