### PR TITLE
fix(ci): mint self-mutation token from a workflow pinned to main (2/2)

### DIFF
--- a/.github/chainguard/self.github.validate.self-mutation.sts.yaml
+++ b/.github/chainguard/self.github.validate.self-mutation.sts.yaml
@@ -1,10 +1,18 @@
-# Policy for: .github/workflows/validate.yml (self-mutation job) in DataDog/orchestrion
+# Policy for: .github/workflows/self-mutation.yml in DataDog/orchestrion, which is called by the
+# self-mutation job of .github/workflows/validate.yml.
+#
+# `job_workflow_ref` is anchored to `self-mutation.yml@refs/heads/main` rather than to validate.yml.
+# For `pull_request` events GitHub runs workflows from the PR merge ref, so a claim pattern matching
+# validate.yml can only ever match a ref the pull request itself controls -- which would let a PR
+# rewrite the token-minting steps and use this `contents: write` token for anything. Because
+# `job_workflow_ref` resolves to the *called* reusable workflow, pinning the call at `@main` keeps
+# this claim tied to code that has already landed on the default branch.
 issuer: https://token.actions.githubusercontent.com
 subject_pattern: repo:DataDog/orchestrion:pull_request
 
 claim_pattern:
   event_name: pull_request
-  job_workflow_ref: DataDog/orchestrion/\.github/workflows/validate\.yml@refs/heads/main
+  job_workflow_ref: DataDog/orchestrion/\.github/workflows/self-mutation\.yml@refs/heads/main
   base_ref: main
   repository: DataDog/orchestrion
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,41 +99,19 @@ jobs:
   # proactively do it with the mutator token.
   self-mutation:
     needs: generate
-    runs-on: ubuntu-latest
     name: Update PR with generated files
     permissions:
-      id-token: write
+      id-token: write # To mint the dd-octo-sts token
       contents: read
-    if: always() && needs.generate.outputs.has-patch == 'true' && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository || github.event.pull_request.maintainer_can_modify)
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Download patch
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: repo.patch
-          path: ${{ runner.temp }}
-      - name: Apply patch
-        run: |-
-          [ -s '${{ runner.temp }}/.repo.patch' ] && git apply '${{ runner.temp }}/.repo.patch' || echo 'Empty patch. Skipping.'
-      - name: Get GitHub token (DataDog/orchestrion)
-        id: generate-token
-        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        with:
-          scope: DataDog/orchestrion
-          policy: self.github.validate.self-mutation
-      # We use ghcommit to create signed commits directly using the GitHub API
-      - name: Push changes
-        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
-        with:
-          commit_message: "chore: update generated files"
-          repo: ${{ github.event.pull_request.head.repo.full_name }}
-          branch: ${{ github.event.pull_request.head.ref }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+    if: always() && needs.generate.outputs.has-patch == 'true'
+    # SECURITY: pinned at `@main` on purpose, and NOT via a relative
+    # `./.github/workflows/self-mutation.yml` path. This job mints a `contents: write` token, and for
+    # `pull_request` events GitHub runs workflows from the PR merge ref -- so anything defined in this
+    # file is rewritable by the pull request itself. Referencing the called workflow at `@main` keeps
+    # the OIDC `job_workflow_ref` claim anchored to a ref the PR cannot influence, which is what the
+    # dd-octo-sts trust policy asserts. A relative reference would resolve to this (untrusted) commit.
+    # See .github/workflows/self-mutation.yml for the full rationale.
+    uses: DataDog/orchestrion/.github/workflows/self-mutation.yml@main # ratchet:exclude
   ##############################################################################
   # Run the various linters we have set up...
   lint:
@@ -187,7 +165,14 @@ jobs:
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@3db98c0363e2fa5df3e1c4c471777a7c10b24cc9 # v3
         with:
-          allowlist: DataDog/dd-trace-go # Trust actions/workflows in the dd-trace-go repository
+          # - DataDog/dd-trace-go: trust actions/workflows in the dd-trace-go repository.
+          # - DataDog/orchestrion: this repository's own reusable workflows are referenced by branch
+          #   (@main) rather than by SHA, because the OIDC `job_workflow_ref` claim must resolve to a
+          #   stable `@refs/heads/main` value for the dd-octo-sts trust policy to match. See
+          #   .github/workflows/self-mutation.yml for details.
+          allowlist: |
+            DataDog/dd-trace-go
+            DataDog/orchestrion
       - name: Verify actions are pinned with ratchet
         uses: sethvargo/ratchet@9ca118155b0f79464185703a50da367e111107cd # ratchet:exclude
         with:


### PR DESCRIPTION
Step 2 of 2. Stacked on [#866](https://github.com/DataDog/orchestrion/pull/866) — **do not merge until #866 lands on `main`.**

## Why this depends on #866
`validate.yml` now calls `.github/workflows/self-mutation.yml` via `uses: DataDog/orchestrion/.github/workflows/self-mutation.yml@main`. That `@main` reference is resolved by GitHub against the actual tip of `main` in this repo — not against this PR's base branch, not against the merge commit being tested. Until #866 merges, `main` doesn't have that file, so **this PR's own CI will fail to load** (the same zero-jobs, instant-failure symptom documented on #866: [run 30830039834](https://github.com/DataDog/orchestrion/actions/runs/30830039834)). That's expected, not a regression — stacking this PR on #866's branch only makes the *diff* clean for review; it doesn't change how `@main` resolves.

Once #866 merges, this PR's base will auto-retarget to `main` and its CI should go green.

## What this does
- `self-mutation` job in `validate.yml` becomes `uses: DataDog/orchestrion/.github/workflows/self-mutation.yml@main` instead of an inline job, moving the token-minting into the trusted reusable workflow added in #866.
- `job_workflow_ref` in `.github/chainguard/self.github.validate.self-mutation.sts.yaml` now targets `self-mutation.yml@refs/heads/main` instead of `validate.yml@refs/heads/main` (the latter being the unsatisfiable pattern from #846 — see #866 for the full history).
- `GitHub Workflow Linters`' SHA-pin allowlist gains `DataDog/orchestrion`, and the `uses:` line gets `# ratchet:exclude`, since this one reference is intentionally a branch ref rather than a SHA.

## Test plan
- [x] `actionlint` clean locally
- [x] YAML parses (chainguard policy + workflow)
- [ ] Once rebased onto `main` (post-#866), confirm `GitHub Workflow Linters` passes and a PR with a generator diff successfully mints the token and pushes (no `permission denied`)