### PR TITLE
fix(injector): return no match instead of an error for function lookups outside a function

### DIFF
--- a/internal/injector/aspect/advice/code/dot_function.go
+++ b/internal/injector/aspect/advice/code/dot_function.go
@@ -110,32 +110,36 @@ func (noFunc) Argument(int) (string, error) {
 	return "", errNoFunction
 }
 
-func (noFunc) ArgumentOfType(string) (string, error) {
-	return "", errNoFunction
-}
-
-func (noFunc) ArgumentThatImplements(string) (string, error) {
-	return "", errNoFunction
-}
-
 func (noFunc) Result(int) (string, error) {
 	return "", errNoFunction
 }
 
+// The methods below are searches, so outside of a function they report "not found" instead of an
+// error. This lets templates branch on the result, e.g. `{{ if $ctx }}`, and still apply to nodes
+// at package scope.
+
+func (noFunc) ArgumentOfType(string) (string, error) {
+	return "", nil
+}
+
+func (noFunc) ArgumentThatImplements(string) (string, error) {
+	return "", nil
+}
+
 func (noFunc) ResultOfType(string) (string, error) {
-	return "", errNoFunction
+	return "", nil
 }
 
 func (noFunc) ResultThatImplements(string) (string, error) {
-	return "", errNoFunction
+	return "", nil
 }
 
 func (noFunc) LastResultThatImplements(string) (string, error) {
-	return "", errNoFunction
+	return "", nil
 }
 
 func (noFunc) FinalResultImplements(string) (bool, error) {
-	return false, errNoFunction
+	return false, nil
 }
 
 type signature struct {

--- a/internal/injector/aspect/advice/code/dot_function_test.go
+++ b/internal/injector/aspect/advice/code/dot_function_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package code
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoFuncLookupsReturnNotFound(t *testing.T) {
+	var fn function = noFunc{}
+
+	for name, lookup := range map[string]func(string) (string, error){
+		"ArgumentOfType":           fn.ArgumentOfType,
+		"ArgumentThatImplements":   fn.ArgumentThatImplements,
+		"ResultOfType":             fn.ResultOfType,
+		"ResultThatImplements":     fn.ResultThatImplements,
+		"LastResultThatImplements": fn.LastResultThatImplements,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := lookup("context.Context")
+			require.NoError(t, err)
+			assert.Empty(t, got)
+		})
+	}
+
+	t.Run("FinalResultImplements", func(t *testing.T) {
+		got, err := fn.FinalResultImplements("error")
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}
+
+func TestNoFuncAccessorsError(t *testing.T) {
+	var fn function = noFunc{}
+
+	_, err := fn.Receiver()
+	require.ErrorIs(t, err, errNoFunction)
+
+	_, err = fn.Name()
+	require.ErrorIs(t, err, errNoFunction)
+
+	_, err = fn.Argument(0)
+	require.ErrorIs(t, err, errNoFunction)
+
+	_, err = fn.Result(0)
+	require.ErrorIs(t, err, errNoFunction)
+}

--- a/internal/injector/testdata/injector/method-call-package-scope/config.yml
+++ b/internal/injector/testdata/injector/method-call-package-scope/config.yml
@@ -1,0 +1,47 @@
+%YAML 1.1
+---
+# Verifies that a wrap-expression template using .Function.ArgumentOfType applies to matched calls
+# that are not enclosed in any function (package-level declarations), where the lookup yields an
+# empty string instead of failing the compilation.
+aspects:
+  - id: http-client-do
+    join-point:
+      method-call:
+        receiver: "net/http.Client"
+        name: Do
+        match: pointer-only
+    advice:
+      - wrap-expression:
+          template: |-
+            {{- $ctx := .Function.ArgumentOfType "context.Context" -}}
+            {{ .AST.Fun }}(
+              {{ index .AST.Args 0 }}.WithContext(
+                {{- if $ctx -}}
+                  {{ $ctx }}
+                {{- else -}}
+                  context.Background()
+                {{- end -}}
+              ),
+            )
+          imports:
+            context: context
+
+code: |-
+  package test
+
+  import (
+    "context"
+    "net/http"
+  )
+
+  var pkgClient = &http.Client{}
+
+  var pkgReq, _ = http.NewRequest("GET", "https://example.com", nil)
+
+  // Matched at package scope: there is no enclosing function, so ArgumentOfType finds nothing.
+  var pkgResp, pkgErr = pkgClient.Do(pkgReq)
+
+  // Matched inside a function: ArgumentOfType resolves the context argument.
+  func doRequest(ctx context.Context, client *http.Client, req *http.Request) {
+    _, _ = client.Do(req)
+  }

--- a/internal/injector/testdata/injector/method-call-package-scope/modified.go.snap
+++ b/internal/injector/testdata/injector/method-call-package-scope/modified.go.snap
@@ -1,0 +1,39 @@
+//line input.go:1:1
+package test
+
+import (
+  "context"
+  "net/http"
+)
+
+var pkgClient = &http.Client{}
+
+var pkgReq, _ = http.NewRequest("GET", "https://example.com", nil)
+
+// Matched at package scope: there is no enclosing function, so ArgumentOfType finds nothing.
+var pkgResp, pkgErr =
+//line <generated>:1
+//line input.go:13
+pkgClient.Do(
+//line <generated>:1
+//line input.go:13
+  pkgReq.
+//line <generated>:1
+    WithContext(context.Background()),
+)
+
+// Matched inside a function: ArgumentOfType resolves the context argument.
+//
+//line input.go:16
+func doRequest(ctx context.Context, client *http.Client, req *http.Request) {
+  _, _ =
+//line <generated>:1
+//line input.go:17
+    client.Do(
+//line <generated>:1
+//line input.go:17
+      req.
+//line <generated>:1
+        WithContext(ctx),
+    )
+}


### PR DESCRIPTION
With an aspect whose template does an argument lookup:

```yaml
aspects:
  - id: http-client-do
    join-point:
      method-call: {receiver: "net/http.Client", name: Do, match: pointer-only}
    advice:
      - wrap-expression:
          imports: {context: context}
          template: |-
            {{- $ctx := .Function.ArgumentOfType "context.Context" -}}
            {{ .AST.Fun }}(
              {{ index .AST.Args 0 }}.WithContext(
                {{- if $ctx -}}{{ $ctx }}{{- else -}}context.Background(){{- end -}}
              ),
            )
```

the `.Function.ArgumentOfType` call fails the build whenever the matched call has no enclosing function, for example a package-level declaration:

```go
package test

...

// no enclosing function, package-level declaration
var resp, err = pkgClient.Do(pkgReq)
```

```
executing "code.Template" at <.Function.ArgumentOfType>: error calling ArgumentOfType:
no function is present in this node chain
```

`dot.Function()` returns `noFunc{}` when nothing in the node chain is a function, and `noFunc` returned an error from its six search methods (`ArgumentOfType`, `ArgumentThatImplements`, `ResultOfType`, `ResultThatImplements`, `LastResultThatImplements`, `FinalResultImplements`), even though the interface documents them as returning an empty result when nothing matches. A template cannot guard against it, because the error happens during template execution.

They now return their zero value and no error, so the template above takes its `{{ else }}` branch at package scope. `Receiver`, `Name`, `Argument` and `Result` still return the error, since having no function really is a failure for those.

### Aspects affected in dd-trace-go

Eight `wrap-expression` aspects use a `.Function` lookup. Six of them can be hit today, because the matched call returns a value and can therefore sit in a package-level declaration:

- `contrib/net/http` — `Get|Head|Post|PostForm`
- `contrib/IBM/sarama` — `NewSyncProducer`, `NewAsyncProducer`
- `contrib/Shopify/sarama` — `NewSyncProducer`, `NewAsyncProducer`
- `contrib/aerospike/aerospike-client-go.v7` — `Client`, added in DataDog/dd-trace-go#5061

Each of these fails to build on v1.11.0 with the error above:

The two zap aspects (`Logger.*` and `SugaredLogger.*`) do the same lookup but cannot be reached, since those log methods return nothing and so cannot appear in a package-level declaration.

Adds an injector testdata case covering both placements, plus unit tests on `noFunc`.
