### PR TITLE
fix(toolexec): scope implicit test coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -241,7 +241,7 @@ jobs:
           mkdir -p coverage
           # The root package's tests each run several complete instrumented builds of a synthetic module,
           # which takes them well past Go's default 10 minute per-package timeout on CI runners.
-          test_args=("-shuffle=on" "-race" "-timeout=30m")
+          test_args=("-shuffle=on" "-race" "-timeout=60m")
           if [ "${{ github.event_name }}" != "merge_group" ]; then
             test_args+=("-cover" "-covermode=atomic" "-coverpkg=./...,github.com/DataDog/orchestrion/...")
           fi

--- a/internal/goflags/flags.go
+++ b/internal/goflags/flags.go
@@ -36,6 +36,13 @@ type CommandFlags struct {
 	Long    map[string]string
 	Short   map[string]struct{}
 	Unknown []string // flags we don't process but store anyway
+
+	// TestCoverpkgInferred reports whether -coverpkg was inferred from a go test
+	// command's package arguments, rather than provided explicitly by the user.
+	TestCoverpkgInferred bool
+	// TestPackagesWithoutTests lists command-line packages that go test covers in
+	// their ordinary form because they contain no test files.
+	TestPackagesWithoutTests []string
 }
 
 var (
@@ -174,7 +181,11 @@ func (f CommandFlags) Get(flag string) (val string, found bool) {
 // The [CommandFlags.Unknown] field is not modified, even if it is in the list
 // of flags to be removed.
 func (f CommandFlags) Except(remove ...string) CommandFlags {
-	res := CommandFlags{Unknown: f.Unknown}
+	res := CommandFlags{
+		Unknown:                  f.Unknown,
+		TestCoverpkgInferred:     f.TestCoverpkgInferred,
+		TestPackagesWithoutTests: slices.Clone(f.TestPackagesWithoutTests),
+	}
 
 	res.Short = make(map[string]struct{}, len(f.Short))
 	for k, v := range f.Short {
@@ -653,8 +664,64 @@ func (f *CommandFlags) inferCoverpkg(ctx context.Context, wd string, command str
 	val := strings.Join(coverpkg, ",")
 	log.Trace().Str("-coverpkg", val).Strs("positional", positionalArgs).Msg("Inferred -coverpkg flag from positional arguments")
 	f.Long["-coverpkg"] = val
+	if command == "test" {
+		f.TestCoverpkgInferred = true
+		f.TestPackagesWithoutTests, err = packagesWithoutTests(&packages.Config{
+			Context:    ctx,
+			Mode:       packages.NeedName | packages.NeedForTest,
+			Dir:        wd,
+			BuildFlags: childBuildFlags,
+			Tests:      true,
+			Logf:       childBuildLogf,
+		}, positionalArgs, pkgs)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
+}
+
+func packagesWithoutTests(config *packages.Config, patterns []string, targets []*packages.Package) ([]string, error) {
+	loaded, err := packages.Load(config, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("determining which covered packages have tests: %w", err)
+	}
+
+	withTests := make(map[string]struct{})
+	for _, pkg := range loaded {
+		if pkg.ForTest != "" {
+			withTests[pkg.ForTest] = struct{}{}
+		}
+		if len(pkg.Errors) == 0 {
+			continue
+		}
+
+		var pkgErr error
+		for _, err := range pkg.Errors {
+			pkgErr = errors.Join(pkgErr, err)
+		}
+		zerolog.Ctx(config.Context).Warn().Err(pkgErr).Str("pkg.ID", pkg.ID).Msg("Error while determining whether package has tests")
+		// Preserve the outer go command's canonical failure instead of risking a
+		// fingerprint mismatch caused by treating incomplete test metadata as proof
+		// that a package has no tests.
+		path := pkg.ForTest
+		if path == "" {
+			path = pkg.PkgPath
+		}
+		withTests[path] = struct{}{}
+	}
+
+	withoutTests := make([]string, 0, len(targets))
+	for _, pkg := range targets {
+		if _, found := withTests[pkg.PkgPath]; !found {
+			withoutTests = append(withoutTests, pkg.PkgPath)
+		}
+	}
+	if len(withoutTests) == 0 {
+		return nil, nil
+	}
+	return withoutTests, nil
 }
 
 // usesOutsideModuleMode reports whether go run resolves its target outside the

--- a/internal/goflags/flags_test.go
+++ b/internal/goflags/flags_test.go
@@ -7,6 +7,7 @@ package goflags
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -47,6 +48,41 @@ func TestTrim(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInferredTestCoverageScope(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/coverage\n\ngo 1.25\n"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "tested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tested", "tested.go"), []byte("package tested\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tested", "tested_test.go"), []byte("package tested\n"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "external"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "external", "external.go"), []byte("package external\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "external", "external_test.go"), []byte("package external_test\n"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "withouttests"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "withouttests", "withouttests.go"), []byte("package withouttests\n"), 0o644))
+	t.Setenv("GOFLAGS", "")
+
+	flags, err := ParseCommandFlags(context.Background(), dir, []string{"test", "-coverprofile=coverage.out", "./..."})
+	require.NoError(t, err)
+	assert.True(t, flags.TestCoverpkgInferred)
+	assert.Equal(t, []string{"example.com/coverage/withouttests"}, flags.TestPackagesWithoutTests)
+
+	copy := flags.Except("-cover")
+	assert.True(t, copy.TestCoverpkgInferred)
+	assert.Equal(t, flags.TestPackagesWithoutTests, copy.TestPackagesWithoutTests)
+	copy.TestPackagesWithoutTests[0] = "changed"
+	assert.Equal(t, "example.com/coverage/withouttests", flags.TestPackagesWithoutTests[0])
+
+	explicit, err := ParseCommandFlags(context.Background(), dir, []string{"test", "-coverpkg=./...", "./..."})
+	require.NoError(t, err)
+	assert.False(t, explicit.TestCoverpkgInferred)
+	assert.Empty(t, explicit.TestPackagesWithoutTests)
+
+	run, err := ParseCommandFlags(context.Background(), dir, []string{"run", "-cover", "./tested"})
+	require.NoError(t, err)
+	assert.False(t, run.TestCoverpkgInferred)
+	assert.Empty(t, run.TestPackagesWithoutTests)
 }
 
 func TestSlicePlacesCoverFalseAfterOptions(t *testing.T) {
@@ -719,17 +755,19 @@ func TestParseArtifactsByGoVersion(t *testing.T) {
 		"go1.25": {
 			goVersion: "go1.25.0",
 			expected: CommandFlags{
-				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
-				Short:   map[string]struct{}{"-cover": {}},
-				Unknown: []string{"-coverprofile=coverage.out", "-artifacts", "./quoted"},
+				Long:                 map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags"},
+				Short:                map[string]struct{}{"-cover": {}},
+				Unknown:              []string{"-coverprofile=coverage.out", "-artifacts", "./quoted"},
+				TestCoverpkgInferred: true,
 			},
 		},
 		"go1.26": {
 			goVersion: "go1.26.0",
 			expected: CommandFlags{
-				Long:    map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
-				Short:   map[string]struct{}{"-cover": {}},
-				Unknown: []string{"-coverprofile=coverage.out", "-artifacts"},
+				Long:                 map[string]string{"-coverpkg": "github.com/DataDog/orchestrion/internal/goflags/quoted"},
+				Short:                map[string]struct{}{"-cover": {}},
+				Unknown:              []string{"-coverprofile=coverage.out", "-artifacts"},
+				TestCoverpkgInferred: true,
 			},
 		},
 	} {

--- a/internal/jobserver/pkgs/coverage_test.go
+++ b/internal/jobserver/pkgs/coverage_test.go
@@ -43,4 +43,21 @@ func TestScopeInferredTestCoverage(t *testing.T) {
 		"example.com/no-tests",
 		"example.com/subject",
 	}))
+
+	for _, preservedBuildFlag := range []string{"-race", "-msan", "-asan"} {
+		t.Run(preservedBuildFlag, func(t *testing.T) {
+			buildFlags := []string{
+				preservedBuildFlag,
+				"-cover",
+				"-coverpkg=example.com/all/...",
+				"-toolexec=orchestrion toolexec",
+			}
+			assert.Equal(t, []string{
+				preservedBuildFlag,
+				"-toolexec=orchestrion toolexec",
+				"-cover",
+				"-coverpkg=example.com/subject",
+			}, scopeInferredTestCoverage(buildFlags, "", []string{"example.com/subject"}))
+		})
+	}
 }

--- a/internal/jobserver/pkgs/coverage_test.go
+++ b/internal/jobserver/pkgs/coverage_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package pkgs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScopeInferredTestCoverage(t *testing.T) {
+	buildFlags := []string{
+		"-race",
+		"-cover",
+		"-covermode=atomic",
+		"-coverpkg=example.com/all/...",
+		"-toolexec=orchestrion toolexec",
+	}
+
+	assert.Equal(t, []string{
+		"-race",
+		"-toolexec=orchestrion toolexec",
+	}, scopeInferredTestCoverage(buildFlags, "atomic", nil))
+
+	assert.Equal(t, []string{
+		"-race",
+		"-toolexec=orchestrion toolexec",
+		"-cover",
+		"-coverpkg=example.com/no-tests,example.com/subject",
+		"-covermode=atomic",
+	}, scopeInferredTestCoverage(buildFlags, "atomic", []string{
+		"example.com/no-tests",
+		"example.com/subject",
+	}))
+}

--- a/internal/jobserver/pkgs/coverage_test.go
+++ b/internal/jobserver/pkgs/coverage_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBuildFlagsHaveCoverage(t *testing.T) {
+	assert.False(t, buildFlagsHaveCoverage(nil))
+	assert.True(t, buildFlagsHaveCoverage([]string{"-cover"}))
+	assert.True(t, buildFlagsHaveCoverage([]string{"-coverpkg=example.com/subject"}))
+	assert.False(t, buildFlagsHaveCoverage([]string{"-covermode=atomic", "-cover=false"}))
+	assert.False(t, buildFlagsHaveCoverage([]string{"-cover=invalid"}))
+}
+
 func TestScopeInferredTestCoverage(t *testing.T) {
 	buildFlags := []string{
 		"-race",

--- a/internal/jobserver/pkgs/pkgs.go
+++ b/internal/jobserver/pkgs/pkgs.go
@@ -23,10 +23,13 @@ const (
 )
 
 type resolvedPackageSet struct {
-	response      ResolveResponse
-	packages      []*packages.Package
-	config        packages.Config
-	buildFlagsErr string
+	response                 ResolveResponse
+	packages                 []*packages.Package
+	config                   packages.Config
+	buildFlagsErr            string
+	testCoverpkgInferred     bool
+	testCoverageMode         string
+	testPackagesWithoutTests []string
 }
 
 type service struct {

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -257,12 +257,12 @@ func loadResolvedPackages(ctx context.Context, req *ResolveRequest, log zerolog.
 	}, nil
 }
 
-func scopeInferredTestCoverage(buildFlags []string, mode string, packages []string) []string {
+func scopeInferredTestCoverage(buildFlags []string, mode string, pkgs []string) []string {
 	result := withoutCoverageBuildFlags(buildFlags)
-	if len(packages) == 0 {
+	if len(pkgs) == 0 {
 		return result
 	}
-	result = append(result, "-cover", "-coverpkg="+strings.Join(packages, ","))
+	result = append(result, "-cover", "-coverpkg="+strings.Join(pkgs, ","))
 	if mode != "" {
 		result = append(result, "-covermode="+mode)
 	}

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -157,6 +157,14 @@ func (s *service) resolve(ctx context.Context, req *ResolveRequest) (ResolveResp
 		resp := maps.Clone(ordinary.response)
 		config := ordinary.config
 		config.Env = resolveEnvironment(ctx, req)
+		config.BuildFlags = slices.Clone(config.BuildFlags)
+		if ordinary.testCoverpkgInferred {
+			coveragePackages := slices.Clone(ordinary.testPackagesWithoutTests)
+			if !slices.Contains(coveragePackages, req.TestVariantFor) {
+				coveragePackages = append(coveragePackages, req.TestVariantFor)
+			}
+			config.BuildFlags = scopeInferredTestCoverage(config.BuildFlags, ordinary.testCoverageMode, coveragePackages)
+		}
 		resp, err = mergeTestVariant(ctx, req, ordinary.packages, resp, config)
 		if err != nil {
 			return resolvedPackageSet{}, err
@@ -195,7 +203,16 @@ func loadResolvedPackages(ctx context.Context, req *ResolveRequest, log zerolog.
 		"-a",
 		"-toolexec",
 	)
+	testCoverpkgInferred := goFlags.TestCoverpkgInferred
+	testCoverageMode, _ := goFlags.Get("-covermode")
+	testPackagesWithoutTests := slices.Clone(goFlags.TestPackagesWithoutTests)
 	buildFlags := append(goFlags.Slice(), fmt.Sprintf("-toolexec=%q toolexec", binpath.Orchestrion))
+	if testCoverpkgInferred {
+		// With implicit test coverage, packages that have tests are covered only in
+		// their own test binaries. Command-line packages without tests are instead
+		// covered in their ordinary form and shared by all of those binaries.
+		buildFlags = scopeInferredTestCoverage(buildFlags, testCoverageMode, testPackagesWithoutTests)
+	}
 	loadConfig := &packages.Config{
 		Context: ctx,
 		Mode: packages.NeedExportFile | packages.NeedFiles |
@@ -229,11 +246,33 @@ func loadResolvedPackages(ctx context.Context, req *ResolveRequest, log zerolog.
 
 	log.Trace().Any("result", resp).Msg("pkgs.Resolve finished")
 	return resolvedPackageSet{
-		response:      resp,
-		packages:      pkgs,
-		config:        *loadConfig,
-		buildFlagsErr: flagsErrText,
+		response:                 resp,
+		packages:                 pkgs,
+		config:                   *loadConfig,
+		buildFlagsErr:            flagsErrText,
+		testCoverpkgInferred:     testCoverpkgInferred,
+		testCoverageMode:         testCoverageMode,
+		testPackagesWithoutTests: testPackagesWithoutTests,
 	}, nil
+}
+
+func scopeInferredTestCoverage(buildFlags []string, mode string, packages []string) []string {
+	result := make([]string, 0, len(buildFlags)+3)
+	for _, flag := range buildFlags {
+		name, _, _ := strings.Cut(flag, "=")
+		if name == "-cover" || name == "-covermode" || name == "-coverpkg" {
+			continue
+		}
+		result = append(result, flag)
+	}
+	if len(packages) == 0 {
+		return result
+	}
+	result = append(result, "-cover", "-coverpkg="+strings.Join(packages, ","))
+	if mode != "" {
+		result = append(result, "-covermode="+mode)
+	}
+	return result
 }
 
 func resolveEnvironment(ctx context.Context, req *ResolveRequest) []string {

--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -257,6 +258,36 @@ func loadResolvedPackages(ctx context.Context, req *ResolveRequest, log zerolog.
 }
 
 func scopeInferredTestCoverage(buildFlags []string, mode string, packages []string) []string {
+	result := withoutCoverageBuildFlags(buildFlags)
+	if len(packages) == 0 {
+		return result
+	}
+	result = append(result, "-cover", "-coverpkg="+strings.Join(packages, ","))
+	if mode != "" {
+		result = append(result, "-covermode="+mode)
+	}
+	return result
+}
+
+func buildFlagsHaveCoverage(buildFlags []string) bool {
+	enabled := false
+	for _, flag := range buildFlags {
+		name, value, assigned := strings.Cut(flag, "=")
+		switch name {
+		case "-covermode", "-coverpkg":
+			enabled = true
+		case "-cover":
+			if !assigned {
+				enabled = true
+			} else if parsed, err := strconv.ParseBool(value); err == nil {
+				enabled = parsed
+			}
+		}
+	}
+	return enabled
+}
+
+func withoutCoverageBuildFlags(buildFlags []string) []string {
 	result := make([]string, 0, len(buildFlags)+3)
 	for _, flag := range buildFlags {
 		name, _, _ := strings.Cut(flag, "=")
@@ -264,13 +295,6 @@ func scopeInferredTestCoverage(buildFlags []string, mode string, packages []stri
 			continue
 		}
 		result = append(result, flag)
-	}
-	if len(packages) == 0 {
-		return result
-	}
-	result = append(result, "-cover", "-coverpkg="+strings.Join(packages, ","))
-	if mode != "" {
-		result = append(result, "-covermode="+mode)
 	}
 	return result
 }

--- a/internal/jobserver/pkgs/testvariants.go
+++ b/internal/jobserver/pkgs/testvariants.go
@@ -109,8 +109,19 @@ func mergeTestVariant(
 
 	all := collectPackages(loaded)
 	if findTestVariant(all, req.TestVariantFor, req.TestVariantFor) == nil {
-		// With external tests only, cmd/go does not augment the package under test and
-		// therefore has no fingerprints that synthetic dependencies must be rebuilt against.
+		// With external tests only, cmd/go does not augment the package under test.
+		// Coverage can nevertheless change its ordinary archive. In that case the
+		// synthetic dependency produced by this load was rebuilt against the covered
+		// archive and must replace the ordinary resolution.
+		if buildFlagsHaveCoverage(config.BuildFlags) {
+			variant := findCoverageVariant(all, req.Pattern, req.TestVariantFor)
+			if variant == nil {
+				return nil, fmt.Errorf("Go did not produce a coverage variant for synthetic dependency %q of %q", req.Pattern, req.TestVariantFor)
+			}
+			if err := collectCoverageVariantClosure(resp, variant, req.TestVariantFor, make(map[string]bool)); err != nil {
+				return nil, err
+			}
+		}
 		delete(resp, req.TestVariantFor)
 		return resp, nil
 	}
@@ -279,6 +290,37 @@ func findTestVariant(pkgs []*packages.Package, pkgPath string, forTest string) *
 	for _, pkg := range pkgs {
 		if pkg.PkgPath == pkgPath && pkg.ForTest == forTest {
 			return pkg
+		}
+	}
+	return nil
+}
+
+func findCoverageVariant(pkgs []*packages.Package, pkgPath string, target string) *packages.Package {
+	for _, pkg := range pkgs {
+		if pkg.PkgPath == pkgPath && importsPackage(pkg, target, make(map[string]bool)) {
+			return pkg
+		}
+	}
+	return nil
+}
+
+func collectCoverageVariantClosure(resp ResolveResponse, pkg *packages.Package, target string, visited map[string]bool) error {
+	if pkg == nil || visited[pkg.ID] || pkg.PkgPath == target {
+		return nil
+	}
+	visited[pkg.ID] = true
+	if !importsPackage(pkg, target, make(map[string]bool)) {
+		return nil
+	}
+	if pkg.PkgPath != "" && pkg.PkgPath != "unsafe" {
+		if pkg.ExportFile == "" {
+			return fmt.Errorf("Go did not produce an export archive for coverage variant %q (%s) of %q", pkg.PkgPath, pkg.ID, target)
+		}
+		resp[pkg.PkgPath] = ResolvedArchive{ExportFile: pkg.ExportFile, ForTest: target}
+	}
+	for _, imported := range pkg.Imports {
+		if err := collectCoverageVariantClosure(resp, imported, target, visited); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/jobserver/pkgs/testvariants_test.go
+++ b/internal/jobserver/pkgs/testvariants_test.go
@@ -89,6 +89,33 @@ func TestInternalImportBridgeRejectsNestedInternalRoot(t *testing.T) {
 	assert.Contains(t, err.Error(), "nested internal")
 }
 
+func TestCollectCoverageVariantClosure(t *testing.T) {
+	const target = "example.com/subject"
+	subject := &packages.Package{ID: target, PkgPath: target, ExportFile: "/subject.a"}
+	unrelated := &packages.Package{ID: "example.com/unrelated", PkgPath: "example.com/unrelated", ExportFile: "/unrelated.a"}
+	middle := &packages.Package{
+		ID:         "example.com/middle",
+		PkgPath:    "example.com/middle",
+		ExportFile: "/middle.a",
+		Imports:    map[string]*packages.Package{target: subject},
+	}
+	root := &packages.Package{
+		ID:         "example.com/root",
+		PkgPath:    "example.com/root",
+		ExportFile: "/root.a",
+		Imports: map[string]*packages.Package{
+			middle.PkgPath:    middle,
+			unrelated.PkgPath: unrelated,
+		},
+	}
+	resp := make(ResolveResponse)
+	require.NoError(t, collectCoverageVariantClosure(resp, root, target, make(map[string]bool)))
+	assert.Equal(t, ResolvedArchive{ExportFile: "/root.a", ForTest: target}, resp[root.PkgPath])
+	assert.Equal(t, ResolvedArchive{ExportFile: "/middle.a", ForTest: target}, resp[middle.PkgPath])
+	assert.NotContains(t, resp, target)
+	assert.NotContains(t, resp, unrelated.PkgPath)
+}
+
 func TestCollectTestVariantClosureRequiresExports(t *testing.T) {
 	const forTest = "example.com/subject"
 	root := &packages.Package{

--- a/main_test.go
+++ b/main_test.go
@@ -212,14 +212,23 @@ func TestValue(t *testing.T) {
 	}
 }
 `)
-	writeFile("root/root.go", `package root
+	writeFile("middle/middle.go", `package middle
 
 import "example.com/externaltestvariant/subject"
 
 func Value() int { return subject.Value() }
 `)
+	writeFile("root/root.go", `package root
 
-	run.exec(t, buildOrchestrion(t), "go", "test", "-a", "./subject")
+import "example.com/externaltestvariant/middle"
+
+func Value() int { return middle.Value() }
+`)
+
+	orchestrion := buildOrchestrion(t)
+	run.exec(t, orchestrion, "go", "test", "-a", "./subject")
+	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage.out"), "./subject")
+	run.exec(t, orchestrion, "go", "test", "-a", "-cover", "-coverpkg=./...", "./subject")
 }
 
 func TestAspectsApplyToTestVariants(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/tools/cover"
 )
 
 func TestSyntheticLinkDependencyUsesTestVariant(t *testing.T) {
@@ -87,8 +88,10 @@ func Value() int { return 40 + leaf.Value() + notests.Value() }
 import "testing"
 
 func TestValue(t *testing.T) {
-	if got := Value(); got != 42 {
-		t.Fatalf("Value() = %d, want 42", got)
+	for range 3 {
+		if got := Value(); got != 42 {
+			t.Fatalf("Value() = %d, want 42", got)
+		}
 	}
 }
 `)
@@ -133,6 +136,25 @@ func Value() int { return subject.Value() }
 	// load for the subject test binary must therefore leave leaf uninstrumented but instrument
 	// notests, matching the archives against which subject was compiled.
 	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage-all.out"), "./...")
+
+	// Coverage mode implied by -race (rather than an explicit -covermode) must remain consistent
+	// between the ordinary archive and each per-binary-scoped test-variant archive. Repeated calls
+	// to subject.Value distinguish atomic counters from set counters instead of only checking that
+	// the build succeeds.
+	t.Run("RaceCoverMode", func(t *testing.T) {
+		t.Setenv("GOFLAGS", "")
+		profile := filepath.Join(run.dir, "coverage-race.out")
+		run.exec(t, orchestrion, "go", "test", "-a", "-race", "-coverprofile="+profile, "./...")
+		requireCoverageCountAtLeast(t, profile, "example.com/testvariant/subject/subject.go", "atomic", 3)
+	})
+
+	// Implied build modes supplied through GOFLAGS must reach the nested scoped rebuilds too.
+	t.Run("RaceCoverModeFromGOFLAGS", func(t *testing.T) {
+		t.Setenv("GOFLAGS", "-race")
+		profile := filepath.Join(run.dir, "coverage-goflags-race.out")
+		run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+profile, "./...")
+		requireCoverageCountAtLeast(t, profile, "example.com/testvariant/subject/subject.go", "atomic", 3)
+	})
 
 	// Value-less test flags must not consume the package patterns that follow them, as coverage is
 	// otherwise applied to the wrong packages in nested loads.
@@ -587,6 +609,26 @@ func (*harness) findLatestGithubReleaseTag(b *testing.B, owner string, repo stri
 	require.NotEmpty(b, payload)
 
 	return payload.TagName
+}
+
+func requireCoverageCountAtLeast(t *testing.T, profilePath, fileName, mode string, minimum int) {
+	t.Helper()
+
+	profiles, err := cover.ParseProfiles(profilePath)
+	require.NoError(t, err)
+	for _, profile := range profiles {
+		if filepath.ToSlash(profile.FileName) != fileName {
+			continue
+		}
+		require.Equal(t, mode, profile.Mode)
+		for _, block := range profile.Blocks {
+			if block.Count >= minimum {
+				return
+			}
+		}
+		require.Failf(t, "coverage count is too low", "%s has no block with a count of at least %d: %#v", fileName, minimum, profile.Blocks)
+	}
+	require.Failf(t, "coverage profile is missing a file", "%s does not contain %s", profilePath, fileName)
 }
 
 func getGithubToken() (string, bool) {

--- a/main_test.go
+++ b/main_test.go
@@ -73,7 +73,15 @@ aspects:
             //go:linkname __orchestrionInternalRootValue example.com/testvariant/dep/internal/root.Value
             func __orchestrionInternalRootValue() int
 `)
-	writeFile("subject/subject.go", "package subject\n\nfunc Value() int { return 42 }\n")
+	writeFile("subject/subject.go", `package subject
+
+import (
+	"example.com/testvariant/leaf"
+	"example.com/testvariant/notests"
+)
+
+func Value() int { return 40 + leaf.Value() + notests.Value() }
+`)
 	writeFile("subject/subject_test.go", `package subject
 
 import "testing"
@@ -84,11 +92,26 @@ func TestValue(t *testing.T) {
 	}
 }
 `)
+	writeFile("leaf/leaf.go", "package leaf\n\nfunc Value() int { return 1 }\n")
+	writeFile("notests/notests.go", "package notests\n\nfunc Value() int { return 1 }\n")
+	writeFile("leaf/leaf_test.go", `package leaf
+
+import "testing"
+
+func TestValue(t *testing.T) {
+	if got := Value(); got != 1 {
+		t.Fatalf("Value() = %d, want 1", got)
+	}
+}
+`)
 	writeFile("root/root.go", `package root
 
-import "example.com/testvariant/subject"
+import (
+	"example.com/testvariant/leaf"
+	"example.com/testvariant/subject"
+)
 
-func Value() int { return subject.Value() }
+func Value() int { return subject.Value() + leaf.Value() - 1 }
 `)
 	writeFile("dep/internal/root/root.go", `package root
 
@@ -105,13 +128,27 @@ func Value() int { return subject.Value() }
 	// Orchestrion injects it into the subject test binary, whose subject archive has coverage.
 	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage.out"), "./root", "./subject")
 
+	// Without an explicit -coverpkg, Go covers each package that has tests only in its own test
+	// binary, while covering command-line packages without tests in their ordinary form. The nested
+	// load for the subject test binary must therefore leave leaf uninstrumented but instrument
+	// notests, matching the archives against which subject was compiled.
+	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage-all.out"), "./...")
+
 	// Value-less test flags must not consume the package patterns that follow them, as coverage is
 	// otherwise applied to the wrong packages in nested loads.
 	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage-v.out"), "-v", "./subject", "./root")
 
 	// The nested test-variant load must preserve an overlay supplied to the outer Go command.
 	writeFile("subject/subject.go", "package subject\n\nfunc Value() int { return missing }\n")
-	writeFile("overlay/subject.go", "package subject\n\nfunc Value() int { return 42 }\n")
+	writeFile("overlay/subject.go", `package subject
+
+import (
+	"example.com/testvariant/leaf"
+	"example.com/testvariant/notests"
+)
+
+func Value() int { return 40 + leaf.Value() + notests.Value() }
+`)
 	writeFile("overlay.json", `{"Replace":{"subject/subject.go":"overlay/subject.go"}}`)
 	run.exec(t, orchestrion, "go", "test", "-a", "-overlay=overlay.json", "./subject")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -611,7 +611,7 @@ func (*harness) findLatestGithubReleaseTag(b *testing.B, owner string, repo stri
 	return payload.TagName
 }
 
-func requireCoverageCountAtLeast(t *testing.T, profilePath, fileName, mode string, minimum int) {
+func requireCoverageCountAtLeast(t *testing.T, profilePath string, fileName string, mode string, minimum int) {
 	t.Helper()
 
 	profiles, err := cover.ParseProfiles(profilePath)


### PR DESCRIPTION
Match nested package loads to the per-binary coverage scope used by `go test` when the user does not provide `-coverpkg`. Cover packages with tests only in their own test variants, while retaining coverage for command-line packages without test files in ordinary loads.

This prevents nested synthetic dependency archives from replacing Go's selected archives with incompatible fingerprints during multi-package coverage runs. Preserve explicit coverage scopes and add unit and end-to-end regression coverage for test and no-test package targets.