### PR TITLE
fix(toolexec): test binaries fail to link, or are not instrumented

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -268,10 +268,9 @@ jobs:
         shell: bash
         run: |-
           mkdir -p coverage
-          test_args=("-shuffle=on" "-race")
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            test_args+=("-timeout=30m")
-          fi
+          # The root package's tests each run several complete instrumented builds of a synthetic module,
+          # which takes them well past Go's default 10 minute per-package timeout on CI runners.
+          test_args=("-shuffle=on" "-race" "-timeout=30m")
           if [ "${{ github.event_name }}" != "merge_group" ]; then
             test_args+=("-cover" "-covermode=atomic" "-coverpkg=./...,github.com/DataDog/orchestrion/...")
           fi
@@ -397,9 +396,13 @@ jobs:
       - name: Build orchestrion
         run: go build -o bin/orchestrion .
       - name: Run E2E tests
-        run: go test -tags=e2e -v -timeout=10m ./test/e2e/ 2>&1 | tee test-e2e.log
+        run: go test -tags=e2e -v -timeout=15m ./test/e2e/ 2>&1 | tee test-e2e.log
         env:
-          E2E_TEST_TIMEOUT: 5m
+          # These tests pin Orchestrion into a synthetic module, which downloads the complete
+          # `dd-trace-go` integration set. Those modules are not part of any committed `go.mod` file, so
+          # they are never in the Go module cache restored by `actions/setup-go`, and downloading them
+          # alone can take several minutes on the slowest runners.
+          E2E_TEST_TIMEOUT: 12m
       - name: Upload E2E artifacts on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/internal/cmd/toolexec.go
+++ b/internal/cmd/toolexec.go
@@ -86,7 +86,9 @@ var Toolexec = &cli.Command{
 		}
 
 		log.Debug().Strs("command", proxyCmd.Args()).Msg("Toolexec original command")
-		weaver := aspect.Weaver{ImportPath: importPath}
+		// NB: the raw `$TOOLEXEC_IMPORTPATH` value was passed to [proxy.ParseCommand], as it uniquely
+		// identifies the compilation task; while the weaver is concerned with the package's identity.
+		weaver := aspect.NewWeaver(importPath)
 
 		if err := proxy.ProcessCommand(ctx, proxyCmd, weaver.OnCompile); errors.Is(err, proxy.ErrSkipCommand) {
 			log.Trace().Msg("OnCompile processor requested command skipping...")

--- a/internal/goenv/gobin.go
+++ b/internal/goenv/gobin.go
@@ -5,7 +5,12 @@
 
 package goenv
 
-import "os/exec"
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
 
 var goBinPath string
 
@@ -21,4 +26,30 @@ func GoBinPath() (string, error) {
 		goBinPath = goBin
 	}
 	return goBinPath, nil
+}
+
+// GOVERSION returns the version reported by the resolved `go` command for the
+// designated working directory. The directory matters when Go selects a newer
+// toolchain based on a module's `go` or `toolchain` directive.
+func GOVERSION(dir string) (string, error) {
+	goBin, err := GoBinPath()
+	if err != nil {
+		return "", fmt.Errorf("resolving go binary: %w", err)
+	}
+	cmd := exec.Command(goBin, "env", "GOVERSION")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if detail := strings.TrimSpace(string(exitErr.Stderr)); detail != "" {
+				return "", fmt.Errorf("running %q: %w: %s", []string{goBin, "env", "GOVERSION"}, err, detail)
+			}
+		}
+		return "", fmt.Errorf("running %q: %w", []string{goBin, "env", "GOVERSION"}, err)
+	}
+	if goVersion := strings.TrimSpace(string(output)); goVersion != "" {
+		return goVersion, nil
+	}
+	return "", fmt.Errorf("running %q returned a blank version", []string{goBin, "env", "GOVERSION"})
 }

--- a/internal/goenv/gobin_test.go
+++ b/internal/goenv/gobin_test.go
@@ -6,6 +6,7 @@
 package goenv
 
 import (
+	"go/version"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,4 +16,10 @@ func Test(t *testing.T) {
 	path, err := GoBinPath()
 	require.NoError(t, err)
 	t.Logf("GOBIN: %s", path)
+}
+
+func TestGOVERSION(t *testing.T) {
+	goVersion, err := GOVERSION(".")
+	require.NoError(t, err)
+	require.True(t, version.IsValid(goVersion), "invalid Go version %q", goVersion)
 }

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -210,13 +210,87 @@ func (f CommandFlags) Slice() []string {
 
 // ParseCommandFlags parses a slice representing a go command invocation
 // and returns its flags. Direct arguments to the command are ignored. The value
-// of $GOFLAGS is also included in the returned flags.
+// of $GOFLAGS is also included in the returned flags. A -C before or immediately
+// after the Go command path is applied relative to wd; a blank or relative wd is
+// resolved against the current process working directory.
 func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFlags, error) {
-	goVersion, err := goenv.GOVERSION(wd)
+	log := zerolog.Ctx(ctx)
+	effectiveWD, args, changed, err := resolveLeadingChdir(wd, args)
+	if err != nil {
+		return CommandFlags{}, fmt.Errorf("resolving leading -C flag: %w", err)
+	}
+	if changed {
+		log.Trace().Str("from", wd).Str("to", effectiveWD).Msg("Applying leading -C flag")
+	}
+
+	goVersion, err := goenv.GOVERSION(effectiveWD)
 	if err != nil {
 		return CommandFlags{}, fmt.Errorf("determining Go toolchain version: %w", err)
 	}
-	return parseCommandFlags(ctx, wd, args, goVersion)
+	return parseCommandFlags(ctx, effectiveWD, args, goVersion)
+}
+
+// resolveLeadingChdir applies the leading -C flag handled specially by cmd/go
+// and removes it from args. The returned working directory is absolute when the
+// flag designates a relative directory.
+func resolveLeadingChdir(wd string, args []string) (effectiveWD string, remaining []string, changed bool, err error) {
+	dir, remaining, changed := leadingChdirFlag(args)
+	if !changed {
+		return wd, args, false, nil
+	}
+	if filepath.IsAbs(dir) {
+		return filepath.Clean(dir), remaining, true, nil
+	}
+	// Rooted and drive-relative paths on Windows are relative to process state,
+	// not to an arbitrary wd. filepath.Abs reproduces os.Chdir's resolution.
+	if filepath.VolumeName(dir) != "" || len(dir) > 0 && os.IsPathSeparator(dir[0]) {
+		effectiveWD, err = filepath.Abs(dir)
+	} else {
+		effectiveWD = filepath.Join(wd, dir)
+		if !filepath.IsAbs(effectiveWD) {
+			effectiveWD, err = filepath.Abs(effectiveWD)
+		}
+	}
+	if err != nil {
+		return "", nil, false, err
+	}
+	return filepath.Clean(effectiveWD), remaining, true, nil
+}
+
+// leadingChdirFlag returns the directory and remaining arguments when args
+// contains one of the leading -C forms accepted by cmd/go. The flag may precede
+// the command or immediately follow the command (or command-group) token.
+func leadingChdirFlag(args []string) (dir string, remaining []string, found bool) {
+	indices := [...]int{0, 1, 2}
+	for _, index := range indices {
+		if index >= len(args) || index == 1 && strings.HasPrefix(args[0], "-") {
+			continue
+		}
+		if index == 2 && (args[0] != "mod" && args[0] != "work" || strings.HasPrefix(args[1], "-")) {
+			continue
+		}
+
+		consumed := 0
+		switch arg := args[index]; {
+		case arg == "-C" || arg == "--C":
+			if index+1 >= len(args) {
+				continue
+			}
+			dir = args[index+1]
+			consumed = 2
+		case strings.HasPrefix(arg, "-C=") || strings.HasPrefix(arg, "--C="):
+			_, dir, _ = strings.Cut(arg, "=")
+			consumed = 1
+		default:
+			continue
+		}
+
+		remaining = make([]string, 0, len(args)-consumed)
+		remaining = append(remaining, args[:index]...)
+		remaining = append(remaining, args[index+consumed:]...)
+		return dir, remaining, true
+	}
+	return "", args, false
 }
 
 func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion string) (CommandFlags, error) {
@@ -235,23 +309,7 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 		log.Trace().Strs("GOFLAGS", goflagsArgs).Msg("GOFLAGS arguments")
 	}
 
