### PR TITLE
fix(bench): drop stale otel/sdk/log@latest override for traefik benchmark

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -274,9 +274,6 @@ func benchmarkGithub(owner string, repo string, subdir string, build string, tes
 		}
 		// traefik needs a few tweaks in order to build successfully
 		if repo == "traefik" {
-			// it fails to build if we don't upgrade the version go.opentelemetry.io/otel/sdk/log
-			tc.exec(b, "go", "get", "go.opentelemetry.io/otel/sdk/log@latest")
-
 			// it fails to build if ./webui/static does not exist, so just create a folder with mock content
 			webuiPath := filepath.Join(tc.dir, "webui")
 			if stat, err := os.Stat(webuiPath); err == nil && stat.IsDir() {


### PR DESCRIPTION
## Summary
- The `Benchmarks (run 1-6)` CI jobs (advisory-only, non-blocking) were failing to build the `traefik/traefik` benchmark case with errors like `undefined: api.KeyValue`, `undefined: log.Value`, `undefined: log.KindBool`.
- Root cause: `benchmarkGithub`'s traefik special-case ran `go get go.opentelemetry.io/otel/sdk/log@latest` to work around a historical build issue. traefik's own `go.mod` (as of the current latest release, v3.7.10) already pins `otel/log`, `otel/sdk/log`, `otlploggrpc`, `otlploghttp`, and `otellogrus` to a mutually-consistent v0.20.0/v0.13.0 set — so the override is no longer needed. Worse, it's actively harmful: `otel/sdk/log@latest` just started resolving to v0.21.0 (a breaking API change to the sibling `otel/log` package), while the exporters/bridge stayed pinned at v0.20.0/v0.13.0, causing the skew that broke the build.
- Fix: remove the now-stale/harmful `@latest` override. The `webui/static` mock-content workaround (still needed) is untouched.

## Verification
- Cloned `traefik@v3.7.10` fresh and ran `go build ./...` with no changes — builds cleanly.
- Reproduced the failure by re-adding the `go get .../otel/sdk/log@latest` step — confirmed it bumps to v0.21.0 and reproduces the exact `undefined: api.KeyValue`/`log.Value`/`log.KindBool` errors from CI.
- Ran `orchestrion pin` (adding the dd-trace-go integration) on top of the unmodified go.mod — resolved `otel/log` stays at v0.20.0, and the build still succeeds.

## Test plan
- [ ] CI: confirm the `Benchmarks (run 1-6)` jobs no longer fail on the `traefik:traefik` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)