-	// Remove any `-C` flag provided on the command line. This is required to immediately follow the `go` command, and
-	// can be present only once.
-	if len(args) > 0 {
-		if arg := args[0]; strings.HasPrefix(arg, "-C") {
-			if arg == "-C" && len(args) > 1 {
-				// ["-C", "directory", ...]
-				log.Trace().Strs("flag", args[:2]).Msg("Skipping '-C <dir>' flag")
-				args = args[2:]
-			} else if arg[:3] == "-C=" {
-				// ["-C=directory", ...]
-				log.Trace().Str("flag", arg).Msg("Skipping '-C=<dir>' flag")
-				args = args[1:]
-			}
-		}
-	}
-
-	// The next argument after a `-C` (if present) is the go command name ("run", "test", "list", etc...).
+	// The first argument is the go command name ("run", "test", "list", etc...).
 	var command string
 	if len(args) > 0 {
 		command = args[0]
@@ -521,7 +579,9 @@ func SetFlagsFromPid(ctx context.Context, pid int) error {
 }
 
 // SetFlags sets the flags for this process to those parsed from the provided
-// slice. Does nothing if SetFlags or Flags has already been called once.
+// slice. wd is the working directory before any -C adjacent to the Go command
+// path; a blank or relative wd is resolved against the current process working
+// directory. Does nothing if SetFlags or Flags has already been called once.
 func SetFlags(ctx context.Context, wd string, args []string) {
 	once.Do(func() {
 		log := zerolog.Ctx(ctx)
@@ -700,7 +760,14 @@ func parentGoCommandFlags(ctx context.Context, pid int) (flags CommandFlags, err
 		return flags, fmt.Errorf("failed to get working directory of %d: %w", p.Pid, err)
 	}
 
-	return ParseCommandFlags(ctx, wd, args[1:])
+	commandArgs := args[1:]
+	if _, remaining, found := leadingChdirFlag(commandArgs); found {
+		// cmd/go changes its process working directory before doing any other work.
+		// The parent process' cwd already reflects -C, so only remove the original
+		// argv entry here instead of applying it a second time.
+		commandArgs = remaining
+	}
+	return ParseCommandFlags(ctx, wd, commandArgs)
 }
 
 var (

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go/version"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -90,7 +91,7 @@ var (
 	// provided in the `-flag value` form.
 	valuelessFlags = map[string]struct{}{
 		// `go test` flags
-		"-artifacts": {}, // Retain test artifacts
+		"-artifacts": {}, // Retain test artifacts (Go 1.26 and later)
 		"-benchmem":  {}, // Print memory allocation statistics for benchmarks
 		"-c":         {}, // Compile the test binary but do not run it
 		"-failfast":  {}, // Do not start new tests after the first test failure
@@ -101,6 +102,62 @@ var (
 		// Build flags that are irrelevant to (and must not be forwarded to) child builds
 		"-n": {}, // Print the commands but do not run them
 		"-x": {}, // Print the commands
+	}
+	// testValueFlags are flags recognized by `go test` which require a value and
+	// which Orchestrion does not otherwise process. Knowing they are recognized is
+	// necessary because package patterns may follow them, unlike flags destined to
+	// the test binary. Both their bare and `-flag=value` forms are accepted.
+	testValueFlags = map[string]struct{}{
+		"-bench":                {},
+		"-benchtime":            {},
+		"-blockprofile":         {},
+		"-blockprofilerate":     {},
+		"-count":                {},
+		"-cpu":                  {},
+		"-cpuprofile":           {},
+		"-debug-actiongraph":    {},
+		"-debug-runtime-trace":  {},
+		"-debug-trace":          {},
+		"-exec":                 {},
+		"-fuzz":                 {},
+		"-fuzzminimizetime":     {},
+		"-fuzztime":             {},
+		"-list":                 {},
+		"-memprofile":           {},
+		"-memprofilerate":       {},
+		"-mutexprofile":         {},
+		"-mutexprofilefraction": {},
+		"-o":                    {},
+		"-outputdir":            {},
+		"-p":                    {},
+		"-parallel":             {},
+		"-run":                  {},
+		"-shuffle":              {},
+		"-skip":                 {},
+		"-timeout":              {},
+		"-trace":                {},
+		"-vet":                  {},
+	}
+	// versionedTestFlags records when test flags unavailable in the minimum
+	// supported Go version were introduced.
+	versionedTestFlags = map[string]string{
+		"-artifacts": "go1.26",
+	}
+	// nonForwardedTestFlags are test command and build flags included in the
+	// valueless and value-taking sets above for parsing purposes, but for which
+	// cmd/go does not accept a `-test.`-prefixed alias.
+	nonForwardedTestFlags = map[string]struct{}{
+		"-c":                   {},
+		"-debug-actiongraph":   {},
+		"-debug-runtime-trace": {},
+		"-debug-trace":         {},
+		"-exec":                {},
+		"-json":                {},
+		"-n":                   {},
+		"-o":                   {},
+		"-p":                   {},
+		"-vet":                 {},
+		"-x":                   {},
 	}
 )
 
@@ -155,6 +212,14 @@ func (f CommandFlags) Slice() []string {
 // and returns its flags. Direct arguments to the command are ignored. The value
 // of $GOFLAGS is also included in the returned flags.
 func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFlags, error) {
+	goVersion, err := goenv.GOVERSION(wd)
+	if err != nil {
+		return CommandFlags{}, fmt.Errorf("determining Go toolchain version: %w", err)
+	}
+	return parseCommandFlags(ctx, wd, args, goVersion)
+}
+
+func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion string) (CommandFlags, error) {
 	log := zerolog.Ctx(ctx)
 
 	flags := CommandFlags{
@@ -200,6 +265,7 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 
 	// Compose the complete list of arguments: those from GOFLAGS, and the rest of the command line so far; in this order
 	// as the CLI arguments have precedence over those from GOFLAGS.
+	goflagsCount := len(goflagsArgs)
 	args = append(append(make([]string, 0, len(goflagsArgs)+len(args)), goflagsArgs...), args...)
 
 	var (
@@ -230,13 +296,18 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 
 		// Any argument without a leading "-" is a positional argument (until proven otherwise).
 		if !strings.HasPrefix(arg, "-") {
-			if !positionalRunEnded {
-				positional = append(positional, arg)
+			if positionalRunEnded {
+				// This cannot be a package pattern. It is a literal argument to the test binary, and
+				// cmd/go consequently passes the entire remainder through without parsing more flags.
+				break
 			}
+			positional = append(positional, arg)
 			continue
 		}
 		// This argument is a flag, so any positional argument run has now ended.
-		positionalRunEnded = len(positional) > 0
+		if len(positional) > 0 {
+			positionalRunEnded = true
+		}
 
 		normArg := arg
 		if strings.HasPrefix(arg, "--") {
@@ -247,13 +318,23 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 
 		key, val, isAssigned := strings.Cut(normArg, "=")
 		hasNextArg := i+1 < len(args)
+		fromGOFLAGS := i < goflagsCount
 		switch {
 		case isAssigned && isLong(key):
 			flags.Long[key] = val
+			// Optional-value flags can be represented in either map. The last occurrence wins,
+			// preserving command-line precedence over GOFLAGS.
+			delete(flags.Short, key)
 
 		case isAssigned:
 			if isTestCommand {
 				flags.honorTestOnlyFlag(log, key)
+				if !fromGOFLAGS && !isKnownTestFlag(key, goVersion) {
+					// cmd/go treats an unknown command-line flag as the end of the package list,
+					// even when its value is assigned inline. Flags from GOFLAGS that are known
+					// to another go command are ignored instead.
+					positionalRunEnded = true
+				}
 			}
 			// Intentionally the un-normalized variant in Unknown flags.
 			flags.Unknown = append(flags.Unknown, arg)
@@ -261,6 +342,7 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 		case isOptionalValue(normArg):
 			// The bare form of these flags does not consume the argument that follows it.
 			flags.Short[normArg] = struct{}{}
+			delete(flags.Long, normArg)
 
 		case isLong(normArg) && hasNextArg:
 			flags.Long[normArg] = args[i+1]
@@ -277,12 +359,22 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 		default:
 			if isTestCommand {
 				flags.honorTestOnlyFlag(log, normArg)
+				if !fromGOFLAGS && !isKnownTestFlag(normArg, goVersion) {
+					// Unknown test-binary flags end the package list. Their possible value is
+					// consumed below, after which recognized go test flags may still follow.
+					positionalRunEnded = true
+				}
 			}
 			// Intentionally the un-normalized variant in Unknown flags.
 			flags.Unknown = append(flags.Unknown, arg)
 			// If this flag consumes the argument that follows it, that argument is its value, and not a
-			// positional argument.
-			if consumesValue(normArg, args[i+1:]) {
+			// positional argument. A GOFLAGS entry must not consume the first command-line argument:
+			// cmd/go considers each GOFLAGS token independently and ignores flags from another command.
+			rest := args[i+1:]
+			if fromGOFLAGS && len(rest) > goflagsCount-i-1 {
+				rest = rest[:goflagsCount-i-1]
+			}
+			if consumesValue(normArg, rest, goVersion) {
 				flags.Unknown = append(flags.Unknown, args[i+1])
 				i++
 			}
@@ -456,17 +548,46 @@ func impliesCover(str string) bool {
 }
 
 // isValueless returns true if the provided flag name (including its leading
-// hyphen, e.g: "-v") is known not to accept a value.
-func isValueless(str string) bool {
-	_, ok := valuelessFlags[canonicalTestFlag(str)]
+// hyphen, e.g: "-v") is known not to accept a value in the current Go version.
+func isValueless(str string, goVersion string) bool {
+	name := canonicalTestFlag(str)
+	if !testFlagSupported(name, goVersion) {
+		return false
+	}
+	_, ok := valuelessFlags[name]
 	return ok
+}
+
+// isKnownTestFlag returns true if the provided flag is recognized by `go test`
+// in the current Go version. Unlike unknown test-binary flags, recognized flags
+// do not prevent a package list from following them.
+func isKnownTestFlag(str string, goVersion string) bool {
+	name := canonicalTestFlag(str)
+	if !testFlagSupported(name, goVersion) {
+		return false
+	}
+	if _, ok := testValueFlags[name]; ok {
+		return true
+	}
+	return isLong(name) || isShort(name) || isOptionalValue(name) || isValueless(name, goVersion) || impliesCover(name)
+}
+
+// testFlagSupported returns whether a versioned test flag is available in the
+// designated Go toolchain. Development toolchains are assumed to support the
+// latest known flags.
+func testFlagSupported(name string, goVersion string) bool {
+	minimum, versioned := versionedTestFlags[canonicalTestFlag(name)]
+	if !versioned {
+		return true
+	}
+	return !version.IsValid(goVersion) || version.Compare(goVersion, minimum) >= 0
 }
 
 // consumesValue returns true if the provided flag, which Orchestrion does not
 // otherwise process, consumes the first of the arguments that follow it as its
 // value.
-func consumesValue(flag string, rest []string) bool {
-	return !isValueless(flag) && len(rest) > 0 && !strings.HasPrefix(rest[0], "-")
+func consumesValue(flag string, rest []string, goVersion string) bool {
+	return !isValueless(flag, goVersion) && len(rest) > 0 && !strings.HasPrefix(rest[0], "-")
 }
 
 // honorTestOnlyFlag records the side effects of `go test`-only flags that
@@ -488,12 +609,25 @@ func isOptionalValue(str string) bool {
 	return ok
 }
 
-// canonicalTestFlag removes the `test.` prefix from test flag names, as the Go
-// CLI accepts both the bare (e.g, `-v`) and prefixed (e.g, `-test.v`) forms of
-// all flags it forwards to the test binary.
+// canonicalTestFlag removes the `test.` prefix from test flag names when cmd/go
+// accepts that alias for a flag it forwards to the test binary.
 func canonicalTestFlag(str string) string {
-	if name, isPrefixed := strings.CutPrefix(str, "-test."); isPrefixed {
-		return "-" + name
+	name, isPrefixed := strings.CutPrefix(str, "-test.")
+	if !isPrefixed {
+		return str
+	}
+	name = "-" + name
+	if _, nonForwarded := nonForwardedTestFlags[name]; nonForwarded {
+		return str
+	}
+	if _, forwarded := valuelessFlags[name]; forwarded {
+		return name
+	}
+	if _, forwarded := testValueFlags[name]; forwarded {
+		return name
+	}
+	if _, forwarded := coverImplyingFlags[name]; forwarded {
+		return name
 	}
 	return str
 }

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -66,6 +66,42 @@ var (
 		"-tags":          {}, // Set build tags
 		"-toolexec":      {}, // Set the command to run around tool execution
 	}
+	// coverImplyingFlags are `go test`-only flags which are not build flags (and
+	// hence must not be forwarded to `go list` or child build commands, which do
+	// not accept them), but which implicitly enable coverage instrumentation,
+	// exactly as the `-cover` flag does. Child builds must apply the same coverage
+	// instrumentation as the parent command, as otherwise archives produced by
+	// child builds are not compatible with those produced by the parent command
+	// (the Go linker rejects them with a "fingerprint mismatch" error).
+	coverImplyingFlags = map[string]struct{}{
+		"-coverprofile": {}, // Write a coverage profile to the designated file
+	}
+	// optionalValueFlags are flags from [longFlags] which accept an optional value,
+	// meaning their bare form does not consume the argument that follows them (the
+	// value can only be provided using the `-flag=value` form).
+	optionalValueFlags = map[string]struct{}{
+		"-buildvcs": {}, // Whether to stamp binaries with version control information
+	}
+	// valuelessFlags are flags Orchestrion does not otherwise process (they are
+	// not build flags, and are consequently not forwarded to child commands), but
+	// which are known not to accept a value. Identifying those is necessary to
+	// correctly tell flags apart from positional arguments (package patterns), as
+	// a flag that accepts a value consumes the argument that follows it when it is
+	// provided in the `-flag value` form.
+	valuelessFlags = map[string]struct{}{
+		// `go test` flags
+		"-artifacts": {}, // Retain test artifacts
+		"-benchmem":  {}, // Print memory allocation statistics for benchmarks
+		"-c":         {}, // Compile the test binary but do not run it
+		"-failfast":  {}, // Do not start new tests after the first test failure
+		"-fullpath":  {}, // Show full file names in the error messages
+		"-json":      {}, // Convert test output to JSON
+		"-short":     {}, // Tell long-running tests to shorten their run time
+		"-v":         {}, // Verbose output
+		// Build flags that are irrelevant to (and must not be forwarded to) child builds
+		"-n": {}, // Print the commands but do not run them
+		"-x": {}, // Print the commands
+	}
 )
 
 // Get returns the value of the specified long-form flag if present. The name is
@@ -150,32 +186,57 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 		}
 	}
 
-	// The next argument after a `-C` (if present) would be the go command name ("run", "test", "list", etc...). This is
-	// not interesting for our purposes, so we skip it.
+	// The next argument after a `-C` (if present) is the go command name ("run", "test", "list", etc...).
+	var command string
 	if len(args) > 0 {
-		log.Trace().Str("command", args[0]).Msg("Go command from arguments")
+		command = args[0]
+		log.Trace().Str("command", command).Msg("Go command from arguments")
 		args = args[1:]
 	}
+	// Some arguments are only meaningful to `go test`. The Go CLI silently ignores flags from $GOFLAGS
+	// that the command at hand does not accept, and fails on unaccepted flags from the command line; so
+	// we must not honor test-only flags when running another command.
+	isTestCommand := command == "test"
 
 	// Compose the complete list of arguments: those from GOFLAGS, and the rest of the command line so far; in this order
 	// as the CLI arguments have precedence over those from GOFLAGS.
 	args = append(append(make([]string, 0, len(goflagsArgs)+len(args)), goflagsArgs...), args...)
 
-	var positional []string
+	var (
+		positional []string
+		// The Go CLI accepts package patterns as a single contiguous run of non-flag arguments: any
+		// non-flag argument that follows a flag once that run has ended is a flag value or an argument
+		// destined to the built program (see `cmd/go/internal/test.testFlags`), and must consequently not
+		// be mistaken for a package pattern.
+		positionalRunEnded bool
+	)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 
-		// Any argument after "--" is a positional argument, so we are done parsing.
+		// Any argument after "--" is a positional argument, so we are done parsing. If package patterns
+		// were already provided, the arguments that follow are destined to the built program instead.
+		// The `go test` command is special, as it never accepts package patterns after the "--" marker.
 		if arg == "--" {
-			positional = append(positional, args[i+1:]...)
+			if !isTestCommand && len(positional) == 0 {
+				positional = append(positional, args[i+1:]...)
+			}
+			break
+		}
+
+		// Every argument after "-args" is passed to the built test binary, so we are done parsing.
+		if isTestCommand && (arg == "-args" || arg == "--args") {
 			break
 		}
 
 		// Any argument without a leading "-" is a positional argument (until proven otherwise).
 		if !strings.HasPrefix(arg, "-") {
-			positional = append(positional, arg)
+			if !positionalRunEnded {
+				positional = append(positional, arg)
+			}
 			continue
 		}
+		// This argument is a flag, so any positional argument run has now ended.
+		positionalRunEnded = len(positional) > 0
 
 		normArg := arg
 		if strings.HasPrefix(arg, "--") {
@@ -184,24 +245,44 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 			normArg = arg[1:]
 		}
 
-		if key, val, isAssigned := strings.Cut(normArg, "="); isAssigned {
-			if isLong(key) {
-				flags.Long[key] = val
-			} else {
-				// Intentionally the un-normalized variant in Unknown flags.
-				flags.Unknown = append(flags.Unknown, arg)
+		key, val, isAssigned := strings.Cut(normArg, "=")
+		hasNextArg := i+1 < len(args)
+		switch {
+		case isAssigned && isLong(key):
+			flags.Long[key] = val
+
+		case isAssigned:
+			if isTestCommand {
+				flags.honorTestOnlyFlag(log, key)
 			}
-		} else if isLong(normArg) {
-			flags.Long[normArg] = args[i+1]
-			i++
-		} else if isShort(normArg) {
-			flags.Short[normArg] = struct{}{}
-		} else {
 			// Intentionally the un-normalized variant in Unknown flags.
 			flags.Unknown = append(flags.Unknown, arg)
-			// If there's more args, and the next one does not have a leading -, we'll assume this is the value of this
-			// unknown flag and consume it.
-			if len(args) > i+1 && !strings.HasPrefix(args[i+1], "-") {
+
+		case isOptionalValue(normArg):
+			// The bare form of these flags does not consume the argument that follows it.
+			flags.Short[normArg] = struct{}{}
+
+		case isLong(normArg) && hasNextArg:
+			flags.Long[normArg] = args[i+1]
+			i++
+
+		case isLong(normArg):
+			// The flag is missing its value; let the Go CLI report this error in its canonical way.
+			log.Trace().Str("flag", arg).Msg("Ignoring flag that is missing its value")
+			flags.Unknown = append(flags.Unknown, arg)
+
+		case isShort(normArg):
+			flags.Short[normArg] = struct{}{}
+
+		default:
+			if isTestCommand {
+				flags.honorTestOnlyFlag(log, normArg)
+			}
+			// Intentionally the un-normalized variant in Unknown flags.
+			flags.Unknown = append(flags.Unknown, arg)
+			// If this flag consumes the argument that follows it, that argument is its value, and not a
+			// positional argument.
+			if consumesValue(normArg, args[i+1:]) {
 				flags.Unknown = append(flags.Unknown, args[i+1])
 				i++
 			}
@@ -219,6 +300,8 @@ func ParseCommandFlags(ctx context.Context, wd string, args []string) (CommandFl
 // inferCoverpkg will add the necessary `-coverpkg` argument if the `-cover` flags is present and
 // `-coverpkg` is not, as otherwise, sub-commands triggered with these flags will not apply coverage
 // to the intended packages.
+// Coverage may have been enabled by way of `-cover`, `-covermode`, or one of the [coverImplyingFlags]
+// (in which case `-cover` was added to the parsed flags during parsing).
 // If `-coverpkg` is present, it will expand any relative paths (recognized by a `./` prefix) into
 // absolute package names, so that child builds do not interpret these relative to a different
 // package root.
@@ -363,6 +446,56 @@ func isLong(str string) bool {
 func isShort(str string) bool {
 	_, ok := shortFlags[str]
 	return ok
+}
+
+// impliesCover returns true if the provided flag name (including its leading
+// hyphen, e.g: "-coverprofile") implicitly enables coverage instrumentation.
+func impliesCover(str string) bool {
+	_, ok := coverImplyingFlags[canonicalTestFlag(str)]
+	return ok
+}
+
+// isValueless returns true if the provided flag name (including its leading
+// hyphen, e.g: "-v") is known not to accept a value.
+func isValueless(str string) bool {
+	_, ok := valuelessFlags[canonicalTestFlag(str)]
+	return ok
+}
+
+// consumesValue returns true if the provided flag, which Orchestrion does not
+// otherwise process, consumes the first of the arguments that follow it as its
+// value.
+func consumesValue(flag string, rest []string) bool {
+	return !isValueless(flag) && len(rest) > 0 && !strings.HasPrefix(rest[0], "-")
+}
+
+// honorTestOnlyFlag records the side effects of `go test`-only flags that
+// Orchestrion does not otherwise process; meaning those that implicitly enable
+// coverage instrumentation.
+func (f *CommandFlags) honorTestOnlyFlag(log *zerolog.Logger, flag string) {
+	if !impliesCover(flag) {
+		return
+	}
+	log.Trace().Str("flag", flag).Msg("Flag implies coverage instrumentation is enabled")
+	f.Short["-cover"] = struct{}{}
+}
+
+// isOptionalValue returns true if the provided flag name (including its leading
+// hyphen, e.g: "-buildvcs") accepts an optional value, meaning its bare form
+// does not consume the argument that follows it.
+func isOptionalValue(str string) bool {
+	_, ok := optionalValueFlags[str]
+	return ok
+}
+
+// canonicalTestFlag removes the `test.` prefix from test flag names, as the Go
+// CLI accepts both the bare (e.g, `-v`) and prefixed (e.g, `-test.v`) forms of
+// all flags it forwards to the test binary.
+func canonicalTestFlag(str string) string {
+	if name, isPrefixed := strings.CutPrefix(str, "-test."); isPrefixed {
+		return "-" + name
+	}
+	return str
 }
 
 // parentGoCommandFlags backtracks through the process tree

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go/build"
 	"go/version"
 	"io/fs"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -200,12 +202,53 @@ func (f CommandFlags) Except(remove ...string) CommandFlags {
 func (f CommandFlags) Slice() []string {
 	flags := make([]string, 0, len(f.Long)+len(f.Short))
 	for flag, val := range f.Long {
+		if flag == "-cover" {
+			continue
+		}
 		flags = append(flags, fmt.Sprintf("%s=%s", flag, val))
+	}
+	// Coverage options imply -cover when parsed, so an explicit false override
+	// must follow every assigned coverage option regardless of map iteration order.
+	if val, found := f.Long["-cover"]; found {
+		flags = append(flags, "-cover="+val)
 	}
 	for flag := range f.Short {
 		flags = append(flags, flag)
 	}
 	return flags
+}
+
+func (f *CommandFlags) setLong(flag string, value string) {
+	f.Long[flag] = value
+	delete(f.Short, flag)
+}
+
+func (f *CommandFlags) setShort(flag string) {
+	f.Short[flag] = struct{}{}
+	delete(f.Long, flag)
+}
+
+func (f *CommandFlags) setBoolean(flag string, value string) (bool, error) {
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		// Preserve the invalid value so cmd/go can report it canonically.
+		f.setLong(flag, value)
+		return false, err
+	}
+	if enabled {
+		f.setShort(flag)
+	} else {
+		f.setLong(flag, "false")
+	}
+	return enabled, nil
+}
+
+func (f *CommandFlags) enableCoverage() {
+	f.setShort("-cover")
+}
+
+func (f *CommandFlags) setAssignedCover(value string) {
+	_, _ = f.setBoolean("-cover", value)
 }
 
 // ParseCommandFlags parses a slice representing a go command invocation
@@ -293,6 +336,21 @@ func leadingChdirFlag(args []string) (dir string, remaining []string, found bool
 	return "", args, false
 }
 
+// runTarget returns the package portion of the arguments remaining after go
+// run's flag parser stops. A target is one package pattern or a contiguous list
+// of .go files; every subsequent argument is passed to the program.
+func runTarget(args []string) []string {
+	if len(args) == 0 || !strings.HasSuffix(args[0], ".go") {
+		return args[:min(len(args), 1)]
+	}
+	for i, arg := range args {
+		if !strings.HasSuffix(arg, ".go") {
+			return args[:i]
+		}
+	}
+	return args
+}
+
 func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion string) (CommandFlags, error) {
 	log := zerolog.Ctx(ctx)
 
@@ -342,7 +400,11 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 		// The `go test` command is special, as it never accepts package patterns after the "--" marker.
 		if arg == "--" {
 			if !isTestCommand && len(positional) == 0 {
-				positional = append(positional, args[i+1:]...)
+				rest := args[i+1:]
+				if command == "run" {
+					rest = runTarget(rest)
+				}
+				positional = append(positional, rest...)
 			}
 			break
 		}
@@ -359,8 +421,19 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 				// cmd/go consequently passes the entire remainder through without parsing more flags.
 				break
 			}
+			if command == "run" {
+				// `go run` accepts one package pattern or a contiguous list of .go files;
+				// everything after that package is passed to the program.
+				positional = append(positional, runTarget(args[i:])...)
+				break
+			}
 			positional = append(positional, arg)
 			continue
+		}
+		// Except for go test's custom parser, standard flag parsing stops at the
+		// first positional argument and leaves every subsequent token untouched.
+		if !isTestCommand && len(positional) > 0 {
+			break
 		}
 		// This argument is a flag, so any positional argument run has now ended.
 		if len(positional) > 0 {
@@ -377,12 +450,25 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 		key, val, isAssigned := strings.Cut(normArg, "=")
 		hasNextArg := i+1 < len(args)
 		fromGOFLAGS := i < goflagsCount
+		if fromGOFLAGS && isBuildCoverageFlag(key) && !commandSupportsCoverage(command) {
+			// cmd/go accepts coverage flags in GOFLAGS because some commands support them,
+			// but silently ignores them for commands without coverage build support.
+			flags.Unknown = append(flags.Unknown, arg)
+			continue
+		}
 		switch {
 		case isAssigned && isLong(key):
-			flags.Long[key] = val
-			// Optional-value flags can be represented in either map. The last occurrence wins,
-			// preserving command-line precedence over GOFLAGS.
-			delete(flags.Short, key)
+			flags.setLong(key, val)
+			if key == "-covermode" || key == "-coverpkg" {
+				flags.enableCoverage()
+			}
+
+		case isAssigned && isShort(key):
+			if key == "-cover" {
+				flags.setAssignedCover(val)
+			} else {
+				_, _ = flags.setBoolean(key, val)
+			}
 
 		case isAssigned:
 			if isTestCommand {
@@ -399,11 +485,13 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 
 		case isOptionalValue(normArg):
 			// The bare form of these flags does not consume the argument that follows it.
-			flags.Short[normArg] = struct{}{}
-			delete(flags.Long, normArg)
+			flags.setShort(normArg)
 
-		case isLong(normArg) && hasNextArg:
-			flags.Long[normArg] = args[i+1]
+		case isLong(normArg) && hasNextArg && !fromGOFLAGS:
+			flags.setLong(normArg, args[i+1])
+			if normArg == "-covermode" || normArg == "-coverpkg" {
+				flags.enableCoverage()
+			}
 			i++
 
 		case isLong(normArg):
@@ -412,7 +500,7 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 			flags.Unknown = append(flags.Unknown, arg)
 
 		case isShort(normArg):
-			flags.Short[normArg] = struct{}{}
+			flags.setShort(normArg)
 
 		default:
 			if isTestCommand {
@@ -439,7 +527,7 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 		}
 	}
 
-	if err := flags.inferCoverpkg(ctx, wd, positional); err != nil {
+	if err := flags.inferCoverpkg(ctx, wd, command, positional); err != nil {
 		return flags, err
 	}
 
@@ -455,8 +543,15 @@ func parseCommandFlags(ctx context.Context, wd string, args []string, goVersion 
 // If `-coverpkg` is present, it will expand any relative paths (recognized by a `./` prefix) into
 // absolute package names, so that child builds do not interpret these relative to a different
 // package root.
-func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalArgs []string) error {
+func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, command string, positionalArgs []string) error {
 	log := zerolog.Ctx(ctx)
+
+	if val, assigned := f.Long["-cover"]; assigned {
+		if enabled, err := strconv.ParseBool(val); err == nil && !enabled {
+			// A trailing explicit false overrides every earlier coverage-implying flag.
+			return nil
+		}
+	}
 
 	// Make sure we satisfy the same build constraints; but don't run -toolexec
 	childBuildFlags := append(f.Slice(), "-toolexec=")
@@ -532,6 +627,11 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalA
 	if !isCover {
 		return nil
 	}
+	if command == "run" && usesOutsideModuleMode(positionalArgs) {
+		// cmd/go resolves path@version run targets outside the current module and
+		// leaves -coverpkg unset. packages.Load cannot resolve this syntax.
+		return nil
+	}
 
 	pkgs, err := packages.Load(
 		&packages.Config{
@@ -555,6 +655,17 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, positionalA
 	f.Long["-coverpkg"] = val
 
 	return nil
+}
+
+// usesOutsideModuleMode reports whether go run resolves its target outside the
+// current module, mirroring cmd/go/internal/run.shouldUseOutsideModuleMode.
+func usesOutsideModuleMode(args []string) bool {
+	return len(args) > 0 &&
+		!strings.HasSuffix(args[0], ".go") &&
+		!strings.HasPrefix(args[0], "-") &&
+		strings.Contains(args[0], "@") &&
+		!build.IsLocalImport(args[0]) &&
+		!filepath.IsAbs(args[0])
 }
 
 // Flags return the top level go command flags
@@ -600,6 +711,19 @@ func isShort(str string) bool {
 	return ok
 }
 
+func isBuildCoverageFlag(flag string) bool {
+	return flag == "-cover" || flag == "-covermode" || flag == "-coverpkg"
+}
+
+func commandSupportsCoverage(command string) bool {
+	switch command {
+	case "build", "install", "list", "run", "test":
+		return true
+	default:
+		return false
+	}
+}
+
 // impliesCover returns true if the provided flag name (including its leading
 // hyphen, e.g: "-coverprofile") implicitly enables coverage instrumentation.
 func impliesCover(str string) bool {
@@ -622,14 +746,31 @@ func isValueless(str string, goVersion string) bool {
 // in the current Go version. Unlike unknown test-binary flags, recognized flags
 // do not prevent a package list from following them.
 func isKnownTestFlag(str string, goVersion string) bool {
+	known, _ := testFlagTakesValue(str, goVersion)
+	return known
+}
+
+// testFlagTakesValue reports whether a flag is recognized by `go test` in the
+// designated Go version and, if so, whether its bare form consumes the next
+// argument regardless of whether that value begins with a hyphen.
+func testFlagTakesValue(str string, goVersion string) (known bool, takesValue bool) {
 	name := canonicalTestFlag(str)
 	if !testFlagSupported(name, goVersion) {
-		return false
+		return false, false
+	}
+	if isOptionalValue(name) || isShort(name) || isValueless(name, goVersion) {
+		return true, false
+	}
+	if isLong(name) {
+		return true, true
 	}
 	if _, ok := testValueFlags[name]; ok {
-		return true
+		return true, true
 	}
-	return isLong(name) || isShort(name) || isOptionalValue(name) || isValueless(name, goVersion) || impliesCover(name)
+	if impliesCover(name) {
+		return true, true
+	}
+	return false, false
 }
 
 // testFlagSupported returns whether a versioned test flag is available in the
@@ -647,7 +788,16 @@ func testFlagSupported(name string, goVersion string) bool {
 // otherwise process, consumes the first of the arguments that follow it as its
 // value.
 func consumesValue(flag string, rest []string, goVersion string) bool {
-	return !isValueless(flag, goVersion) && len(rest) > 0 && !strings.HasPrefix(rest[0], "-")
+	if len(rest) == 0 {
+		return false
+	}
+	if known, takesValue := testFlagTakesValue(flag, goVersion); known {
+		return takesValue
+	}
+	// cmd/go cannot know an unknown test-binary flag's arity. It optimistically
+	// treats the next non-flag argument as its value, but parses a hyphen-prefixed
+	// argument as another flag.
+	return !strings.HasPrefix(rest[0], "-")
 }
 
 // honorTestOnlyFlag records the side effects of `go test`-only flags that
@@ -658,7 +808,7 @@ func (f *CommandFlags) honorTestOnlyFlag(log *zerolog.Logger, flag string) {
 		return
 	}
 	log.Trace().Str("flag", flag).Msg("Flag implies coverage instrumentation is enabled")
-	f.Short["-cover"] = struct{}{}
+	f.enableCoverage()
 }
 
 // isOptionalValue returns true if the provided flag name (including its leading

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DataDog/orchestrion/internal/goenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,6 +51,9 @@ func TestTrim(t *testing.T) {
 func TestParse(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	thisDir := filepath.Dir(thisFile)
+
+	goVersion, err := goenv.GOVERSION(thisDir)
+	require.NoError(t, err)
 
 	for name, tc := range map[string]struct {
 		flags    []string
@@ -174,6 +178,37 @@ func TestParse(t *testing.T) {
 			},
 			useStdFlags: true,
 		},
+		"unknown-assigned-flag-ends-package-list": {
+			// cmd/go treats an unknown assigned flag as the start of test-binary arguments, so the
+			// package-like argument that follows is not a package pattern.
+			flags: []string{"test", "-coverprofile=coverage.out", "-custom=value", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-custom=value"},
+			},
+			useStdFlags: true,
+		},
+		"assigned-known-test-flag-keeps-positional": {
+			flags: []string{"test", "-coverprofile=coverage.out", "-run=TestFoo", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-run=TestFoo"},
+			},
+			useStdFlags: true,
+		},
+		"test-prefix-does-not-apply-to-command-flags": {
+			// cmd/go only accepts the `test.` prefix for flags forwarded to the test binary.
+			// `-test.tags` is therefore unknown and ends the package list.
+			flags: []string{"test", "-coverprofile=coverage.out", "-test.tags=value", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-test.tags=value"},
+			},
+			useStdFlags: true,
+		},
 		"value-accepting-unknown-flag-consumes-value": {
 			// `-run` accepts a value, so `TestFoo` is not a positional argument.
 			flags: []string{"test", "-cover", "-run", "TestFoo", "./quoted"},
@@ -195,6 +230,15 @@ func TestParse(t *testing.T) {
 			},
 			useStdFlags: true,
 		},
+		"literal-test-argument-terminates-parsing": {
+			// A literal argument after the package list has ended causes cmd/go to pass the entire
+			// remainder to the test binary, including flags it would otherwise recognize.
+			flags: []string{"test", "./quoted", "-v", "custom", "-coverprofile=coverage.out"},
+			expected: CommandFlags{
+				Unknown: []string{"-v"},
+			},
+			useStdFlags: true,
+		},
 		"coverprofile-is-ignored-outside-go-test": {
 			// The Go CLI silently ignores flags from $GOFLAGS that the command at hand does not accept, so
 			// `go build` does not enable coverage here; and neither must child builds.
@@ -202,6 +246,18 @@ func TestParse(t *testing.T) {
 			goflags: "-coverprofile=coverage.out",
 			expected: CommandFlags{
 				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"goflags-entry-does-not-consume-command-line-package": {
+			// `-run` is valid in GOFLAGS because another go command accepts it, but `go build` ignores it.
+			// Its missing value must therefore not consume the first command-line package pattern.
+			flags:   []string{"build", "./quoted"},
+			goflags: "-cover -run",
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-run"},
 			},
 			useStdFlags: true,
 		},
@@ -244,6 +300,27 @@ func TestParse(t *testing.T) {
 					"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted",
 				},
 				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"assigned-buildvcs-overrides-bare-goflags": {
+			flags:   []string{"test", "-cover", "-buildvcs=false", "./quoted"},
+			goflags: "-buildvcs",
+			expected: CommandFlags{
+				Long: map[string]string{
+					"-buildvcs": "false",
+					"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted",
+				},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"bare-buildvcs-overrides-assigned-goflags": {
+			flags:   []string{"test", "-cover", "-buildvcs", "./quoted"},
+			goflags: "-buildvcs=false",
+			expected: CommandFlags{
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short: map[string]struct{}{"-cover": {}, "-buildvcs": {}},
 			},
 			useStdFlags: true,
 		},
@@ -313,10 +390,111 @@ func TestParse(t *testing.T) {
 			for _, flag := range flags.Slice() {
 				name, _, _ := strings.Cut(flag, "=")
 				assert.False(t, impliesCover(name), "flag %q must not be forwarded to child commands", flag)
-				assert.False(t, isValueless(name), "flag %q must not be forwarded to child commands", flag)
+				assert.False(t, isValueless(name, goVersion), "flag %q must not be forwarded to child commands", flag)
 			}
 		})
 	}
+}
+
+func TestParseArtifactsByGoVersion(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	thisDir := filepath.Dir(thisFile)
+	t.Setenv("GOFLAGS", "")
+
+	for name, tc := range map[string]struct {
+		goVersion string
+		expected  CommandFlags
+	}{
+		"go1.25": {
+			goVersion: "go1.25.0",
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-artifacts", "./quoted"},
+			},
+		},
+		"go1.26": {
+			goVersion: "go1.26.0",
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-artifacts"},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			flags, err := parseCommandFlags(
+				context.Background(),
+				thisDir,
+				[]string{"test", "-coverprofile=coverage.out", "-artifacts", "./quoted"},
+				tc.goVersion,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, flags)
+		})
+	}
+}
+
+func TestTestFlagSupported(t *testing.T) {
+	for name, tc := range map[string]struct {
+		goVersion string
+		expected  bool
+	}{
+		"go1.25":              {goVersion: "go1.25.0"},
+		"go1.25 experiment":   {goVersion: "go1.25.0-X:jsonv2"},
+		"go1.26 release":      {goVersion: "go1.26.0", expected: true},
+		"go1.26 candidate":    {goVersion: "go1.26rc1", expected: true},
+		"development version": {goVersion: "devel go1.27-abcdef", expected: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, testFlagSupported("-artifacts", tc.goVersion))
+		})
+	}
+}
+
+func TestCanonicalTestFlag(t *testing.T) {
+	expected := map[string]struct{}{
+		"-artifacts":            {},
+		"-bench":                {},
+		"-benchmem":             {},
+		"-benchtime":            {},
+		"-blockprofile":         {},
+		"-blockprofilerate":     {},
+		"-count":                {},
+		"-coverprofile":         {},
+		"-cpu":                  {},
+		"-cpuprofile":           {},
+		"-failfast":             {},
+		"-fullpath":             {},
+		"-fuzz":                 {},
+		"-fuzzminimizetime":     {},
+		"-fuzztime":             {},
+		"-list":                 {},
+		"-memprofile":           {},
+		"-memprofilerate":       {},
+		"-mutexprofile":         {},
+		"-mutexprofilefraction": {},
+		"-outputdir":            {},
+		"-parallel":             {},
+		"-run":                  {},
+		"-short":                {},
+		"-shuffle":              {},
+		"-skip":                 {},
+		"-timeout":              {},
+		"-trace":                {},
+		"-v":                    {},
+	}
+
+	actual := make(map[string]struct{}, len(expected))
+	for _, flags := range []map[string]struct{}{valuelessFlags, testValueFlags, coverImplyingFlags} {
+		for name := range flags {
+			prefixed := "-test." + strings.TrimPrefix(name, "-")
+			if canonicalTestFlag(prefixed) == name {
+				actual[name] = struct{}{}
+			}
+		}
+	}
+	assert.Equal(t, expected, actual)
 }
 
 func restore(short map[string]struct{}, long map[string]struct{}) {

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -46,6 +47,22 @@ func TestTrim(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSlicePlacesCoverFalseAfterOptions(t *testing.T) {
+	flags := CommandFlags{
+		Long: map[string]string{
+			"-cover":     "false",
+			"-covermode": "atomic",
+			"-coverpkg":  "./...",
+		},
+	}
+
+	result := flags.Slice()
+	coverFalse := slices.Index(result, "-cover=false")
+	require.NotEqual(t, -1, coverFalse)
+	assert.Less(t, slices.Index(result, "-covermode=atomic"), coverFalse)
+	assert.Less(t, slices.Index(result, "-coverpkg=./..."), coverFalse)
 }
 
 func TestParse(t *testing.T) {
@@ -109,7 +126,7 @@ func TestParse(t *testing.T) {
 			flags: []string{"run", "-covermode=count"},
 			expected: CommandFlags{
 				Long:  map[string]string{"-covermode": "count", "-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
-				Short: nil,
+				Short: map[string]struct{}{"-cover": {}},
 			},
 		},
 		"cover-with-coverpkg": {
@@ -178,6 +195,64 @@ func TestParse(t *testing.T) {
 			},
 			useStdFlags: true,
 		},
+		"assigned-cover-true": {
+			flags: []string{"test", "-cover=true", "./quoted"},
+			expected: CommandFlags{
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"covermode-then-cover-false": {
+			flags: []string{"test", "-covermode=atomic", "-cover=false", "./quoted"},
+			expected: CommandFlags{
+				Long: map[string]string{"-cover": "false", "-covermode": "atomic"},
+			},
+			useStdFlags: true,
+		},
+		"cover-false-then-covermode": {
+			flags: []string{"test", "-cover=false", "-covermode=atomic", "./quoted"},
+			expected: CommandFlags{
+				Long: map[string]string{
+					"-covermode": "atomic",
+					"-coverpkg":  "github.com/DataDog/orchestrion/internal/goflags/quoted",
+				},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"coverprofile-then-cover-false": {
+			flags: []string{"test", "-coverprofile=coverage.out", "-cover=false", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-cover": "false"},
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"cover-false-then-coverprofile": {
+			flags: []string{"test", "-cover=false", "-coverprofile=coverage.out", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"coverpkg-then-cover-false": {
+			flags: []string{"test", "-coverpkg=./quoted", "-cover=false", "."},
+			expected: CommandFlags{
+				Long: map[string]string{"-cover": "false", "-coverpkg": "./quoted"},
+			},
+			useStdFlags: true,
+		},
+		"cover-false-then-coverpkg": {
+			flags: []string{"test", "-cover=false", "-coverpkg=./quoted", "."},
+			expected: CommandFlags{
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
 		"valueless-unknown-flag-keeps-positional": {
 			// `-v` accepts no value, so `./quoted` is a positional argument (and hence, the only package
 			// coverage must be applied to).
@@ -220,13 +295,64 @@ func TestParse(t *testing.T) {
 			},
 			useStdFlags: true,
 		},
-		"value-accepting-unknown-flag-consumes-value": {
+		"value-accepting-test-flag-consumes-value": {
 			// `-run` accepts a value, so `TestFoo` is not a positional argument.
 			flags: []string{"test", "-cover", "-run", "TestFoo", "./quoted"},
 			expected: CommandFlags{
 				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
 				Short:   map[string]struct{}{"-cover": {}},
 				Unknown: []string{"-run", "TestFoo"},
+			},
+			useStdFlags: true,
+		},
+		"test-flag-consumes-dash-prefixed-value": {
+			// Registered non-boolean flags consume the next argument even when it begins with a hyphen.
+			flags: []string{"test", "-coverprofile=coverage.out", "-run", "-TestFoo", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-run", "-TestFoo"},
+			},
+			useStdFlags: true,
+		},
+		"dash-prefixed-value-is-not-another-build-flag": {
+			flags: []string{"test", "-coverprofile=coverage.out", "-run", "-race", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-run", "-race"},
+			},
+			useStdFlags: true,
+		},
+		"assigned-boolean-build-flag": {
+			flags: []string{"test", "-coverprofile=coverage.out", "-race=true", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}, "-race": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"assigned-boolean-overrides-goflags": {
+			flags:   []string{"test", "-coverprofile=coverage.out", "-race=false", "./quoted"},
+			goflags: "-race",
+			expected: CommandFlags{
+				Long: map[string]string{
+					"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted",
+					"-race":     "false",
+				},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"bare-boolean-overrides-assigned-goflags": {
+			flags:   []string{"test", "-coverprofile=coverage.out", "-race", "./quoted"},
+			goflags: "-race=false",
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}, "-race": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
 			},
 			useStdFlags: true,
 		},
@@ -250,6 +376,37 @@ func TestParse(t *testing.T) {
 			},
 			useStdFlags: true,
 		},
+		"non-test-command-stops-parsing-after-package": {
+			flags: []string{"run", "-cover", "./quoted", "-race"},
+			expected: CommandFlags{
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"go-run-program-argument-is-not-a-package": {
+			flags: []string{"run", "-cover", "./quoted", "argument", "-race"},
+			expected: CommandFlags{
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"go-run-terminator-preserves-program-arguments": {
+			flags: []string{"run", "-cover", "--", "./quoted", "argument"},
+			expected: CommandFlags{
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"go-run-versioned-package-skips-coverpkg-inference": {
+			flags: []string{"run", "-cover", "example.com/tool@latest"},
+			expected: CommandFlags{
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
 		"coverprofile-is-ignored-outside-go-test": {
 			// The Go CLI silently ignores flags from $GOFLAGS that the command at hand does not accept, so
 			// `go build` does not enable coverage here; and neither must child builds.
@@ -269,6 +426,14 @@ func TestParse(t *testing.T) {
 				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
 				Short:   map[string]struct{}{"-cover": {}},
 				Unknown: []string{"-run"},
+			},
+			useStdFlags: true,
+		},
+		"unsupported-command-ignores-cover-goflags": {
+			flags:   []string{"vet", "./quoted"},
+			goflags: "-cover -covermode=atomic -coverpkg=./...",
+			expected: CommandFlags{
+				Unknown: []string{"-cover", "-covermode=atomic", "-coverpkg=./..."},
 			},
 			useStdFlags: true,
 		},
@@ -403,6 +568,50 @@ func TestParse(t *testing.T) {
 				assert.False(t, impliesCover(name), "flag %q must not be forwarded to child commands", flag)
 				assert.False(t, isValueless(name, goVersion), "flag %q must not be forwarded to child commands", flag)
 			}
+		})
+	}
+}
+
+func TestRunTarget(t *testing.T) {
+	for name, tc := range map[string]struct {
+		args     []string
+		expected []string
+	}{
+		"empty": {},
+		"package": {
+			args:     []string{"./cmd", "argument", "-flag"},
+			expected: []string{"./cmd"},
+		},
+		"go files": {
+			args:     []string{"main.go", "extra.go", "argument", "-flag"},
+			expected: []string{"main.go", "extra.go"},
+		},
+		"go files only": {
+			args:     []string{"main.go", "extra.go"},
+			expected: []string{"main.go", "extra.go"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, runTarget(tc.args))
+		})
+	}
+}
+
+func TestUsesOutsideModuleMode(t *testing.T) {
+	for name, tc := range map[string]struct {
+		args     []string
+		expected bool
+	}{
+		"versioned package": {args: []string{"example.com/tool@latest"}, expected: true},
+		"local import":      {args: []string{"./tool@latest"}},
+		"absolute path":     {args: []string{filepath.Join(t.TempDir(), "tool@latest")}},
+		"go file":           {args: []string{"tool@latest.go"}},
+		"unversioned":       {args: []string{"example.com/tool"}},
+		"flag":              {args: []string{"-tool@latest"}},
+		"empty":             {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, usesOutsideModuleMode(tc.args))
 		})
 	}
 }
@@ -551,6 +760,36 @@ func TestTestFlagSupported(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, testFlagSupported("-artifacts", tc.goVersion))
 		})
+	}
+}
+
+func TestTestFlagArity(t *testing.T) {
+	const goVersion = "go1.26.0"
+
+	for name := range longFlags {
+		known, takesValue := testFlagTakesValue(name, goVersion)
+		assert.True(t, known, "%s must be recognized", name)
+		assert.Equal(t, !isOptionalValue(name), takesValue, "%s has incorrect arity", name)
+	}
+	for name := range shortFlags {
+		known, takesValue := testFlagTakesValue(name, goVersion)
+		assert.True(t, known, "%s must be recognized", name)
+		assert.False(t, takesValue, "%s must not consume a value", name)
+	}
+	for name := range valuelessFlags {
+		known, takesValue := testFlagTakesValue(name, goVersion)
+		assert.True(t, known, "%s must be recognized", name)
+		assert.False(t, takesValue, "%s must not consume a value", name)
+	}
+	for name := range testValueFlags {
+		known, takesValue := testFlagTakesValue(name, goVersion)
+		assert.True(t, known, "%s must be recognized", name)
+		assert.True(t, takesValue, "%s must consume a value", name)
+	}
+	for name := range coverImplyingFlags {
+		known, takesValue := testFlagTakesValue(name, goVersion)
+		assert.True(t, known, "%s must be recognized", name)
+		assert.True(t, takesValue, "%s must consume a value", name)
 	}
 }
 

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -139,6 +140,124 @@ func TestParse(t *testing.T) {
 				Short: map[string]struct{}{"-cover": {}},
 			},
 		},
+		"coverprofile-implies-cover": {
+			// `-coverprofile` is not a build flag (it must not be forwarded to child builds), but it implies
+			// coverage instrumentation is enabled, so child builds must apply it to the same packages.
+			flags: []string{"test", "-coverprofile=coverage.out", "./..."},
+			expected: CommandFlags{
+				Long: map[string]string{
+					"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags,github.com/DataDog/orchestrion/internal/goflags/quoted",
+				},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"test-coverprofile-implies-cover": {
+			// The Go CLI accepts test flags with a `test.` prefix, too.
+			flags: []string{"test", "-test.coverprofile", "coverage.out", "."},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-test.coverprofile", "coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"valueless-unknown-flag-keeps-positional": {
+			// `-v` accepts no value, so `./quoted` is a positional argument (and hence, the only package
+			// coverage must be applied to).
+			flags: []string{"test", "-coverprofile=coverage.out", "-v", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-v"},
+			},
+			useStdFlags: true,
+		},
+		"value-accepting-unknown-flag-consumes-value": {
+			// `-run` accepts a value, so `TestFoo` is not a positional argument.
+			flags: []string{"test", "-cover", "-run", "TestFoo", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-run", "TestFoo"},
+			},
+			useStdFlags: true,
+		},
+		"package-patterns-are-a-contiguous-run": {
+			// The Go CLI stops accepting package patterns once a flag follows them, so `./quoted` is an
+			// argument destined to the test binary here, and not a package pattern.
+			flags: []string{"test", "-coverprofile=coverage.out", ".", "-v", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out", "-v"},
+			},
+			useStdFlags: true,
+		},
+		"coverprofile-is-ignored-outside-go-test": {
+			// The Go CLI silently ignores flags from $GOFLAGS that the command at hand does not accept, so
+			// `go build` does not enable coverage here; and neither must child builds.
+			flags:   []string{"build", "./quoted"},
+			goflags: "-coverprofile=coverage.out",
+			expected: CommandFlags{
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"go-test-ignores-patterns-after-terminator": {
+			// `go test` never accepts package patterns after the "--" marker; everything that follows is
+			// destined to the test binary, and coverage hence applies to the working directory's package.
+			flags: []string{"test", "-coverprofile=coverage.out", "--", "./quoted"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
+		},
+		"args-terminates-parsing": {
+			// Everything after `-args` is destined to the test binary.
+			flags: []string{"test", "-cover", "-args", "./quoted", "-some-flag"},
+			expected: CommandFlags{
+				// No package pattern was provided, so coverage applies to the package in the working directory.
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"bare-buildvcs-accepts-no-value": {
+			// `-buildvcs` accepts an optional value, so `./quoted` is a package pattern, and not the flag's
+			// value.
+			flags: []string{"test", "-cover", "-buildvcs", "./quoted"},
+			expected: CommandFlags{
+				Long:  map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short: map[string]struct{}{"-cover": {}, "-buildvcs": {}},
+			},
+			useStdFlags: true,
+		},
+		"assigned-buildvcs-keeps-its-value": {
+			flags: []string{"test", "-cover", "-buildvcs=false", "./quoted"},
+			expected: CommandFlags{
+				Long: map[string]string{
+					"-buildvcs": "false",
+					"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted",
+				},
+				Short: map[string]struct{}{"-cover": {}},
+			},
+			useStdFlags: true,
+		},
+		"trailing-flag-without-value": {
+			// A value-accepting flag with no value is invalid; the Go CLI reports the error in its canonical
+			// way, and we must not panic trying to read the missing value.
+			flags: []string{"test", "-cover", "./quoted", "-tags"},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-tags"},
+			},
+			useStdFlags: true,
+		},
 		"coverpkg-relative-with-goflags": {
 			flags:   []string{"test", "./...", "-timeout", "30m", "-cover", "-covermode=atomic", "-coverprofile=coverage.out", "-coverpkg", "./..."},
 			goflags: `"-toolexec=orchestrion toolexec"`,
@@ -185,6 +304,17 @@ func TestParse(t *testing.T) {
 				flags.Long = make(map[string]string)
 			}
 			assert.True(t, reflect.DeepEqual(tc.expected.Long, flags.Long), "expected:\n%#v\nactual:\n%#v", tc.expected.Long, flags.Long)
+
+			if tc.expected.Unknown != nil {
+				assert.Equal(t, tc.expected.Unknown, flags.Unknown)
+			}
+
+			// Flags that are not build flags must never be forwarded to child commands.
+			for _, flag := range flags.Slice() {
+				name, _, _ := strings.Cut(flag, "=")
+				assert.False(t, impliesCover(name), "flag %q must not be forwarded to child commands", flag)
+				assert.False(t, isValueless(name), "flag %q must not be forwarded to child commands", flag)
+			}
 		})
 	}
 }

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -120,21 +120,32 @@ func TestParse(t *testing.T) {
 				Short: map[string]struct{}{"-cover": {}},
 			},
 		},
-		"cover-dash-c": {
-			flags: []string{"-C", "..", "run", "-cover", "-covermode=atomic"},
+		"cover-dash-c-after-command": {
+			flags: []string{"test", "-C", "quoted", "-coverprofile=coverage.out", "."},
 			expected: CommandFlags{
-				// Note - the "-C" flags has no effect at this stage, so it's expected coverpkg is this package.
-				Long:  map[string]string{"-covermode": "atomic", "-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
-				Short: map[string]struct{}{"-cover": {}},
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
 			},
+			useStdFlags: true,
 		},
-		"cover-dash-c-alt": {
-			flags: []string{"-C=..", "run", "-cover", "-covermode=atomic", "."},
+		"cover-dash-c-assigned": {
+			flags: []string{"-C=quoted", "test", "-coverprofile=coverage.out", "."},
 			expected: CommandFlags{
-				// Note - the "-C" flags has no effect at this stage, so it's expected coverpkg is this package.
-				Long:  map[string]string{"-covermode": "atomic", "-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
-				Short: map[string]struct{}{"-cover": {}},
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
 			},
+			useStdFlags: true,
+		},
+		"cover-double-dash-c-assigned": {
+			flags: []string{"--C=quoted", "test", "-coverprofile=coverage.out", "."},
+			expected: CommandFlags{
+				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:   map[string]struct{}{"-cover": {}},
+				Unknown: []string{"-coverprofile=coverage.out"},
+			},
+			useStdFlags: true,
 		},
 		"goflags": {
 			flags:   []string{"run", "."},
@@ -392,6 +403,97 @@ func TestParse(t *testing.T) {
 				assert.False(t, impliesCover(name), "flag %q must not be forwarded to child commands", flag)
 				assert.False(t, isValueless(name, goVersion), "flag %q must not be forwarded to child commands", flag)
 			}
+		})
+	}
+}
+
+func TestResolveLeadingChdir(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	thisDir := filepath.Dir(thisFile)
+	t.Chdir(thisDir)
+	quotedDir := filepath.Join(thisDir, "quoted")
+
+	for name, tc := range map[string]struct {
+		wd               string
+		args             []string
+		expectedDir      string
+		expectedArgs     []string
+		expectedToChange bool
+	}{
+		"before command": {
+			wd:               thisDir,
+			args:             []string{"-C", "quoted", "test", "./..."},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"test", "./..."},
+			expectedToChange: true,
+		},
+		"after command": {
+			wd:               thisDir,
+			args:             []string{"test", "--C", "quoted", "./..."},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"test", "./..."},
+			expectedToChange: true,
+		},
+		"single-dash assigned": {
+			wd:               thisDir,
+			args:             []string{"-C=quoted", "test"},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"test"},
+			expectedToChange: true,
+		},
+		"double-dash assigned": {
+			wd:               thisDir,
+			args:             []string{"--C=quoted", "test"},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"test"},
+			expectedToChange: true,
+		},
+		"after command group": {
+			wd:               thisDir,
+			args:             []string{"mod", "-C", "quoted", "tidy"},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"mod", "tidy"},
+			expectedToChange: true,
+		},
+		"after grouped subcommand": {
+			wd:               thisDir,
+			args:             []string{"mod", "tidy", "-C=quoted"},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"mod", "tidy"},
+			expectedToChange: true,
+		},
+		"blank working directory": {
+			args:             []string{"-C", "quoted", "test"},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"test"},
+			expectedToChange: true,
+		},
+		"absolute directory": {
+			wd:               filepath.Dir(thisDir),
+			args:             []string{"test", "-C=" + quotedDir},
+			expectedDir:      quotedDir,
+			expectedArgs:     []string{"test"},
+			expectedToChange: true,
+		},
+		"missing value": {
+			wd:           thisDir,
+			args:         []string{"test", "-C"},
+			expectedDir:  thisDir,
+			expectedArgs: []string{"test", "-C"},
+		},
+		"after positional argument": {
+			wd:           thisDir,
+			args:         []string{"test", "./...", "-C", "quoted"},
+			expectedDir:  thisDir,
+			expectedArgs: []string{"test", "./...", "-C", "quoted"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir, args, changed, err := resolveLeadingChdir(tc.wd, tc.args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDir, dir)
+			assert.Equal(t, tc.expectedArgs, args)
+			assert.Equal(t, tc.expectedToChange, changed)
 		})
 	}
 }

--- a/internal/toolexec/aspect/oncompile-main.go
+++ b/internal/toolexec/aspect/oncompile-main.go
@@ -17,7 +17,6 @@ import (
 	"slices"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
@@ -48,12 +47,12 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 	if cmd.Flags.Package != "main" {
 		return nil
 	}
-	if pkgs.ResolvingTestVariants() && cmd.Flags.Package == "main" && strings.HasSuffix(w.ImportPath, ".test") {
+	if pkgs.ResolvingTestVariants() && cmd.Flags.Package == "main" && w.isTestMain() {
 		// The nested test main only exists to make cmd/go build affected variants.
 		// Its source may come from the build cache without the _testmain.go filename.
 		return nil
 	}
-	isTestMain := cmd.TestMain() && strings.HasSuffix(w.ImportPath, ".test")
+	isTestMain := cmd.TestMain() && w.isTestMain()
 
 	span, ctx := tracer.StartSpanFromContext(ctx, "Weaver.OnCompileMain",
 		tracer.ResourceName(w.ImportPath),
@@ -70,7 +69,7 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 
 	testVariantFor := ""
 	if isTestMain {
-		testVariantFor = strings.TrimSuffix(w.ImportPath, ".test")
+		testVariantFor = w.packageUnderTest()
 		cmd.MarkTestMain(testVariantFor)
 	}
 

--- a/internal/toolexec/aspect/oncompile-main.go
+++ b/internal/toolexec/aspect/oncompile-main.go
@@ -52,14 +52,23 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 		// Its source may come from the build cache without the _testmain.go filename.
 		return nil
 	}
+	// Both signals are required: cmd.TestMain validates the generated source,
+	// while w.isTestMain validates a variant-free ".test" identity; package
+	// names may themselves end in ".test".
 	isTestMain := cmd.TestMain() && w.isTestMain()
 
-	span, ctx := tracer.StartSpanFromContext(ctx, "Weaver.OnCompileMain",
-		tracer.ResourceName(w.ImportPath),
-	)
+	spanOptions := []tracer.StartSpanOption{tracer.ResourceName(w.ImportPath)}
+	if w.Variant != "" {
+		spanOptions = append(spanOptions, tracer.Tag("variant", w.Variant))
+	}
+	span, ctx := tracer.StartSpanFromContext(ctx, "Weaver.OnCompileMain", spanOptions...)
 	defer func() { span.Finish(tracer.WithError(err)) }()
 
-	log := zerolog.Ctx(ctx).With().Str("phase", "compile(main)").Logger()
+	logContext := zerolog.Ctx(ctx).With().Str("phase", "compile(main)")
+	if w.Variant != "" {
+		logContext = logContext.Str("variant", w.Variant)
+	}
+	log := logContext.Logger()
 	ctx = log.WithContext(ctx)
 
 	reg, err := importcfg.ParseFile(ctx, cmd.Flags.ImportCfg)

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -38,12 +38,20 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resEr
 		return nil
 	}
 
-	span, ctx := tracer.StartSpanFromContext(ctx, "Weaver.OnCompile",
-		tracer.ResourceName(w.ImportPath),
-	)
+	spanOptions := []tracer.StartSpanOption{tracer.ResourceName(w.ImportPath)}
+	if w.Variant != "" {
+		spanOptions = append(spanOptions, tracer.Tag("variant", w.Variant))
+	}
+	span, ctx := tracer.StartSpanFromContext(ctx, "Weaver.OnCompile", spanOptions...)
 	defer func() { span.Finish(tracer.WithError(resErr)) }()
 
-	log := zerolog.Ctx(ctx).With().Str("phase", "compile").Str("import-path", w.ImportPath).Logger()
+	logContext := zerolog.Ctx(ctx).With().
+		Str("phase", "compile").
+		Str("import-path", w.ImportPath)
+	if w.Variant != "" {
+		logContext = logContext.Str("variant", w.Variant)
+	}
+	log := logContext.Logger()
 	ctx = log.WithContext(ctx)
 
 	imports, err := importcfg.ParseFile(ctx, cmd.Flags.ImportCfg)
@@ -96,9 +104,12 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resEr
 		RootConfig: map[string]string{"httpmode": "wrap"},
 		Lookup:     imports.Lookup,
 		ImportPath: w.ImportPath,
-		TestMain:   cmd.TestMain() && w.isTestMain(),
-		ImportMap:  imports.PackageFile,
-		GoVersion:  cmd.Flags.Lang,
+		// Both signals are required: cmd.TestMain validates the generated source,
+		// while w.isTestMain validates a variant-free ".test" identity; package
+		// names may themselves end in ".test".
+		TestMain:  cmd.TestMain() && w.isTestMain(),
+		ImportMap: imports.PackageFile,
+		GoVersion: cmd.Flags.Lang,
 		ModifiedFile: func(file string) string {
 			return filepath.Join(filepath.Dir(cmd.Flags.Output), OrchestrionDirPathElement, cmd.Flags.Package, filepath.Base(file))
 		},

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/orchestrion/internal/goenv"
@@ -32,7 +31,7 @@ import (
 var OrchestrionDirPathElement = filepath.Join("orchestrion", "src")
 
 func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resErr error) {
-	if pkgs.ResolvingTestVariants() && cmd.Flags.Package == "main" && strings.HasSuffix(w.ImportPath, ".test") {
+	if pkgs.ResolvingTestVariants() && cmd.Flags.Package == "main" && w.isTestMain() {
 		// The nested test main only exists to make cmd/go build affected variants.
 		// Its source may come from the build cache without the _testmain.go filename,
 		// so identify it from cmd/go's package metadata instead of its input path.
@@ -97,7 +96,7 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resEr
 		RootConfig: map[string]string{"httpmode": "wrap"},
 		Lookup:     imports.Lookup,
 		ImportPath: w.ImportPath,
-		TestMain:   cmd.TestMain() && strings.HasSuffix(w.ImportPath, ".test"),
+		TestMain:   cmd.TestMain() && w.isTestMain(),
 		ImportMap:  imports.PackageFile,
 		GoVersion:  cmd.Flags.Lang,
 		ModifiedFile: func(file string) string {

--- a/internal/toolexec/aspect/onlink.go
+++ b/internal/toolexec/aspect/onlink.go
@@ -20,12 +20,18 @@ import (
 )
 
 func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "Weaver.OnLink",
-		tracer.ResourceName(w.ImportPath),
-	)
+	spanOptions := []tracer.StartSpanOption{tracer.ResourceName(w.ImportPath)}
+	if w.Variant != "" {
+		spanOptions = append(spanOptions, tracer.Tag("variant", w.Variant))
+	}
+	span, ctx := tracer.StartSpanFromContext(ctx, "Weaver.OnLink", spanOptions...)
 	defer func() { span.Finish(tracer.WithError(err)) }()
 
-	log := zerolog.Ctx(ctx).With().Str("phase", "link").Logger()
+	logContext := zerolog.Ctx(ctx).With().Str("phase", "link")
+	if w.Variant != "" {
+		logContext = logContext.Str("variant", w.Variant)
+	}
+	log := logContext.Logger()
 	ctx = log.WithContext(ctx)
 
 	reg, err := importcfg.ParseFile(ctx, cmd.Flags.ImportCfg)

--- a/internal/toolexec/aspect/weaver.go
+++ b/internal/toolexec/aspect/weaver.go
@@ -5,6 +5,66 @@
 
 package aspect
 
+import "strings"
+
+// variantSeparator introduces the variant annotation Go adds to the
+// `$TOOLEXEC_IMPORTPATH` value of packages it builds more than once, as
+// implemented by `(*load.Package).Desc` in `cmd/go`. Module import paths can
+// contain neither spaces nor square brackets, so this cannot appear in the
+// import path of a package Orchestrion can process (it requires module-aware
+// builds, as it resolves its configuration from the module's `go.mod` file).
+const variantSeparator = " ["
+
+// testMainSuffix is the suffix Go appends to a package's import path to name the
+// generated main package of its test binary.
+const testMainSuffix = ".test"
+
+// Weaver applies aspects to the Go toolchain commands used to build a package.
+// It is created from the `$TOOLEXEC_IMPORTPATH` value Go provides for those
+// commands, using [NewWeaver].
 type Weaver struct {
+	// ImportPath is the import path of the package being built, without the
+	// variant annotation Go adds to `$TOOLEXEC_IMPORTPATH`; so that aspects apply
+	// to every variant of a package exactly as they do to its ordinary build.
 	ImportPath string
+	// Variant identifies why Go is building a variant of [Weaver.ImportPath], if
+	// it is. It is the import path of the test binary a test variant is built for
+	// (e.g, `example.com/pkg.test`), or that of the main package a
+	// profile-guided optimization variant is specialized for. It is blank when Go
+	// builds the package's ordinary variant.
+	Variant string
+}
+
+// NewWeaver returns the [Weaver] for the package designated by the provided
+// `$TOOLEXEC_IMPORTPATH` value.
+//
+// Go annotates that value for packages it builds more than once, so that
+// `example.com/pkg` becomes `example.com/pkg [example.com/pkg.test]` when it is
+// re-built with its in-package test files, for example. Such annotations must
+// not be mistaken for a part of the package's import path, as this would result
+// in aspects not being applied to those variants at all.
+func NewWeaver(toolexecImportPath string) Weaver {
+	importPath, variant, hasVariant := strings.Cut(toolexecImportPath, variantSeparator)
+	if !hasVariant {
+		return Weaver{ImportPath: toolexecImportPath}
+	}
+	return Weaver{ImportPath: importPath, Variant: strings.TrimSuffix(variant, "]")}
+}
+
+// isTestMain returns true if the package being built is a test binary's
+// generated main package (e.g, `example.com/pkg.test`), as opposed to any of the
+// packages that test binary is composed of. As a package can legitimately be
+// named `<something>.test`, callers should also verify the compilation's inputs
+// include Go's generated test-main source (see [proxy.CompileCommand.TestMain])
+// unless they cannot, which is the case when the source is served from Go's
+// build cache under a content-addressed file name.
+func (w Weaver) isTestMain() bool {
+	// Go does not build variants of the generated main package of a test binary.
+	return w.Variant == "" && strings.HasSuffix(w.ImportPath, testMainSuffix)
+}
+
+// packageUnderTest returns the import path of the package a test binary's
+// generated main package tests. The receiver must satisfy [Weaver.isTestMain].
+func (w Weaver) packageUnderTest() string {
+	return strings.TrimSuffix(w.ImportPath, testMainSuffix)
 }

--- a/internal/toolexec/aspect/weaver_test.go
+++ b/internal/toolexec/aspect/weaver_test.go
@@ -65,13 +65,14 @@ func TestNewWeaver(t *testing.T) {
 	}
 }
 
-func TestBehaviorOverrideAppliesToTestVariants(t *testing.T) {
-	// Special cases are keyed on import paths, so they must be evaluated against the import path of the
-	// package being built, and not the variant-annotated `$TOOLEXEC_IMPORTPATH` value; as failing to do
-	// so would for example allow circular instrumentation of the tracer's own test variants.
-	weaver := NewWeaver("github.com/DataDog/dd-trace-go/v2/ddtrace/tracer [github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.test]")
+func TestBehaviorOverrideAppliesToExactMatchTestVariants(t *testing.T) {
+	// Exact-match special cases do not match a variant-annotated `$TOOLEXEC_IMPORTPATH` directly.
+	toolexecImportPath := "github.com/DataDog/go-tuf/client [github.com/DataDog/go-tuf/client.test]"
+	_, found := FindBehaviorOverride(toolexecImportPath)
+	require.False(t, found)
 
+	weaver := NewWeaver(toolexecImportPath)
 	behavior, found := FindBehaviorOverride(weaver.ImportPath)
 	require.True(t, found)
-	assert.Equal(t, WeaveTracerInternal, behavior)
+	assert.Equal(t, NeverWeave, behavior)
 }

--- a/internal/toolexec/aspect/weaver_test.go
+++ b/internal/toolexec/aspect/weaver_test.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package aspect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWeaver(t *testing.T) {
+	// The expected `$TOOLEXEC_IMPORTPATH` values are those produced by `(*load.Package).Desc` in
+	// `cmd/go` for the packages Go builds when running `go test example.com/pkg`.
+	for name, tc := range map[string]struct {
+		toolexecImportPath string
+		expected           Weaver
+		isTestMain         bool
+		packageUnderTest   string
+	}{
+		"ordinary": {
+			toolexecImportPath: "example.com/pkg",
+			expected:           Weaver{ImportPath: "example.com/pkg"},
+		},
+		"in-package test variant": {
+			toolexecImportPath: "example.com/pkg [example.com/pkg.test]",
+			expected:           Weaver{ImportPath: "example.com/pkg", Variant: "example.com/pkg.test"},
+		},
+		"external test package": {
+			toolexecImportPath: "example.com/pkg_test [example.com/pkg.test]",
+			expected:           Weaver{ImportPath: "example.com/pkg_test", Variant: "example.com/pkg.test"},
+		},
+		"dependency rebuilt for a test binary": {
+			toolexecImportPath: "example.com/dep [example.com/pkg.test]",
+			expected:           Weaver{ImportPath: "example.com/dep", Variant: "example.com/pkg.test"},
+		},
+		"test main": {
+			toolexecImportPath: "example.com/pkg.test",
+			expected:           Weaver{ImportPath: "example.com/pkg.test"},
+			isTestMain:         true,
+			packageUnderTest:   "example.com/pkg",
+		},
+		// Go also annotates packages it specializes for a main package's profile-guided optimization.
+		"profile-guided optimization variant": {
+			toolexecImportPath: "example.com/pkg [example.com/cmd/app]",
+			expected:           Weaver{ImportPath: "example.com/pkg", Variant: "example.com/cmd/app"},
+		},
+		// A test variant of a package that is itself named `<something>.test` is not a test main.
+		"test variant of a .test package": {
+			toolexecImportPath: "example.com/pkg.test [example.com/pkg.test.test]",
+			expected:           Weaver{ImportPath: "example.com/pkg.test", Variant: "example.com/pkg.test.test"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			weaver := NewWeaver(tc.toolexecImportPath)
+			require.Equal(t, tc.expected, weaver)
+			assert.Equal(t, tc.isTestMain, weaver.isTestMain())
+			if tc.isTestMain {
+				assert.Equal(t, tc.packageUnderTest, weaver.packageUnderTest())
+			}
+		})
+	}
+}
+
+func TestBehaviorOverrideAppliesToTestVariants(t *testing.T) {
+	// Special cases are keyed on import paths, so they must be evaluated against the import path of the
+	// package being built, and not the variant-annotated `$TOOLEXEC_IMPORTPATH` value; as failing to do
+	// so would for example allow circular instrumentation of the tracer's own test variants.
+	weaver := NewWeaver("github.com/DataDog/dd-trace-go/v2/ddtrace/tracer [github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.test]")
+
+	behavior, found := FindBehaviorOverride(weaver.ImportPath)
+	require.True(t, found)
+	assert.Equal(t, WeaveTracerInternal, behavior)
+}

--- a/internal/toolexec/proxy/compile.go
+++ b/internal/toolexec/proxy/compile.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/DataDog/orchestrion/internal/files"
@@ -68,11 +69,18 @@ func (c *CompileCommand) ShowVersion() bool {
 }
 
 // TestMain returns true if the compiled package name is "main" and its original
-// compiler inputs include Go's generated `_testmain.go` source. Callers should
-// also validate that the declared package import path ends in `.test`.
+// compiler inputs include Go's generated test-main source, which is named
+// `_testmain.go`, or `_testmain.cover.go` in coverage-enabled builds. Callers
+// should also validate that the declared package import path ends in `.test`.
 func (c *CompileCommand) TestMain() bool {
 	return c.testMain
 }
+
+// testMainFileNames are the base names Go may use for the generated test-main
+// source file. Coverage-enabled builds run the generated file through
+// `go tool cover`, which renames it by replacing the `.go` suffix with
+// `.cover.go`.
+var testMainFileNames = []string{"_testmain.go", "_testmain.cover.go"}
 
 func (c *CompileCommand) detectTestMain() bool {
 	if c.Flags.Package != "main" {
@@ -80,7 +88,7 @@ func (c *CompileCommand) detectTestMain() bool {
 	}
 
 	for _, f := range c.GoFiles() {
-		if filepath.Base(f) == "_testmain.go" {
+		if slices.Contains(testMainFileNames, filepath.Base(f)) {
 			return true
 		}
 	}

--- a/internal/toolexec/proxy/compile_test.go
+++ b/internal/toolexec/proxy/compile_test.go
@@ -99,6 +99,20 @@ func TestTestMainIdentitySurvivesSourceRewrite(t *testing.T) {
 	require.True(t, cmd.TestMain())
 }
 
+func TestCoverInstrumentedTestMainIsTestMain(t *testing.T) {
+	// Coverage-enabled builds run the generated `_testmain.go` through `go tool cover`, which renames
+	// it to `_testmain.cover.go` and adds a `covervars.go` file to the compiler inputs.
+	stage := t.TempDir()
+	cmd := &CompileCommand{
+		Files: []string{
+			filepath.Join(stage, "covervars.go"),
+			filepath.Join(stage, "_testmain.cover.go"),
+		},
+		Flags: compileFlagSet{Package: "main", ImportCfg: filepath.Join(stage, "importcfg")},
+	}
+	require.True(t, cmd.detectTestMain())
+}
+
 func TestCgoMainIsNotTestMain(t *testing.T) {
 	stage := t.TempDir()
 	cmd := &CompileCommand{

--- a/main_test.go
+++ b/main_test.go
@@ -101,6 +101,10 @@ func Value() int { return subject.Value() }
 	run.exec(t, orchestrion, "go", "test", "-a", "./subject")
 	run.exec(t, orchestrion, "go", "test", "-a", "-cover", "-coverpkg=./...", "./subject")
 
+	// A multi-package coverage run compiles root against the ordinary subject archive before
+	// Orchestrion injects it into the subject test binary, whose subject archive has coverage.
+	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage.out"), "./root", "./subject")
+
 	// The nested test-variant load must preserve an overlay supplied to the outer Go command.
 	writeFile("subject/subject.go", "package subject\n\nfunc Value() int { return missing }\n")
 	writeFile("overlay/subject.go", "package subject\n\nfunc Value() int { return 42 }\n")

--- a/main_test.go
+++ b/main_test.go
@@ -105,6 +105,10 @@ func Value() int { return subject.Value() }
 	// Orchestrion injects it into the subject test binary, whose subject archive has coverage.
 	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage.out"), "./root", "./subject")
 
+	// Value-less test flags must not consume the package patterns that follow them, as coverage is
+	// otherwise applied to the wrong packages in nested loads.
+	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage-v.out"), "-v", "./subject", "./root")
+
 	// The nested test-variant load must preserve an overlay supplied to the outer Go command.
 	writeFile("subject/subject.go", "package subject\n\nfunc Value() int { return missing }\n")
 	writeFile("overlay/subject.go", "package subject\n\nfunc Value() int { return 42 }\n")

--- a/main_test.go
+++ b/main_test.go
@@ -185,6 +185,148 @@ func Value() int { return subject.Value() }
 	run.exec(t, buildOrchestrion(t), "go", "test", "-a", "./subject")
 }
 
+func TestAspectsApplyToTestVariants(t *testing.T) {
+	run := runner{dir: t.TempDir()}
+	writeFile := func(name, contents string) {
+		t.Helper()
+		path := filepath.Join(run.dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	}
+
+	writeFile("go.mod", `module example.com/testvariantaspect
+
+go 1.25
+
+require github.com/DataDog/orchestrion v0.0.0
+
+replace github.com/DataDog/orchestrion => `+rootDir+"\n")
+	writeFile("orchestrion.tool.go", `//go:build tools
+
+package tools
+
+import (
+	_ "example.com/testvariantaspect/instrumentation"
+	_ "github.com/DataDog/orchestrion"
+)
+`)
+	writeFile("instrumentation/instrumentation.go", "package instrumentation\n")
+	writeFile("instrumentation/orchestrion.yml", `meta:
+  name: Test variant aspects
+  description: Records that the packages a test binary is composed of were instrumented.
+aspects:
+  - id: instrument-subject
+    join-point:
+      all-of:
+        - import-path: example.com/testvariantaspect/subject
+        - function-body:
+            function:
+              - name: Value
+    advice:
+      - prepend-statements:
+          template: |-
+            Instrumented = true
+  - id: instrument-helper
+    join-point:
+      all-of:
+        - import-path: example.com/testvariantaspect/helper
+        - function-body:
+            function:
+              - name: Doubled
+    advice:
+      - prepend-statements:
+          template: |-
+            Instrumented = true
+  - id: instrument-external-test
+    join-point:
+      all-of:
+        - import-path: example.com/testvariantaspect/subject_test
+        - function-body:
+            function:
+              - name: value
+    advice:
+      - prepend-statements:
+          template: |-
+            instrumented = true
+`)
+	writeFile("subject/subject.go", `package subject
+
+// Instrumented is set by the instrumentation aspect when Value is called.
+var Instrumented bool
+
+func Value() int { return 42 }
+`)
+	// Go rebuilds the importers of the package under test against its test variant, and identifies those
+	// with an annotated $TOOLEXEC_IMPORTPATH value as well.
+	writeFile("helper/helper.go", `package helper
+
+import "example.com/testvariantaspect/subject"
+
+// Instrumented is set by the instrumentation aspect when Doubled is called.
+var Instrumented bool
+
+func Doubled() int { return 2 * subject.Value() }
+`)
+	// Go builds the package under test again together with its in-package test files, which it identifies
+	// with an annotated $TOOLEXEC_IMPORTPATH value. Aspects must apply to that variant, too.
+	writeFile("subject/subject_test.go", `package subject
+
+import "testing"
+
+func TestInPackage(t *testing.T) {
+	if got := Value(); got != 42 {
+		t.Fatalf("Value() = %d, want 42", got)
+	}
+	if !Instrumented {
+		t.Fatal("aspects were not applied to the in-package test variant of the package under test")
+	}
+}
+`)
+	writeFile("subject/external_test.go", `package subject_test
+
+import (
+	"testing"
+
+	"example.com/testvariantaspect/helper"
+	"example.com/testvariantaspect/subject"
+)
+
+// instrumented is set by the instrumentation aspect when value is called.
+var instrumented bool
+
+func value() int { return subject.Value() }
+
+func TestExternal(t *testing.T) {
+	if got := subject.Value(); got != 42 {
+		t.Fatalf("subject.Value() = %d, want 42", got)
+	}
+	if !subject.Instrumented {
+		t.Error("aspects were not applied to the test variant imported by the external test package")
+	}
+
+	if got := value(); got != 42 {
+		t.Fatalf("value() = %d, want 42", got)
+	}
+	if !instrumented {
+		t.Error("aspects were not applied to the external test package")
+	}
+
+	if got := helper.Doubled(); got != 84 {
+		t.Fatalf("helper.Doubled() = %d, want 84", got)
+	}
+	if !helper.Instrumented {
+		t.Error("aspects were not applied to the importer Go rebuilt for this test binary")
+	}
+}
+`)
+
+	orchestrion := buildOrchestrion(t)
+	run.exec(t, orchestrion, "go", "test", "-a", "./subject")
+	// Coverage-enabled builds hand the compiler sources rewritten by `go tool cover` instead of the
+	// package's own, which must not prevent aspects from applying either.
+	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage.out"), "./subject")
+}
+
 func TestBuildFromModuleSubdirectory(t *testing.T) {
 	run := runner{dir: t.TempDir()}
 


### PR DESCRIPTION
This fixes two independent bugs affecting `orchestrion go test` builds. Both were
found while investigating the first one, which makes multi-package coverage runs
unusable.

## `go test` with coverage fails to link test binaries

A multi-package coverage run fails in the link step:

```
link: fingerprint mismatch: example.com/m/subject has cc53…, import from example.com/m/dep expecting 6340…
```

Orchestrion resolves the synthetic link-time dependencies aspects introduce
(through `//go:linkname`, recorded as `link.deps` entries in the archives) and
adds them to the archives it hands to the linker. When the binary being produced
is a test binary, those dependencies must be resolved to the variants Go rebuilds
against the package under test: the ordinary archives expect the fingerprint of
the ordinary package-under-test archive, and not that of the test variant the
linker actually consumes.

Two defects prevented that from happening:

- Orchestrion identifies the test-main compilation by looking for Go's generated
  `_testmain.go` among the compiler inputs, but coverage-enabled builds run that
  file through `go tool cover`, which renames it to `_testmain.cover.go`. The
  compilation was consequently not recognized as a test main's, and the synthetic
  dependencies were resolved to ordinary archives.
- `-coverprofile` implies `-cover` in `go test`, but Orchestrion only looked for
  `-cover` and `-covermode`, so the nested package loads it performs to obtain
  those variant archives built them without coverage instrumentation — which
  again does not match the parent build. `-coverprofile` is not a build flag
  (`go list` rejects it), so it is now honored without being forwarded to child
  commands, and only for `go test`, since the Go CLI silently ignores `$GOFLAGS`
  entries the command at hand does not accept.

Coverage applies to the packages named on the command line, so Orchestrion has to
tell package patterns apart from flags and flag values in order to configure the
nested loads identically. That parsing was too approximate to support this:
unknown flags always consumed the argument that followed them, so
`go test -coverprofile=cover.out -v ./a ./b` lost `./a` and applied coverage to
`./b` alone in nested loads, reproducing the very same link failure. Flag parsing
now knows which flags accept no value, that `-buildvcs` accepts an optional one
(its bare form used to consume the argument that followed it, and to panic when
it was the last one), that `go test` accepts package patterns only as a single
contiguous run of arguments, and that `-args` and `--` terminate them.

The inferred `-coverpkg` value remains an approximation of the default `go test`
coverage mode, which instruments the test variant of each package under test but
not their ordinary variant — a distinction `-coverpkg` cannot express. Nested
builds consequently instrument slightly more packages than the parent build,
which can still yield incompatible archives when a synthetic link-time dependency
imports another package under test that has tests of its own. Addressing that
requires per-test-binary coverage configuration in nested loads, and is left out
of this change.

## The package under test is not instrumented in its own test binary

Aspects did not apply to any of the variants Go builds of a package when it builds
it more than once. This is most visible for a package under test: its ordinary
build was instrumented, but the build that also includes its own test files was
not.

`$TOOLEXEC_IMPORTPATH` is `(*load.Package).Desc`, which annotates those variants:
the package under test is built again with its in-package test files as
`example.com/pkg [example.com/pkg.test]`, its external test package as
`example.com/pkg_test [example.com/pkg.test]`, every importer of the package under
test is rebuilt against that variant, and packages specialized for a main
package's profile-guided optimization are annotated with that main package's
import path. Orchestrion used the annotated value as if it were the package's
import path, so `import-path` join points — which compare import paths verbatim —
and `package-filter` patterns never matched any variant of the package they
target.

The weaving special cases were not matched either, meaning the tracer's own test
variants were fully woven instead of being restricted to `tracer-internal`
aspects, which risks circular instrumentation. Finally, the type checker and the
AST decorator both received the annotated value as the identity of the package
being injected; they agreed with each other, which is why this stayed invisible.

`Weaver` now parses `$TOOLEXEC_IMPORTPATH`, keeping the variant annotation apart
from the import path. It only needs the annotation in order to tell Go's generated
test-main package, which never has one, apart from a package that is legitimately
named `<something>.test`.
