### PR TITLE
fix(toolexec): rebuild synthetic test imports

### DIFF
--- a/internal/jobserver/pkgs/resolve.go
+++ b/internal/jobserver/pkgs/resolve.go
@@ -42,6 +42,12 @@ var envIgnoreList = map[string]func(*ResolveRequest, string){
 		}
 		r.TempDir = dir
 	},
+	envVarReverseVariant: func(r *ResolveRequest, path string) {
+		r.reverseVariantPath = path
+	},
+	envVarReverseVariantFlavor: func(r *ResolveRequest, flavor string) {
+		r.ReverseVariantFlavor = flavor
+	},
 	// Known to change between invocations & irrelevant to the resolution, but can be used to detect cycles.
 	"TOOLEXEC_IMPORTPATH":       func(r *ResolveRequest, path string) { r.toolexecImportpath = path },
 	envVarParentID:              func(r *ResolveRequest, id string) { r.resolveParentID = id },
@@ -50,15 +56,21 @@ var envIgnoreList = map[string]func(*ResolveRequest, string){
 
 type (
 	ResolveRequest struct {
-		Dir            string   `json:"dir"`                      // The directory to resolve from (usually where `go.mod` is)
-		Env            []string `json:"env"`                      // Environment variables to use during resolution
-		Pattern        string   `json:"pattern"`                  // Package pattern to resolve
-		TempDir        string   `json:"tmpdir,omitempty"`         // A temporary directory to use for Go build artifacts
-		TestVariantFor string   `json:"testVariantFor,omitempty"` // Resolve the literal Pattern as built for this package's tests
+		Dir                string   `json:"dir"`                          // The directory to resolve from (usually where `go.mod` is)
+		Env                []string `json:"env"`                          // Environment variables to use during resolution
+		Pattern            string   `json:"pattern"`                      // Package pattern to resolve
+		TempDir            string   `json:"tmpdir,omitempty"`             // A temporary directory to use for Go build artifacts
+		TestVariantFor     string   `json:"testVariantFor,omitempty"`     // Resolve the literal Pattern as built for this package's tests
+		ReverseTestVariant bool     `json:"reverseTestVariant,omitempty"` // Rebuild Pattern's test-binary import closure against the authoritative test target
+		// AuthoritativeTarget is the package-under-test archive selected by the outer test-main compilation.
+		AuthoritativeTarget string `json:"authoritativeTarget,omitempty"`
+		// ReverseVariantFlavor preserves the stable reverse-universe identity while its temporary environment path is canonicalized out.
+		ReverseVariantFlavor string `json:"reverseVariantFlavor,omitempty"`
 
 		// Fields set by canonicalization
 		resolveParentID    string // The value of the [envVarParentID] environment variable
 		toolexecImportpath string // The value of the TOOLEXEC_IMPORTPATH environment variable
+		reverseVariantPath string // The value of the [envVarReverseVariant] environment variable
 		canonical          bool   // Whether this request was canonicalized yet
 	}
 	// ResolvedArchive identifies an export archive and, when non-empty, the test target for which
@@ -86,6 +98,9 @@ func (r ResolveRequest) ForeachSpanTag(set func(key string, value any)) {
 	set("request.pattern", r.Pattern)
 	if r.TestVariantFor != "" {
 		set("request.test-variant-for", r.TestVariantFor)
+	}
+	if r.ReverseTestVariant {
+		set("request.reverse-test-variant", true)
 	}
 }
 
@@ -137,6 +152,9 @@ func (s *service) resolve(ctx context.Context, req *ResolveRequest) (ResolveResp
 	resolved, err := s.resolved.Load(reqHash, func() (_ resolvedPackageSet, err error) {
 		if req.TestVariantFor == "" {
 			return loadResolvedPackages(ctx, req, *log)
+		}
+		if req.ReverseTestVariant {
+			return s.resolveReverseTestVariant(ctx, req, *log)
 		}
 
 		ordinaryReq := *req
@@ -309,6 +327,12 @@ func resolveEnvironment(ctx context.Context, req *ResolveRequest) []string {
 	}
 	if req.TempDir != "" {
 		env = append(env, fmt.Sprintf("%s=%s", envVarGotmpdir, req.TempDir))
+	}
+	if req.reverseVariantPath != "" {
+		env = append(env,
+			envVarReverseVariant+"="+req.reverseVariantPath,
+			envVarReverseVariantFlavor+"="+req.ReverseVariantFlavor,
+		)
 	}
 	return env
 }

--- a/internal/jobserver/pkgs/reversevariants.go
+++ b/internal/jobserver/pkgs/reversevariants.go
@@ -1,0 +1,270 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package pkgs
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/DataDog/orchestrion/internal/toolexec/archive"
+	"github.com/rs/zerolog"
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	envVarReverseVariant       = "ORCHESTRION_REVERSE_VARIANT"
+	envVarReverseVariantFlavor = "ORCHESTRION_REVERSE_VARIANT_FLAVOR"
+)
+
+type reverseVariantEnvironment struct {
+	Flavor       string            `json:"flavor"`
+	PackageFiles map[string]string `json:"packageFiles"`
+}
+
+// ReverseVariantEnvironment returns the flavor and authoritative package files
+// for a nested build that reconstructs synthetic importers for a test binary.
+func ReverseVariantEnvironment() (flavor string, packageFiles map[string]string, active bool, err error) {
+	path := os.Getenv(envVarReverseVariant)
+	if path == "" {
+		return "", nil, false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, true, fmt.Errorf("reading reverse test variant environment %q: %w", path, err)
+	}
+	var value reverseVariantEnvironment
+	if err := json.Unmarshal(data, &value); err != nil {
+		return "", nil, true, fmt.Errorf("parsing reverse test variant environment %q: %w", path, err)
+	}
+	if value.Flavor == "" {
+		return "", nil, true, fmt.Errorf("reverse test variant environment %q has no flavor", path)
+	}
+	if flavor := os.Getenv(envVarReverseVariantFlavor); flavor != value.Flavor {
+		return "", nil, true, fmt.Errorf("reverse test variant environment %q has flavor %q, process declares %q", path, value.Flavor, flavor)
+	}
+	if len(value.PackageFiles) == 0 {
+		return "", nil, true, fmt.Errorf("reverse test variant environment %q has no package files", path)
+	}
+	return value.Flavor, value.PackageFiles, true, nil
+}
+
+func (s *service) resolveReverseTestVariant(ctx context.Context, req *ResolveRequest, log zerolog.Logger) (resolvedPackageSet, error) {
+	if req.Pattern == "" || req.TestVariantFor == "" || req.AuthoritativeTarget == "" {
+		return resolvedPackageSet{}, fmt.Errorf("incomplete reverse test variant request for %q", req.Pattern)
+	}
+
+	ordinaryReq := *req
+	ordinaryReq.Pattern = req.TestVariantFor
+	ordinaryReq.TestVariantFor = ""
+	ordinaryReq.ReverseTestVariant = false
+	ordinaryReq.AuthoritativeTarget = ""
+	ordinaryHash, err := ordinaryReq.hash()
+	if err != nil {
+		return resolvedPackageSet{}, err
+	}
+	ordinary, err := s.resolved.Load(ordinaryHash, func() (resolvedPackageSet, error) {
+		return loadResolvedPackages(ctx, &ordinaryReq, log)
+	})
+	if err != nil {
+		return resolvedPackageSet{}, err
+	}
+	if ordinary.buildFlagsErr != "" {
+		return resolvedPackageSet{}, fmt.Errorf("obtaining Go build flags for reverse test variant resolution: %s", ordinary.buildFlagsErr)
+	}
+
+	config := ordinary.config
+	config.Context = ctx
+	config.Env = resolveEnvironment(ctx, req)
+	config.BuildFlags = slices.Clone(config.BuildFlags)
+	if ordinary.testCoverpkgInferred {
+		coveragePackages := slices.Clone(ordinary.testPackagesWithoutTests)
+		if !slices.Contains(coveragePackages, req.TestVariantFor) {
+			coveragePackages = append(coveragePackages, req.TestVariantFor)
+		}
+		config.BuildFlags = scopeInferredTestCoverage(config.BuildFlags, ordinary.testCoverageMode, coveragePackages)
+	}
+
+	return buildReverseTestVariant(req, config)
+}
+
+func buildReverseTestVariant(req *ResolveRequest, config packages.Config) (resolvedPackageSet, error) {
+	// Detect same-package test augmentation before comparing the authoritative
+	// archive. Reconstructing a reverse edge through that augmented package would
+	// require solving a compiler-fingerprint cycle, so preserve the explicit
+	// safety failure instead of reporting a misleading coverage mismatch.
+	provenanceConfig := config
+	provenanceConfig.Tests = true
+	provenanceConfig.Mode = packages.NeedName | packages.NeedImports | packages.NeedDeps | packages.NeedForTest
+	provenance, err := packages.Load(&provenanceConfig, req.TestVariantFor)
+	if err != nil {
+		return resolvedPackageSet{}, fmt.Errorf("loading reverse test target provenance for %q: %w", req.TestVariantFor, err)
+	}
+	if err := packageErrors(provenance); err != nil {
+		return resolvedPackageSet{}, fmt.Errorf("loading reverse test target provenance for %q: %w", req.TestVariantFor, err)
+	}
+	if findTestVariant(collectPackages(provenance), req.TestVariantFor, req.TestVariantFor) != nil {
+		return resolvedPackageSet{}, fmt.Errorf("synthetic importer %q cannot be rebuilt against same-package tests for %q without creating a package fingerprint cycle", req.Pattern, req.TestVariantFor)
+	}
+
+	// Resolve the package-under-test closure under the same scoped coverage flags
+	// as the nested test graph. Synthetic importers receive this closure directly
+	// and therefore cannot recurse into the jobserver while it is being built.
+	config.Tests = false
+	config.Mode = packages.NeedName | packages.NeedImports | packages.NeedDeps |
+		packages.NeedExportFile | packages.NeedForTest
+	targets, err := packages.Load(&config, req.TestVariantFor)
+	if err != nil {
+		return resolvedPackageSet{}, fmt.Errorf("loading authoritative reverse test target %q: %w", req.TestVariantFor, err)
+	}
+	if err := packageErrors(targets); err != nil {
+		return resolvedPackageSet{}, fmt.Errorf("loading authoritative reverse test target %q: %w", req.TestVariantFor, err)
+	}
+	overrides := make(ResolveResponse)
+	for _, target := range targets {
+		if err := overrides.mergeFrom(target); err != nil {
+			return resolvedPackageSet{}, err
+		}
+	}
+	selected, found := overrides[req.TestVariantFor]
+	if !found || selected.ExportFile == "" {
+		return resolvedPackageSet{}, fmt.Errorf("Go did not produce an export archive for reverse test target %q", req.TestVariantFor)
+	}
+	resolvedFingerprint, err := archive.Fingerprint(selected.ExportFile)
+	if err != nil {
+		return resolvedPackageSet{}, err
+	}
+	authoritativeFingerprint, err := archive.Fingerprint(req.AuthoritativeTarget)
+	if err != nil {
+		return resolvedPackageSet{}, err
+	}
+	if resolvedFingerprint != authoritativeFingerprint {
+		return resolvedPackageSet{}, fmt.Errorf("scoped reverse test target %q has fingerprint %s, outer test binary selected %s", req.TestVariantFor, resolvedFingerprint, authoritativeFingerprint)
+	}
+	selected.ExportFile = req.AuthoritativeTarget
+	overrides[req.TestVariantFor] = selected
+
+	packageFiles := make(map[string]string, len(overrides))
+	paths := make([]string, 0, len(overrides))
+	for path, resolved := range overrides {
+		packageFiles[path] = resolved.ExportFile
+		paths = append(paths, path)
+	}
+	slices.Sort(paths)
+	contractHash := sha256.New()
+	for _, path := range paths {
+		fingerprint, err := archive.CompatibilityFingerprint(packageFiles[path])
+		if err != nil {
+			return resolvedPackageSet{}, fmt.Errorf("fingerprinting authoritative reverse test dependency %q: %w", path, err)
+		}
+		_, _ = contractHash.Write([]byte(path))
+		_, _ = contractHash.Write([]byte{0})
+		_, _ = contractHash.Write([]byte(fingerprint))
+		_, _ = contractHash.Write([]byte{0})
+	}
+	// The target path and the complete injected closure identify the compiler
+	// contract consumed out-of-band by synthetic importers. Using that contract
+	// as the tool flavor isolates incompatible coverage scopes while allowing
+	// compatible reverse variants to reuse Go's cache across runs.
+	targetHash := sha256.Sum256([]byte(req.TestVariantFor))
+	flavor := hex.EncodeToString(targetHash[:8]) + "-" + hex.EncodeToString(contractHash.Sum(nil)[:16])
+	config.Env = append(config.Env, envVarResolvingTestVariants+"=1")
+	cleanup, err := addReverseVariantEnvironment(&config, req.TempDir, flavor, packageFiles)
+	if err != nil {
+		return resolvedPackageSet{}, err
+	}
+	defer cleanup()
+
+	config.Tests = true
+	config.Mode = packages.NeedName | packages.NeedCompiledGoFiles | packages.NeedImports |
+		packages.NeedDeps | packages.NeedExportFile | packages.NeedForTest
+	loaded, err := packages.Load(&config, req.TestVariantFor)
+	if err != nil {
+		return resolvedPackageSet{}, fmt.Errorf("loading reverse test variants for %q: %w", req.TestVariantFor, err)
+	}
+	if err := packageErrors(loaded); err != nil {
+		return resolvedPackageSet{}, fmt.Errorf("constructing reverse test variant for synthetic importer %q of %q: %w", req.Pattern, req.TestVariantFor, err)
+	}
+	all := collectPackages(loaded)
+	root := findTestVariant(all, req.Pattern, req.TestVariantFor)
+	if root == nil {
+		// The synthetic importer may itself be a link dependency that is absent
+		// from the package-under-test graph. Build that root in the same flavored
+		// universe; the generated test main will import the rebuilt root directly.
+		config.Tests = false
+		standalone, err := packages.Load(&config, req.Pattern)
+		if err != nil {
+			return resolvedPackageSet{}, fmt.Errorf("loading standalone reverse test variant %q for %q: %w", req.Pattern, req.TestVariantFor, err)
+		}
+		if err := packageErrors(standalone); err != nil {
+			return resolvedPackageSet{}, fmt.Errorf("constructing standalone reverse test variant %q for %q: %w", req.Pattern, req.TestVariantFor, err)
+		}
+		root = findPackage(collectPackages(standalone), req.Pattern)
+		if root == nil {
+			return resolvedPackageSet{}, fmt.Errorf("Go did not produce reverse test variant %q for %q", req.Pattern, req.TestVariantFor)
+		}
+	}
+
+	resp := make(ResolveResponse)
+	if err := collectReverseVariantClosure(config.Context, resp, root, req.TestVariantFor, make(map[string]bool)); err != nil {
+		return resolvedPackageSet{}, err
+	}
+	delete(resp, req.TestVariantFor)
+	return resolvedPackageSet{response: resp}, nil
+}
+
+func collectReverseVariantClosure(ctx context.Context, resp ResolveResponse, pkg *packages.Package, target string, visited map[string]bool) error {
+	if pkg == nil || visited[pkg.ID] || pkg.PkgPath == target {
+		return nil
+	}
+	visited[pkg.ID] = true
+	if pkg.PkgPath != "" && pkg.PkgPath != "unsafe" {
+		if pkg.ExportFile == "" {
+			return fmt.Errorf("Go did not produce an export archive for reverse test variant %q (%s) of %q", pkg.PkgPath, pkg.ID, target)
+		}
+		resp[pkg.PkgPath] = ResolvedArchive{ExportFile: pkg.ExportFile, ForTest: target}
+	}
+	for _, imported := range pkg.Imports {
+		if err := collectReverseVariantClosure(ctx, resp, imported, target, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addReverseVariantEnvironment(config *packages.Config, tempDir string, flavor string, packageFiles map[string]string) (func(), error) {
+	dir, err := os.MkdirTemp(tempDir, "orchestrion-reverse-variant-")
+	if err != nil {
+		return nil, fmt.Errorf("creating reverse test variant environment: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	path := filepath.Join(dir, "environment.json")
+	file, err := os.Create(path)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("creating reverse test variant environment: %w", err)
+	}
+	value := reverseVariantEnvironment{Flavor: flavor, PackageFiles: packageFiles}
+	if err := json.NewEncoder(file).Encode(value); err != nil {
+		_ = file.Close()
+		cleanup()
+		return nil, fmt.Errorf("writing reverse test variant environment: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("closing reverse test variant environment: %w", err)
+	}
+	config.Env = append(config.Env,
+		envVarReverseVariant+"="+path,
+		envVarReverseVariantFlavor+"="+flavor,
+	)
+	return cleanup, nil
+}

--- a/internal/jobserver/pkgs/reversevariants_test.go
+++ b/internal/jobserver/pkgs/reversevariants_test.go
@@ -1,0 +1,177 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package pkgs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+func TestReverseVariantEnvironment(t *testing.T) {
+	t.Setenv(envVarReverseVariant, "")
+	t.Setenv(envVarReverseVariantFlavor, "")
+
+	flavor, packageFiles, active, err := ReverseVariantEnvironment()
+	require.NoError(t, err)
+	assert.False(t, active)
+	assert.Empty(t, flavor)
+	assert.Nil(t, packageFiles)
+
+	path := filepath.Join(t.TempDir(), "environment.json")
+	t.Setenv(envVarReverseVariant, path)
+	_, _, active, err = ReverseVariantEnvironment()
+	assert.True(t, active)
+	require.ErrorContains(t, err, "reading reverse test variant environment")
+
+	tests := []struct {
+		name          string
+		contents      string
+		processFlavor string
+		wantError     string
+	}{
+		{name: "invalid JSON", contents: "{", wantError: "parsing reverse test variant environment"},
+		{name: "missing flavor", contents: `{"packageFiles":{"example.com/root":"/root.a"}}`, wantError: "has no flavor"},
+		{name: "flavor mismatch", contents: `{"flavor":"expected","packageFiles":{"example.com/root":"/root.a"}}`, processFlavor: "actual", wantError: `has flavor "expected", process declares "actual"`},
+		{name: "missing package files", contents: `{"flavor":"expected"}`, processFlavor: "expected", wantError: "has no package files"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, os.WriteFile(path, []byte(tt.contents), 0o644))
+			t.Setenv(envVarReverseVariantFlavor, tt.processFlavor)
+			_, _, active, err := ReverseVariantEnvironment()
+			assert.True(t, active)
+			require.ErrorContains(t, err, tt.wantError)
+		})
+	}
+
+	require.NoError(t, os.WriteFile(path, []byte(`{"flavor":"expected","packageFiles":{"example.com/root":"/root.a"}}`), 0o644))
+	t.Setenv(envVarReverseVariantFlavor, "expected")
+	flavor, packageFiles, active, err = ReverseVariantEnvironment()
+	require.NoError(t, err)
+	assert.True(t, active)
+	assert.Equal(t, "expected", flavor)
+	assert.Equal(t, map[string]string{"example.com/root": "/root.a"}, packageFiles)
+}
+
+func TestAddReverseVariantEnvironment(t *testing.T) {
+	config := packages.Config{Env: []string{"EXISTING=value"}}
+	packageFiles := map[string]string{"example.com/root": "/root.a"}
+	cleanup, err := addReverseVariantEnvironment(&config, t.TempDir(), "flavor", packageFiles)
+	require.NoError(t, err)
+	require.Len(t, config.Env, 3)
+	assert.Equal(t, envVarReverseVariantFlavor+"=flavor", config.Env[2])
+
+	path, found := strings.CutPrefix(config.Env[1], envVarReverseVariant+"=")
+	require.True(t, found)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var environment reverseVariantEnvironment
+	require.NoError(t, json.Unmarshal(data, &environment))
+	assert.Equal(t, reverseVariantEnvironment{Flavor: "flavor", PackageFiles: packageFiles}, environment)
+
+	cleanup()
+	_, err = os.Stat(filepath.Dir(path))
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	invalidParent := filepath.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(invalidParent, nil, 0o644))
+	_, err = addReverseVariantEnvironment(&packages.Config{}, invalidParent, "flavor", packageFiles)
+	require.ErrorContains(t, err, "creating reverse test variant environment")
+}
+
+func TestCollectReverseVariantClosure(t *testing.T) {
+	const target = "example.com/subject"
+	subject := &packages.Package{ID: target, PkgPath: target, ExportFile: "/subject.a"}
+	unsafe := &packages.Package{ID: "unsafe", PkgPath: "unsafe"}
+	middle := &packages.Package{
+		ID:         "example.com/middle",
+		PkgPath:    "example.com/middle",
+		ExportFile: "/middle.a",
+		Imports:    map[string]*packages.Package{target: subject, "unsafe": unsafe},
+	}
+	root := &packages.Package{
+		ID:         "example.com/root",
+		PkgPath:    "example.com/root",
+		ExportFile: "/root.a",
+		Imports:    map[string]*packages.Package{middle.PkgPath: middle},
+	}
+	resp := make(ResolveResponse)
+	require.NoError(t, collectReverseVariantClosure(context.Background(), resp, root, target, make(map[string]bool)))
+	assert.Equal(t, ResolvedArchive{ExportFile: "/root.a", ForTest: target}, resp[root.PkgPath])
+	assert.Equal(t, ResolvedArchive{ExportFile: "/middle.a", ForTest: target}, resp[middle.PkgPath])
+	assert.NotContains(t, resp, target)
+	assert.NotContains(t, resp, "unsafe")
+
+	missing := &packages.Package{ID: "example.com/missing", PkgPath: "example.com/missing"}
+	err := collectReverseVariantClosure(context.Background(), make(ResolveResponse), missing, target, make(map[string]bool))
+	require.ErrorContains(t, err, "did not produce an export archive")
+
+	visited := map[string]bool{missing.ID: true}
+	shortCircuited := make(ResolveResponse)
+	require.NoError(t, collectReverseVariantClosure(context.Background(), shortCircuited, missing, target, visited))
+	assert.Empty(t, shortCircuited)
+
+	shortCircuited = make(ResolveResponse)
+	require.NoError(t, collectReverseVariantClosure(context.Background(), shortCircuited, nil, target, make(map[string]bool)))
+	assert.Empty(t, shortCircuited)
+}
+
+func TestResolveReverseTestVariantRejectsIncompleteRequest(t *testing.T) {
+	_, err := (&service{}).resolveReverseTestVariant(context.Background(), &ResolveRequest{Pattern: "example.com/root"}, zerolog.Nop())
+	require.ErrorContains(t, err, "incomplete reverse test variant request")
+}
+
+func TestBuildReverseTestVariantStandaloneRoot(t *testing.T) {
+	const (
+		module = "example.com/reverse"
+		target = module + "/target"
+		root   = module + "/root"
+	)
+	dir := t.TempDir()
+	writeFile := func(name string, contents string) {
+		t.Helper()
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	}
+	writeFile("go.mod", "module "+module+"\n\ngo 1.25.0\n")
+	writeFile("target/target.go", "package target\n\nconst Value = 42\n")
+	writeFile("target/target_test.go", "package target_test\n\nimport (\"testing\"; \"example.com/reverse/target\")\n\nfunc TestValue(t *testing.T) { if target.Value != 42 { t.Fail() } }\n")
+	writeFile("root/root.go", "package root\n\nimport \"example.com/reverse/target\"\n\nconst Value = target.Value\n")
+
+	config := packages.Config{
+		Dir: dir,
+		Env: append(os.Environ(), "GOWORK=off", "GOFLAGS="),
+		Mode: packages.NeedName | packages.NeedImports | packages.NeedDeps |
+			packages.NeedExportFile | packages.NeedForTest,
+	}
+	loaded, err := packages.Load(&config, target)
+	require.NoError(t, err)
+	require.NoError(t, packageErrors(loaded))
+	selected := findPackage(collectPackages(loaded), target)
+	require.NotNil(t, selected)
+	require.NotEmpty(t, selected.ExportFile)
+
+	result, err := buildReverseTestVariant(&ResolveRequest{
+		Pattern:             root,
+		TestVariantFor:      target,
+		AuthoritativeTarget: selected.ExportFile,
+		TempDir:             t.TempDir(),
+	}, config)
+	require.NoError(t, err)
+	assert.Equal(t, target, result.response[root].ForTest)
+	assert.NotEmpty(t, result.response[root].ExportFile)
+	assert.NotContains(t, result.response, target)
+}

--- a/internal/jobserver/pkgs/testvariants.go
+++ b/internal/jobserver/pkgs/testvariants.go
@@ -141,7 +141,8 @@ func mergeTestVariant(
 // into the outer importcfg, whose package-under-test archive remains authoritative.
 func resolveTestTargetProvenance(ctx context.Context, req *ResolveRequest, resp ResolveResponse, config packages.Config) (ResolveResponse, error) {
 	config.Context = ctx
-	config.Mode = packages.NeedName | packages.NeedImports | packages.NeedDeps | packages.NeedForTest
+	config.Mode = packages.NeedName | packages.NeedImports | packages.NeedDeps |
+		packages.NeedExportFile | packages.NeedForTest
 	config.Env = append(slices.Clone(config.Env), envVarResolvingTestVariants+"=1")
 	config.Tests = true
 	loaded, err := packages.Load(&config, req.TestVariantFor)
@@ -151,7 +152,22 @@ func resolveTestTargetProvenance(ctx context.Context, req *ResolveRequest, resp 
 	if err := packageErrors(loaded); err != nil {
 		return nil, fmt.Errorf("loading test target provenance for %q: %w", req.TestVariantFor, err)
 	}
-	variant := findTestVariant(collectPackages(loaded), req.TestVariantFor, req.TestVariantFor)
+	all := collectPackages(loaded)
+	variant := findTestVariant(all, req.TestVariantFor, req.TestVariantFor)
+	if variant == nil && buildFlagsHaveCoverage(config.BuildFlags) {
+		// External-only tests do not create a same-package test variant in a
+		// packages.Load test graph. Implicit coverage can nevertheless make the
+		// archive selected by this test binary differ from the ordinary archive.
+		// Compare the scoped load with the ordinary resolution so callers reject
+		// or reconstruct fingerprint-bearing synthetic importers as appropriate.
+		variant = findPackage(all, req.TestVariantFor)
+		if variant == nil || variant.ExportFile == "" {
+			return nil, fmt.Errorf("Go did not produce an export archive for covered test target %q", req.TestVariantFor)
+		}
+		if variant.ExportFile == resp[req.TestVariantFor].ExportFile {
+			return resp, nil
+		}
+	}
 	if variant == nil {
 		return resp, nil
 	}
@@ -284,6 +300,15 @@ func collectPackages(roots []*packages.Package) []*packages.Package {
 		visit(root)
 	}
 	return result
+}
+
+func findPackage(pkgs []*packages.Package, pkgPath string) *packages.Package {
+	for _, pkg := range pkgs {
+		if pkg.PkgPath == pkgPath && pkg.ForTest == "" {
+			return pkg
+		}
+	}
+	return nil
 }
 
 func findTestVariant(pkgs []*packages.Package, pkgPath string, forTest string) *packages.Package {

--- a/internal/jobserver/pkgs/testvariants_test.go
+++ b/internal/jobserver/pkgs/testvariants_test.go
@@ -6,6 +6,7 @@
 package pkgs
 
 import (
+	"context"
 	"crypto/sha256"
 	"path/filepath"
 	"testing"
@@ -50,6 +51,19 @@ func TestResolveRequestTestVariantHash(t *testing.T) {
 	assert.NotEqual(t, variantHash, changedHash)
 }
 
+func TestResolveRequestReverseVariantSpanTag(t *testing.T) {
+	tags := make(map[string]any)
+	ResolveRequest{
+		Dir:                "/module",
+		Pattern:            "example.com/root",
+		TestVariantFor:     "example.com/subject",
+		ReverseTestVariant: true,
+	}.ForeachSpanTag(func(key string, value any) {
+		tags[key] = value
+	})
+	assert.Equal(t, true, tags["request.reverse-test-variant"])
+}
+
 func TestResolveRequestReverseVariantHash(t *testing.T) {
 	first := ResolveRequest{
 		Dir:     "/module",
@@ -68,12 +82,23 @@ func TestResolveRequestReverseVariantHash(t *testing.T) {
 	assert.Equal(t, firstHash, secondHash)
 	assert.Equal(t, "/tmp/first.json", first.reverseVariantPath)
 	assert.Equal(t, "flavor", first.ReverseVariantFlavor)
+	assert.ElementsMatch(t, []string{
+		envVarReverseVariant + "=/tmp/first.json",
+		envVarReverseVariantFlavor + "=flavor",
+	}, resolveEnvironment(context.Background(), &first))
 
 	second.Env = []string{envVarReverseVariant + "=/tmp/second.json", envVarReverseVariantFlavor + "=other"}
 	second.canonical = false
 	secondHash, err = second.hash()
 	require.NoError(t, err)
 	assert.NotEqual(t, firstHash, secondHash)
+}
+
+func TestFindPackage(t *testing.T) {
+	ordinary := &packages.Package{ID: "ordinary", PkgPath: "example.com/subject"}
+	variant := &packages.Package{ID: "variant", PkgPath: "example.com/subject", ForTest: "example.com/subject"}
+	assert.Same(t, ordinary, findPackage([]*packages.Package{variant, ordinary}, "example.com/subject"))
+	assert.Nil(t, findPackage([]*packages.Package{variant}, "example.com/subject"))
 }
 
 func TestPackageSourceDirUsesOtherFiles(t *testing.T) {

--- a/internal/jobserver/pkgs/testvariants_test.go
+++ b/internal/jobserver/pkgs/testvariants_test.go
@@ -50,6 +50,32 @@ func TestResolveRequestTestVariantHash(t *testing.T) {
 	assert.NotEqual(t, variantHash, changedHash)
 }
 
+func TestResolveRequestReverseVariantHash(t *testing.T) {
+	first := ResolveRequest{
+		Dir:     "/module",
+		Env:     []string{envVarReverseVariant + "=/tmp/first.json", envVarReverseVariantFlavor + "=flavor"},
+		Pattern: "example.com/dependency",
+	}
+	second := ResolveRequest{
+		Dir:     "/module",
+		Env:     []string{envVarReverseVariant + "=/tmp/second.json", envVarReverseVariantFlavor + "=flavor"},
+		Pattern: "example.com/dependency",
+	}
+	firstHash, err := first.hash()
+	require.NoError(t, err)
+	secondHash, err := second.hash()
+	require.NoError(t, err)
+	assert.Equal(t, firstHash, secondHash)
+	assert.Equal(t, "/tmp/first.json", first.reverseVariantPath)
+	assert.Equal(t, "flavor", first.ReverseVariantFlavor)
+
+	second.Env = []string{envVarReverseVariant + "=/tmp/second.json", envVarReverseVariantFlavor + "=other"}
+	second.canonical = false
+	secondHash, err = second.hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, firstHash, secondHash)
+}
+
 func TestPackageSourceDirUsesOtherFiles(t *testing.T) {
 	pkg := &packages.Package{OtherFiles: []string{filepath.Join("module", "subject", "subject.swig")}}
 	assert.Equal(t, filepath.Join("module", "subject"), packageSourceDir(pkg))

--- a/internal/toolexec/archive/fingerprint.go
+++ b/internal/toolexec/archive/fingerprint.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package archive reads metadata from Go object archives.
+package archive
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/blakesmith/ar"
+)
+
+// ErrNoFingerprint reports an archive without compiler export-data identity.
+var ErrNoFingerprint = errors.New("Go archive has no object fingerprint")
+
+const (
+	goObjectMagic      = "\x00go120ld"
+	fingerprintSize    = 8
+	objectHeaderPrefix = 4 << 10
+)
+
+// CompatibilityFingerprint returns Fingerprint, or "none" for an archive
+// without compiler export data and therefore without a linker compatibility identity.
+func CompatibilityFingerprint(filename string) (string, error) {
+	fingerprint, err := Fingerprint(filename)
+	if errors.Is(err, ErrNoFingerprint) {
+		return "none", nil
+	}
+	return fingerprint, err
+}
+
+// Fingerprint returns the compiler export-data fingerprint stored in a Go
+// archive. Go uses this value to validate every compiler-import edge at link
+// time, so equal fingerprints are the compatibility identity needed by test
+// variant reconstruction.
+func Fingerprint(filename string) (string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", fmt.Errorf("opening Go archive %q: %w", filename, err)
+	}
+	defer file.Close()
+
+	rd := ar.NewReader(file)
+	for {
+		hdr, err := rd.Next()
+		if errors.Is(err, io.EOF) {
+			return "", fmt.Errorf("%w: %q", ErrNoFingerprint, filename)
+		}
+		if err != nil {
+			return "", fmt.Errorf("reading Go archive %q: %w", filename, err)
+		}
+		if hdr.Name != "__.PKGDEF" && hdr.Name != "_go_.o" {
+			continue
+		}
+		data, err := io.ReadAll(io.LimitReader(rd, objectHeaderPrefix))
+		if err != nil {
+			return "", fmt.Errorf("reading Go object %q in %q: %w", hdr.Name, filename, err)
+		}
+		index := bytes.Index(data, []byte(goObjectMagic))
+		if index < 0 || len(data) < index+len(goObjectMagic)+fingerprintSize {
+			continue
+		}
+		fingerprint := data[index+len(goObjectMagic) : index+len(goObjectMagic)+fingerprintSize]
+		return hex.EncodeToString(fingerprint), nil
+	}
+}

--- a/internal/toolexec/archive/fingerprint.go
+++ b/internal/toolexec/archive/fingerprint.go
@@ -56,7 +56,7 @@ func Fingerprint(filename string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("reading Go archive %q: %w", filename, err)
 		}
-		if hdr.Name != "__.PKGDEF" && hdr.Name != "_go_.o" {
+		if hdr.Name != "_go_.o" {
 			continue
 		}
 		data, err := io.ReadAll(io.LimitReader(rd, objectHeaderPrefix))

--- a/internal/toolexec/archive/fingerprint.go
+++ b/internal/toolexec/archive/fingerprint.go
@@ -7,7 +7,7 @@
 package archive
 
 import (
-	"bytes"
+	"bufio"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -20,10 +20,12 @@ import (
 // ErrNoFingerprint reports an archive without compiler export-data identity.
 var ErrNoFingerprint = errors.New("Go archive has no object fingerprint")
 
+var errMalformedGoObject = errors.New("malformed Go object header")
+
 const (
-	goObjectMagic      = "\x00go120ld"
-	fingerprintSize    = 8
-	objectHeaderPrefix = 4 << 10
+	goObjectHeaderEnd = "\n!\n"
+	goObjectMagic     = "\x00go120ld"
+	fingerprintSize   = 8
 )
 
 // CompatibilityFingerprint returns Fingerprint, or "none" for an archive
@@ -59,15 +61,43 @@ func Fingerprint(filename string) (string, error) {
 		if hdr.Name != "_go_.o" {
 			continue
 		}
-		data, err := io.ReadAll(io.LimitReader(rd, objectHeaderPrefix))
+		fingerprint, err := readObjectFingerprint(io.LimitReader(rd, hdr.Size))
 		if err != nil {
 			return "", fmt.Errorf("reading Go object %q in %q: %w", hdr.Name, filename, err)
 		}
-		index := bytes.Index(data, []byte(goObjectMagic))
-		if index < 0 || len(data) < index+len(goObjectMagic)+fingerprintSize {
-			continue
-		}
-		fingerprint := data[index+len(goObjectMagic) : index+len(goObjectMagic)+fingerprintSize]
-		return hex.EncodeToString(fingerprint), nil
+		return fingerprint, nil
 	}
+}
+
+// readObjectFingerprint scans the variable-length textual header of a _go_.o
+// linker object, which ends in "\n!\n", then reads the binary object magic and
+// fingerprint that immediately follow it.
+func readObjectFingerprint(r io.Reader) (string, error) {
+	rd := bufio.NewReader(r)
+	var first, second, third byte
+	for {
+		value, err := rd.ReadByte()
+		if errors.Is(err, io.EOF) {
+			return "", fmt.Errorf("%w: missing textual header terminator", errMalformedGoObject)
+		}
+		if err != nil {
+			return "", err
+		}
+		first, second, third = second, third, value
+		if first == goObjectHeaderEnd[0] && second == goObjectHeaderEnd[1] && third == goObjectHeaderEnd[2] {
+			break
+		}
+	}
+
+	var header [len(goObjectMagic) + fingerprintSize]byte
+	if _, err := io.ReadFull(rd, header[:]); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return "", fmt.Errorf("%w: truncated binary header", errMalformedGoObject)
+		}
+		return "", err
+	}
+	if string(header[:len(goObjectMagic)]) != goObjectMagic {
+		return "", fmt.Errorf("%w: unexpected object magic", errMalformedGoObject)
+	}
+	return hex.EncodeToString(header[len(goObjectMagic):]), nil
 }

--- a/internal/toolexec/archive/fingerprint_test.go
+++ b/internal/toolexec/archive/fingerprint_test.go
@@ -7,7 +7,9 @@ package archive
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/blakesmith/ar"
@@ -27,7 +29,7 @@ func TestFingerprint(t *testing.T) {
 	_, err = writer.Write(packageDefinition)
 	require.NoError(t, err)
 
-	object := []byte("go object header\n\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xeftrailing data")
+	object := []byte("go object header\n!\n\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xeftrailing data")
 	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(object))}))
 	_, err = writer.Write(object)
 	require.NoError(t, err)
@@ -38,22 +40,33 @@ func TestFingerprint(t *testing.T) {
 	assert.Equal(t, "0123456789abcdef", fingerprint)
 }
 
+func TestFingerprintWithLongBuildID(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "subject.go")
+	require.NoError(t, os.WriteFile(source, []byte("package subject\nconst Value = 42\n"), 0o644))
+	compile := func(name string, buildID string) string {
+		t.Helper()
+		archive := filepath.Join(dir, name)
+		cmd := exec.Command("go", "tool", "compile", "-pack", "-buildid="+buildID, "-o", archive, source)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(output))
+		return archive
+	}
+
+	shortFingerprint, err := Fingerprint(compile("short.a", "short"))
+	require.NoError(t, err)
+	longFingerprint, err := Fingerprint(compile("long.a", strings.Repeat("x", 5_000)))
+	require.NoError(t, err)
+	assert.Equal(t, shortFingerprint, longFingerprint)
+	assert.NotEqual(t, strings.Repeat("0", fingerprintSize*2), longFingerprint)
+}
+
 func TestFingerprintErrors(t *testing.T) {
 	fingerprint, err := Fingerprint(filepath.Join(t.TempDir(), "missing.a"))
 	assert.Empty(t, fingerprint)
 	require.ErrorContains(t, err, "opening Go archive")
 
-	path := filepath.Join(t.TempDir(), "subject.a")
-	file, err := os.Create(path)
-	require.NoError(t, err)
-	writer := ar.NewWriter(file)
-	require.NoError(t, writer.WriteGlobalHeader())
-	object := []byte("go object header\n\x00go120ld\x01\x23")
-	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(object))}))
-	_, err = writer.Write(object)
-	require.NoError(t, err)
-	require.NoError(t, file.Close())
-
+	path := writeArchiveEntry(t, "__.PKGDEF", []byte("package definition"))
 	fingerprint, err = Fingerprint(path)
 	assert.Empty(t, fingerprint)
 	require.ErrorIs(t, err, ErrNoFingerprint)
@@ -61,4 +74,58 @@ func TestFingerprintErrors(t *testing.T) {
 	fingerprint, err = CompatibilityFingerprint(path)
 	require.NoError(t, err)
 	assert.Equal(t, "none", fingerprint)
+}
+
+func TestFingerprintRejectsMalformedGoObject(t *testing.T) {
+	tests := []struct {
+		name   string
+		object []byte
+	}{
+		{name: "missing header terminator", object: []byte("go object header")},
+		{name: "truncated binary header", object: []byte("go object header\n!\n\x00go120ld\x01\x23")},
+		{name: "unexpected object magic", object: []byte("go object header\n!\nnotmagic\x01\x23\x45\x67\x89\xab\xcd\xef")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeArchiveEntry(t, "_go_.o", tt.object)
+			_, err := Fingerprint(path)
+			require.ErrorIs(t, err, errMalformedGoObject)
+			_, err = CompatibilityFingerprint(path)
+			require.ErrorIs(t, err, errMalformedGoObject)
+		})
+	}
+}
+
+func TestFingerprintDoesNotScanFollowingArchiveMembers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "subject.a")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteGlobalHeader())
+	first := []byte("go object header without terminator")
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(first))}))
+	_, err = writer.Write(first)
+	require.NoError(t, err)
+	second := []byte("\n!\n\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xef")
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "second.o", Mode: 0o644, Size: int64(len(second))}))
+	_, err = writer.Write(second)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	_, err = Fingerprint(path)
+	require.ErrorIs(t, err, errMalformedGoObject)
+}
+
+func writeArchiveEntry(t *testing.T, name string, contents []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "subject.a")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteGlobalHeader())
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: name, Mode: 0o644, Size: int64(len(contents))}))
+	_, err = writer.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	return path
 }

--- a/internal/toolexec/archive/fingerprint_test.go
+++ b/internal/toolexec/archive/fingerprint_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package archive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blakesmith/ar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFingerprint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "subject.a")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	_, err = file.WriteString("!<arch>\n")
+	require.NoError(t, err)
+	writer := ar.NewWriter(file)
+	contents := []byte("go object header\n\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xeftrailing data")
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "__.PKGDEF", Mode: 0o644, Size: int64(len(contents))}))
+	_, err = writer.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	fingerprint, err := Fingerprint(path)
+	require.NoError(t, err)
+	assert.Equal(t, "0123456789abcdef", fingerprint)
+}

--- a/internal/toolexec/archive/fingerprint_test.go
+++ b/internal/toolexec/archive/fingerprint_test.go
@@ -22,9 +22,14 @@ func TestFingerprint(t *testing.T) {
 	_, err = file.WriteString("!<arch>\n")
 	require.NoError(t, err)
 	writer := ar.NewWriter(file)
-	contents := []byte("go object header\n\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xeftrailing data")
-	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "__.PKGDEF", Mode: 0o644, Size: int64(len(contents))}))
-	_, err = writer.Write(contents)
+	packageDefinition := []byte("exported string constant: \x00go120ldpoisoned")
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "__.PKGDEF", Mode: 0o644, Size: int64(len(packageDefinition))}))
+	_, err = writer.Write(packageDefinition)
+	require.NoError(t, err)
+
+	object := []byte("go object header\n\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xeftrailing data")
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(object))}))
+	_, err = writer.Write(object)
 	require.NoError(t, err)
 	require.NoError(t, file.Close())
 

--- a/internal/toolexec/archive/fingerprint_test.go
+++ b/internal/toolexec/archive/fingerprint_test.go
@@ -37,3 +37,28 @@ func TestFingerprint(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "0123456789abcdef", fingerprint)
 }
+
+func TestFingerprintErrors(t *testing.T) {
+	fingerprint, err := Fingerprint(filepath.Join(t.TempDir(), "missing.a"))
+	assert.Empty(t, fingerprint)
+	require.ErrorContains(t, err, "opening Go archive")
+
+	path := filepath.Join(t.TempDir(), "subject.a")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteGlobalHeader())
+	object := []byte("go object header\n\x00go120ld\x01\x23")
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(object))}))
+	_, err = writer.Write(object)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	fingerprint, err = Fingerprint(path)
+	assert.Empty(t, fingerprint)
+	require.ErrorIs(t, err, ErrNoFingerprint)
+
+	fingerprint, err = CompatibilityFingerprint(path)
+	require.NoError(t, err)
+	assert.Equal(t, "none", fingerprint)
+}

--- a/internal/toolexec/aspect/linkdeps/linkdeps.go
+++ b/internal/toolexec/aspect/linkdeps/linkdeps.go
@@ -65,11 +65,14 @@ func FromImportConfig(ctx context.Context, importcfg *importcfg.ImportConfig) (L
 		}
 
 		for dep, kind := range ld.deps {
-			if _, satisfied := importcfg.PackageFile[dep]; satisfied {
-				// This transitive link-time dependency is already satisfied at
-				// compile-time, so we don't need to carry it over.
+			if _, satisfied := importcfg.PackageFile[dep]; satisfied && kind == RelocationDependency {
+				// Satisfied relocation dependencies need no further link-time work.
 				continue
 			}
+			// Preserve compiler-import dependencies even when this package already
+			// satisfies them naturally. Test-main compilation needs this provenance
+			// to detect when a transitive synthetic importer was built against the
+			// ordinary package but the test binary selects a different variant.
 			res.Add(dep, kind)
 		}
 	}

--- a/internal/toolexec/aspect/linkdeps/linkdeps_test.go
+++ b/internal/toolexec/aspect/linkdeps/linkdeps_test.go
@@ -7,9 +7,13 @@ package linkdeps
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
+	"github.com/blakesmith/ar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +43,33 @@ func TestV1HeaderWithoutNewline(t *testing.T) {
 	decoded, err := Read(strings.NewReader("#link.deps@v1"))
 	require.NoError(t, err)
 	assert.True(t, decoded.Empty())
+}
+
+func TestFromImportConfigPreservesSatisfiedImports(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dependency.a")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	_, err = file.WriteString("!<arch>\n")
+	require.NoError(t, err)
+	var metadata LinkDeps
+	metadata.Add("example.com/import", ImportDependency)
+	metadata.Add("example.com/relocation", RelocationDependency)
+	var contents bytes.Buffer
+	require.NoError(t, metadata.Write(&contents))
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: Filename, Mode: 0o644, Size: int64(contents.Len())}))
+	_, err = writer.Write(contents.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	deps, err := FromImportConfig(t.Context(), &importcfg.ImportConfig{PackageFile: map[string]string{
+		"example.com/parent":     path,
+		"example.com/import":     path,
+		"example.com/relocation": path,
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, ImportDependency, deps.Kind("example.com/import"))
+	assert.False(t, deps.Contains("example.com/relocation"))
 }
 
 func TestImportDependencyWins(t *testing.T) {

--- a/internal/toolexec/aspect/oncompile-main.go
+++ b/internal/toolexec/aspect/oncompile-main.go
@@ -298,18 +298,6 @@ func resolveReverseTestVariants(
 	if testVariantFor == "" {
 		return nil, nil, nil
 	}
-	selected, err := resolveTestTargetProvenance()
-	if err != nil {
-		return nil, nil, fmt.Errorf("resolving test target provenance for %q: %w", testVariantFor, err)
-	}
-	if selected.ForTest != testVariantFor {
-		return nil, nil, nil
-	}
-	authoritative := reg.PackageFile[testVariantFor]
-	if authoritative == "" {
-		return nil, nil, fmt.Errorf("test-main import configuration is missing the authoritative package-under-test archive %q", testVariantFor)
-	}
-
 	parents := make([]string, 0, len(reg.PackageFile))
 	for parent := range reg.PackageFile {
 		parents = append(parents, parent)
@@ -317,6 +305,7 @@ func resolveReverseTestVariants(
 	sort.Strings(parents)
 	result := make(map[string]string)
 	var roots []string
+	var selected *pkgs.ResolvedArchive
 	for _, parent := range parents {
 		if parent == testVariantFor {
 			continue
@@ -328,6 +317,20 @@ func resolveReverseTestVariants(
 		}
 		if !deps.Contains(testVariantFor) || deps.Kind(testVariantFor) != linkdeps.ImportDependency {
 			continue
+		}
+		if selected == nil {
+			resolved, err := resolveTestTargetProvenance()
+			if err != nil {
+				return nil, nil, fmt.Errorf("resolving test target provenance for %q: %w", testVariantFor, err)
+			}
+			selected = &resolved
+		}
+		if selected.ForTest != testVariantFor {
+			return nil, nil, nil
+		}
+		authoritative := reg.PackageFile[testVariantFor]
+		if authoritative == "" {
+			return nil, nil, fmt.Errorf("test-main import configuration is missing the authoritative package-under-test archive %q", testVariantFor)
 		}
 		variants, err := resolveReversePackageFilesForTest(ctx, parent, testVariantFor, authoritative, workDir)
 		if err != nil {

--- a/internal/toolexec/aspect/oncompile-main.go
+++ b/internal/toolexec/aspect/oncompile-main.go
@@ -83,11 +83,24 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 	}
 
 	resolveTestTargetProvenance := newTestTargetProvenanceResolver(ctx, testVariantFor, cmd.WorkDir)
-	stack, err := initialLinkDependencies(ctx, &reg, testVariantFor, resolveTestTargetProvenance)
+	reversePackageFiles, reverseRoots, err := resolveReverseTestVariants(ctx, &reg, testVariantFor, cmd.WorkDir, resolveTestTargetProvenance)
+	if err != nil {
+		return err
+	}
+	if len(reversePackageFiles) > 0 {
+		cmd.SetTestMainPackageFiles(reversePackageFiles)
+	}
+	for _, root := range reverseRoots {
+		cmd.AddTestMainReverseRoot(root)
+	}
+	stack, err := initialLinkDependencies(ctx, &reg, testVariantFor, resolveTestTargetProvenance, reversePackageFiles)
 	if err != nil {
 		return fmt.Errorf("reading %s closure from %s: %w", linkdeps.Filename, cmd.Flags.ImportCfg, err)
 	}
 	if len(stack) == 0 {
+		if len(reversePackageFiles) > 0 {
+			return writeMainImportConfig(log, &reg, cmd.Flags.ImportCfg)
+		}
 		return nil
 	}
 
@@ -112,13 +125,35 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 		if err != nil {
 			return fmt.Errorf("resolving %q: %w", item.path, err)
 		}
+		requiresReverse, err := resolvedClosureImportsTarget(ctx, deps, testVariantFor)
+		if err != nil {
+			return fmt.Errorf("checking resolved closure for %q: %w", item.path, err)
+		}
+		if testVariantFor != "" && requiresReverse {
+			variants, err := resolveReversePackageFilesForTest(ctx, item.path, testVariantFor, reg.PackageFile[testVariantFor], cmd.WorkDir)
+			if err != nil {
+				return fmt.Errorf("rebuilding synthetic importer %q for tests of %q: %w", item.path, testVariantFor, err)
+			}
+			deps = variants
+			if reversePackageFiles == nil {
+				reversePackageFiles = make(map[string]string)
+				cmd.SetTestMainPackageFiles(reversePackageFiles)
+			}
+			for path, archive := range variants {
+				reversePackageFiles[path] = archive.ExportFile
+			}
+			cmd.AddTestMainReverseRoot(item.path)
+		}
 		for path, archive := range deps {
 			if current, found := processed[path]; !found || current.ForTest == "" || archive.ForTest != "" {
 				processed[path] = archive
 			}
 		}
-		if err := rejectResolvedSyntheticVariantDependency(item.parent, item.path, testVariantFor, item.kind == linkdeps.ImportDependency, deps); err != nil {
-			return err
+		parentRebuilt := reversePackageFiles[item.parent] != "" || processed[item.parent].ForTest == testVariantFor
+		if !parentRebuilt {
+			if err := rejectResolvedSyntheticVariantDependency(item.parent, item.path, testVariantFor, item.kind == linkdeps.ImportDependency, deps); err != nil {
+				return err
+			}
 		}
 		changed, err := mergeResolvedArchives(&reg, deps, testVariantFor)
 		if err != nil {
@@ -137,6 +172,9 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 			}
 			for _, tDep := range tDeps.Dependencies() {
 				kind := tDeps.Kind(tDep)
+				if tDep == testVariantFor && kind == linkdeps.ImportDependency && resolved.ForTest == testVariantFor {
+					continue
+				}
 				candidate := pendingLinkDep{path: tDep, parent: p, kind: kind}
 				if current, found := pending[tDep]; found {
 					cmd.LinkDeps.Add(tDep, candidate.kind)
@@ -144,12 +182,18 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 					continue
 				}
 				if previous, found := processed[tDep]; found {
+					if resolved.ForTest == testVariantFor {
+						continue
+					}
 					if err := rejectSyntheticVariantDependency(candidate.parent, candidate.path, testVariantFor, candidate.kind == linkdeps.ImportDependency, previous); err != nil {
 						return err
 					}
 					continue
 				}
 				if reg.PackageFile[tDep] != "" {
+					if resolved.ForTest == testVariantFor {
+						continue
+					}
 					if tDep == testVariantFor && kind == linkdeps.ImportDependency {
 						selected, err := resolveTestTargetProvenance()
 						if err != nil {
@@ -169,17 +213,8 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 		}
 	}
 
-	// We back up the original ImportCfg file only if there's not already such a file (could have been created by OnCompile)
-	backupFile := cmd.Flags.ImportCfg + ".original"
-	if _, err := os.Stat(backupFile); errors.Is(err, os.ErrNotExist) {
-		log.Trace().Str("path", cmd.Flags.ImportCfg).Msg("Backing up original file")
-		if err := os.Rename(cmd.Flags.ImportCfg, backupFile); err != nil {
-			return fmt.Errorf("renaming %q: %w", cmd.Flags.ImportCfg, err)
-		}
-	}
-	log.Trace().Str("path", cmd.Flags.ImportCfg).Msg("Writing updated file")
-	if err := reg.WriteFile(cmd.Flags.ImportCfg); err != nil {
-		return fmt.Errorf("writing updated %q: %w", cmd.Flags.ImportCfg, err)
+	if err := writeMainImportConfig(log, &reg, cmd.Flags.ImportCfg); err != nil {
+		return err
 	}
 
 	// Generate a synthetic source file with blank imports to link-time
@@ -215,11 +250,113 @@ func (w Weaver) OnCompileMain(ctx context.Context, cmd *proxy.CompileCommand) (e
 	return nil
 }
 
+func writeMainImportConfig(log zerolog.Logger, reg *importcfg.ImportConfig, filename string) error {
+	// We back up the original ImportCfg file only if there is not already such a
+	// file; OnCompile may have created it before main-specific processing.
+	backupFile := filename + ".original"
+	if _, err := os.Stat(backupFile); errors.Is(err, os.ErrNotExist) {
+		log.Trace().Str("path", filename).Msg("Backing up original file")
+		if err := os.Rename(filename, backupFile); err != nil {
+			return fmt.Errorf("renaming %q: %w", filename, err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("checking import configuration backup %q: %w", backupFile, err)
+	}
+	log.Trace().Str("path", filename).Msg("Writing updated file")
+	if err := reg.WriteFile(filename); err != nil {
+		return fmt.Errorf("writing updated %q: %w", filename, err)
+	}
+	return nil
+}
+
+func resolvedClosureImportsTarget(ctx context.Context, archives pkgs.ResolveResponse, target string) (bool, error) {
+	if target == "" {
+		return false, nil
+	}
+	for path, resolved := range archives {
+		if resolved.ForTest == target {
+			continue
+		}
+		deps, err := linkdeps.FromArchive(ctx, resolved.ExportFile)
+		if err != nil {
+			return false, fmt.Errorf("reading %s from %s[%s]: %w", linkdeps.Filename, path, resolved.ExportFile, err)
+		}
+		if deps.Contains(target) && deps.Kind(target) == linkdeps.ImportDependency {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func resolveReverseTestVariants(
+	ctx context.Context,
+	reg *importcfg.ImportConfig,
+	testVariantFor string,
+	workDir string,
+	resolveTestTargetProvenance func() (pkgs.ResolvedArchive, error),
+) (map[string]string, []string, error) {
+	if testVariantFor == "" {
+		return nil, nil, nil
+	}
+	selected, err := resolveTestTargetProvenance()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving test target provenance for %q: %w", testVariantFor, err)
+	}
+	if selected.ForTest != testVariantFor {
+		return nil, nil, nil
+	}
+	authoritative := reg.PackageFile[testVariantFor]
+	if authoritative == "" {
+		return nil, nil, fmt.Errorf("test-main import configuration is missing the authoritative package-under-test archive %q", testVariantFor)
+	}
+
+	parents := make([]string, 0, len(reg.PackageFile))
+	for parent := range reg.PackageFile {
+		parents = append(parents, parent)
+	}
+	sort.Strings(parents)
+	result := make(map[string]string)
+	var roots []string
+	for _, parent := range parents {
+		if parent == testVariantFor {
+			continue
+		}
+		archive := reg.PackageFile[parent]
+		deps, err := linkdeps.FromArchive(ctx, archive)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading %s from %s=%s: %w", linkdeps.Filename, parent, archive, err)
+		}
+		if !deps.Contains(testVariantFor) || deps.Kind(testVariantFor) != linkdeps.ImportDependency {
+			continue
+		}
+		variants, err := resolveReversePackageFilesForTest(ctx, parent, testVariantFor, authoritative, workDir)
+		if err != nil {
+			return nil, nil, fmt.Errorf("rebuilding synthetic importer %q for tests of %q: %w", parent, testVariantFor, err)
+		}
+		if variants[parent].ForTest != testVariantFor {
+			return nil, nil, fmt.Errorf("reverse test variant resolution did not rebuild synthetic importer %q for %q", parent, testVariantFor)
+		}
+		changed, err := mergeResolvedArchives(reg, variants, testVariantFor)
+		if err != nil {
+			return nil, nil, err
+		}
+		roots = append(roots, parent)
+		for path, archive := range changed {
+			result[path] = archive
+		}
+	}
+	if len(result) == 0 {
+		return nil, nil, nil
+	}
+	return result, roots, nil
+}
+
 func initialLinkDependencies(
 	ctx context.Context,
 	reg *importcfg.ImportConfig,
 	testVariantFor string,
 	resolveTestTargetProvenance func() (pkgs.ResolvedArchive, error),
+	reversePackageFiles map[string]string,
 ) ([]pendingLinkDep, error) {
 	byPath := make(map[string]pendingLinkDep)
 	parents := make([]string, 0, len(reg.PackageFile))
@@ -240,6 +377,9 @@ func initialLinkDependencies(
 				return nil, fmt.Errorf("test-main import configuration is missing the authoritative package-under-test archive %q", testVariantFor)
 			}
 			if satisfied {
+				if path == testVariantFor && kind == linkdeps.ImportDependency && reversePackageFiles[parent] == archive {
+					continue
+				}
 				if path == testVariantFor && kind == linkdeps.ImportDependency {
 					selected, err := resolveTestTargetProvenance()
 					if err != nil {

--- a/internal/toolexec/aspect/oncompile-main_test.go
+++ b/internal/toolexec/aspect/oncompile-main_test.go
@@ -27,7 +27,7 @@ func TestInitialLinkDependenciesRetainParent(t *testing.T) {
 	deps, err := initialLinkDependencies(context.Background(), &reg, "example.com/subject", func() (pkgs.ResolvedArchive, error) {
 		t.Fatal("unexpected target provenance resolution")
 		return pkgs.ResolvedArchive{}, nil
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Len(t, deps, 1)
 	assert.Equal(t, "example.com/dependency", deps[0].path)
@@ -42,7 +42,7 @@ func TestInitialLinkDependenciesPreserveTestTargetImportParent(t *testing.T) {
 	deps, err := initialLinkDependencies(context.Background(), &reg, "example.com/subject", func() (pkgs.ResolvedArchive, error) {
 		t.Fatal("unexpected target provenance resolution")
 		return pkgs.ResolvedArchive{}, nil
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Len(t, deps, 1)
 	assert.Equal(t, "example.com/subject", deps[0].parent)
@@ -60,7 +60,7 @@ func TestInitialLinkDependenciesValidateSatisfiedTargetImport(t *testing.T) {
 	t.Run("same-package tests", func(t *testing.T) {
 		_, err := initialLinkDependencies(context.Background(), &reg, target, func() (pkgs.ResolvedArchive, error) {
 			return pkgs.ResolvedArchive{ForTest: target}, nil
-		})
+		}, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "an archive in that synthetic dependency closure was compiled without this edge")
 	})
@@ -68,7 +68,7 @@ func TestInitialLinkDependenciesValidateSatisfiedTargetImport(t *testing.T) {
 	t.Run("external tests only", func(t *testing.T) {
 		deps, err := initialLinkDependencies(context.Background(), &reg, target, func() (pkgs.ResolvedArchive, error) {
 			return pkgs.ResolvedArchive{}, nil
-		})
+		}, nil)
 		require.NoError(t, err)
 		assert.Empty(t, deps)
 	})
@@ -82,7 +82,7 @@ func TestInitialLinkDependenciesValidateSatisfiedTargetImport(t *testing.T) {
 		deps, err := initialLinkDependencies(context.Background(), &relocationReg, target, func() (pkgs.ResolvedArchive, error) {
 			t.Fatal("unexpected target provenance resolution")
 			return pkgs.ResolvedArchive{}, nil
-		})
+		}, nil)
 		require.NoError(t, err)
 		assert.Empty(t, deps)
 	})

--- a/internal/toolexec/aspect/oncompile-main_test.go
+++ b/internal/toolexec/aspect/oncompile-main_test.go
@@ -20,6 +20,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResolveReverseTestVariantsSkipsProvenanceWithoutTargetImporter(t *testing.T) {
+	const target = "example.com/subject"
+	for _, tt := range []struct {
+		name              string
+		withTargetPackage bool
+	}{
+		{name: "package under test", withTargetPackage: true},
+		{name: "external tests only"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := importcfg.ImportConfig{PackageFile: map[string]string{
+				"example.com/parent": writeLinkDepsArchive(t, "parent.a", "example.com/other", linkdeps.ImportDependency),
+			}}
+			if tt.withTargetPackage {
+				reg.PackageFile[target] = writeLinkDepsArchive(t, "subject.a", "", linkdeps.RelocationDependency)
+			}
+
+			packageFiles, roots, err := resolveReverseTestVariants(
+				context.Background(),
+				&reg,
+				target,
+				t.TempDir(),
+				func() (pkgs.ResolvedArchive, error) {
+					t.Fatal("unexpected target provenance resolution")
+					return pkgs.ResolvedArchive{}, nil
+				},
+			)
+			require.NoError(t, err)
+			assert.Empty(t, packageFiles)
+			assert.Empty(t, roots)
+		})
+	}
+}
+
 func TestInitialLinkDependenciesRetainParent(t *testing.T) {
 	archive := writeLinkDepsArchive(t, "parent.a", "example.com/dependency", linkdeps.ImportDependency)
 	reg := importcfg.ImportConfig{PackageFile: map[string]string{"example.com/parent": archive}}

--- a/internal/toolexec/aspect/oncompile-main_test.go
+++ b/internal/toolexec/aspect/oncompile-main_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/orchestrion/internal/toolexec/aspect/linkdeps"
 	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 	"github.com/blakesmith/ar"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,6 +53,52 @@ func TestResolveReverseTestVariantsSkipsProvenanceWithoutTargetImporter(t *testi
 			assert.Empty(t, roots)
 		})
 	}
+}
+
+func TestResolveReverseTestVariantsValidateProvenance(t *testing.T) {
+	const target = "example.com/subject"
+	parent := writeLinkDepsArchive(t, "parent.a", target, linkdeps.ImportDependency)
+
+	t.Run("ordinary target", func(t *testing.T) {
+		reg := importcfg.ImportConfig{PackageFile: map[string]string{
+			"example.com/parent": parent,
+			target:               writeLinkDepsArchive(t, "subject.a", "", linkdeps.RelocationDependency),
+		}}
+		packageFiles, roots, err := resolveReverseTestVariants(
+			context.Background(),
+			&reg,
+			target,
+			t.TempDir(),
+			func() (pkgs.ResolvedArchive, error) { return pkgs.ResolvedArchive{}, nil },
+		)
+		require.NoError(t, err)
+		assert.Empty(t, packageFiles)
+		assert.Empty(t, roots)
+	})
+
+	t.Run("missing authoritative target", func(t *testing.T) {
+		reg := importcfg.ImportConfig{PackageFile: map[string]string{"example.com/parent": parent}}
+		_, _, err := resolveReverseTestVariants(
+			context.Background(),
+			&reg,
+			target,
+			t.TempDir(),
+			func() (pkgs.ResolvedArchive, error) { return pkgs.ResolvedArchive{ForTest: target}, nil },
+		)
+		require.ErrorContains(t, err, "missing the authoritative package-under-test archive")
+	})
+
+	t.Run("provenance error", func(t *testing.T) {
+		reg := importcfg.ImportConfig{PackageFile: map[string]string{"example.com/parent": parent}}
+		_, _, err := resolveReverseTestVariants(
+			context.Background(),
+			&reg,
+			target,
+			t.TempDir(),
+			func() (pkgs.ResolvedArchive, error) { return pkgs.ResolvedArchive{}, assert.AnError },
+		)
+		require.ErrorIs(t, err, assert.AnError)
+	})
 }
 
 func TestInitialLinkDependenciesRetainParent(t *testing.T) {
@@ -120,6 +167,85 @@ func TestInitialLinkDependenciesValidateSatisfiedTargetImport(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, deps)
 	})
+}
+
+func TestInitialLinkDependenciesSkipRebuiltTargetImport(t *testing.T) {
+	const target = "example.com/subject"
+	archive := writeLinkDepsArchive(t, "root.a", target, linkdeps.ImportDependency)
+	reg := importcfg.ImportConfig{PackageFile: map[string]string{
+		"example.com/root": archive,
+		target:             writeLinkDepsArchive(t, "subject.a", "", linkdeps.RelocationDependency),
+	}}
+
+	deps, err := initialLinkDependencies(context.Background(), &reg, target, func() (pkgs.ResolvedArchive, error) {
+		t.Fatal("unexpected target provenance resolution")
+		return pkgs.ResolvedArchive{}, nil
+	}, map[string]string{"example.com/root": archive})
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestResolvedClosureImportsTarget(t *testing.T) {
+	const target = "example.com/subject"
+
+	importsTarget, err := resolvedClosureImportsTarget(context.Background(), nil, "")
+	require.NoError(t, err)
+	assert.False(t, importsTarget)
+
+	importArchive := writeLinkDepsArchive(t, "import.a", target, linkdeps.ImportDependency)
+	importsTarget, err = resolvedClosureImportsTarget(context.Background(), pkgs.ResolveResponse{
+		"example.com/root": {ExportFile: importArchive},
+	}, target)
+	require.NoError(t, err)
+	assert.True(t, importsTarget)
+
+	relocationArchive := writeLinkDepsArchive(t, "relocation.a", target, linkdeps.RelocationDependency)
+	importsTarget, err = resolvedClosureImportsTarget(context.Background(), pkgs.ResolveResponse{
+		"example.com/root": {ExportFile: relocationArchive},
+	}, target)
+	require.NoError(t, err)
+	assert.False(t, importsTarget)
+
+	importsTarget, err = resolvedClosureImportsTarget(context.Background(), pkgs.ResolveResponse{
+		"example.com/root": {ExportFile: importArchive, ForTest: target},
+	}, target)
+	require.NoError(t, err)
+	assert.False(t, importsTarget)
+
+	invalid := filepath.Join(t.TempDir(), "invalid.a")
+	file, err := os.Create(invalid)
+	require.NoError(t, err)
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteGlobalHeader())
+	contents := []byte("invalid")
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: linkdeps.Filename, Mode: 0o644, Size: int64(len(contents))}))
+	_, err = writer.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	_, err = resolvedClosureImportsTarget(context.Background(), pkgs.ResolveResponse{
+		"example.com/root": {ExportFile: invalid},
+	}, target)
+	require.ErrorContains(t, err, "reading link.deps")
+}
+
+func TestWriteMainImportConfig(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "importcfg")
+	require.NoError(t, os.WriteFile(filename, []byte("original\n"), 0o644))
+	reg := importcfg.ImportConfig{PackageFile: map[string]string{"example.com/root": "/root.a"}}
+
+	require.NoError(t, writeMainImportConfig(zerolog.Nop(), &reg, filename))
+	backup, err := os.ReadFile(filename + ".original")
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", string(backup))
+	updated, err := os.ReadFile(filename)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "packagefile example.com/root=/root.a")
+
+	reg.PackageFile["example.com/second"] = "/second.a"
+	require.NoError(t, writeMainImportConfig(zerolog.Nop(), &reg, filename))
+	backup, err = os.ReadFile(filename + ".original")
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", string(backup))
 }
 
 func TestStrongestPendingLinkDep(t *testing.T) {

--- a/internal/toolexec/aspect/oncompile.go
+++ b/internal/toolexec/aspect/oncompile.go
@@ -139,6 +139,11 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resEr
 		return nil
 	}
 
+	_, reversePackageFiles, reverseVariant, err := pkgs.ReverseVariantEnvironment()
+	if err != nil {
+		return err
+	}
+
 	var regUpdated bool
 	for depImportPath, kind := range references.Map() {
 		if depImportPath == "unsafe" {
@@ -168,10 +173,22 @@ func (w Weaver) OnCompile(ctx context.Context, cmd *proxy.CompileCommand) (resEr
 			continue
 		}
 
-		// Imported packages need to be provided in the compilation's importcfg file
-		deps, err := resolvePackageFiles(ctx, depImportPath, cmd.WorkDir)
-		if err != nil {
-			return fmt.Errorf("resolving woven dependency on %s: %w", depImportPath, err)
+		// Imported packages need to be provided in the compilation's importcfg file.
+		// Reverse test-variant builds receive the authoritative package-under-test
+		// closure from their outer test-main compilation. Using it directly avoids
+		// recursively resolving the same synthetic edge and ensures this archive is
+		// compiled against the exact fingerprint the outer test binary will link.
+		var deps pkgs.ResolveResponse
+		if _, found := reversePackageFiles[depImportPath]; reverseVariant && found {
+			deps = make(pkgs.ResolveResponse, len(reversePackageFiles))
+			for path, archive := range reversePackageFiles {
+				deps[path] = pkgs.ResolvedArchive{ExportFile: archive}
+			}
+		} else {
+			deps, err = resolvePackageFiles(ctx, depImportPath, cmd.WorkDir)
+			if err != nil {
+				return fmt.Errorf("resolving woven dependency on %s: %w", depImportPath, err)
+			}
 		}
 		for dep, resolved := range deps {
 			archive := resolved.ExportFile

--- a/internal/toolexec/aspect/onlink.go
+++ b/internal/toolexec/aspect/onlink.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
+	"github.com/DataDog/orchestrion/internal/toolexec/archive"
 	"github.com/DataDog/orchestrion/internal/toolexec/aspect/linkdeps"
 	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
@@ -39,9 +40,23 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 		return fmt.Errorf("parsing %q: %w", cmd.Flags.ImportCfg, err)
 	}
 
-	testVariantFor, _, err := cmd.TestVariantFor(ctx)
+	testMain, _, err := cmd.TestMainInfo(ctx)
 	if err != nil {
 		return fmt.Errorf("reading test-main metadata: %w", err)
+	}
+	testVariantFor := testMain.Target
+	if err := refreshTestMainPackageFiles(ctx, &testMain, &reg, cmd.WorkDir); err != nil {
+		return err
+	}
+	variantArchives := make(map[string]string, len(testMain.PackageFiles))
+	changed := false
+	for importPath, archive := range testMain.PackageFiles {
+		variantArchives[importPath] = archive
+		if reg.PackageFile[importPath] == archive {
+			continue
+		}
+		reg.PackageFile[importPath] = archive
+		changed = true
 	}
 
 	type archiveWork struct {
@@ -61,7 +76,6 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 	sort.Slice(queue, less)
 	processed := make(map[archiveWork]bool)
 	resolveTestTargetProvenance := newTestTargetProvenanceResolver(ctx, testVariantFor, cmd.WorkDir)
-	var changed bool
 	for len(queue) > 0 {
 		item := queue[0]
 		queue = queue[1:]
@@ -69,6 +83,11 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 			continue
 		}
 		processed[item] = true
+		if current, found := reg.PackageFile[item.importPath]; found && current != item.archive {
+			// A test-variant resolution replaced this archive after it was queued.
+			// Its stale dependency metadata no longer describes the selected closure.
+			continue
+		}
 
 		linkDeps, err := linkdeps.FromArchive(ctx, item.archive)
 		if err != nil {
@@ -77,6 +96,10 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 		log.Debug().Str("import-path", item.importPath).Str("archive", item.archive).Msg("Processing " + linkdeps.Filename + " dependencies")
 		for _, depPath := range linkDeps.Dependencies() {
 			kind := linkDeps.Kind(depPath)
+			if depPath == testVariantFor && kind == linkdeps.ImportDependency &&
+				(variantArchives[item.importPath] == item.archive || item.importPath == testVariantFor+".test") {
+				continue
+			}
 			if arch, found := reg.PackageFile[depPath]; found && (testVariantFor == "" || depPath == testVariantFor) {
 				var selected pkgs.ResolvedArchive
 				if depPath == testVariantFor && kind == linkdeps.ImportDependency {
@@ -108,6 +131,9 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 			added := false
 			for p, archive := range updates {
 				log.Debug().Str("import-path", p).Str("archive", archive).Msg("Recording resolved " + linkdeps.Filename + " dependency")
+				if deps[p].ForTest == testVariantFor {
+					variantArchives[p] = archive
+				}
 				queue = append(queue, archiveWork{importPath: p, archive: archive})
 				added = true
 				changed = true
@@ -131,5 +157,56 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 		return fmt.Errorf("writing updated %q: %w", cmd.Flags.ImportCfg, err)
 	}
 
+	return nil
+}
+
+func refreshTestMainPackageFiles(ctx context.Context, info *proxy.TestMainInfo, reg *importcfg.ImportConfig, workDir string) error {
+	if len(info.PackageFiles) == 0 {
+		return nil
+	}
+	stale := false
+	for importPath, filename := range info.PackageFiles {
+		fingerprint, err := archive.CompatibilityFingerprint(filename)
+		if err != nil || fingerprint != info.PackageFingerprints[importPath] {
+			stale = true
+			break
+		}
+	}
+	if !stale {
+		return nil
+	}
+	if len(info.ReverseRoots) == 0 {
+		return fmt.Errorf("cached test-main metadata for %q references unavailable reverse variants and has no reconstruction roots", info.Target)
+	}
+	authoritative := reg.PackageFile[info.Target]
+	if authoritative == "" {
+		return fmt.Errorf("test-main import configuration is missing the authoritative package-under-test archive %q", info.Target)
+	}
+	refreshed := make(map[string]string)
+	for _, root := range info.ReverseRoots {
+		variants, err := resolveReversePackageFilesForTest(ctx, root, info.Target, authoritative, workDir)
+		if err != nil {
+			return fmt.Errorf("reconstructing cached reverse test variant %q for %q: %w", root, info.Target, err)
+		}
+		for importPath, resolved := range variants {
+			refreshed[importPath] = resolved.ExportFile
+		}
+	}
+	selected := make(map[string]string, len(info.PackageFingerprints))
+	for importPath, expected := range info.PackageFingerprints {
+		filename := refreshed[importPath]
+		if filename == "" {
+			return fmt.Errorf("reconstructed reverse test variants for %q omitted %q", info.Target, importPath)
+		}
+		fingerprint, err := archive.CompatibilityFingerprint(filename)
+		if err != nil {
+			return fmt.Errorf("fingerprinting reconstructed reverse test variant %q: %w", importPath, err)
+		}
+		if fingerprint != expected {
+			return fmt.Errorf("reconstructed reverse test variant %q has fingerprint %s, cached test main expects %s", importPath, fingerprint, expected)
+		}
+		selected[importPath] = filename
+	}
+	info.PackageFiles = selected
 	return nil
 }

--- a/internal/toolexec/aspect/onlink.go
+++ b/internal/toolexec/aspect/onlink.go
@@ -45,7 +45,7 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 		return fmt.Errorf("reading test-main metadata: %w", err)
 	}
 	testVariantFor := testMain.Target
-	if err := refreshTestMainPackageFiles(ctx, &testMain, &reg, cmd.WorkDir); err != nil {
+	if err := refreshTestMainPackageFiles(ctx, &testMain, &reg, cmd.WorkDir, resolveReversePackageFilesForTest); err != nil {
 		return err
 	}
 	variantArchives := make(map[string]string, len(testMain.PackageFiles))
@@ -160,7 +160,21 @@ func (w Weaver) OnLink(ctx context.Context, cmd *proxy.LinkCommand) (err error) 
 	return nil
 }
 
-func refreshTestMainPackageFiles(ctx context.Context, info *proxy.TestMainInfo, reg *importcfg.ImportConfig, workDir string) error {
+type reversePackageFilesResolver func(
+	ctx context.Context,
+	importPath string,
+	testVariantFor string,
+	authoritativeTarget string,
+	workDir string,
+) (pkgs.ResolveResponse, error)
+
+func refreshTestMainPackageFiles(
+	ctx context.Context,
+	info *proxy.TestMainInfo,
+	reg *importcfg.ImportConfig,
+	workDir string,
+	resolve reversePackageFilesResolver,
+) error {
 	if len(info.PackageFiles) == 0 {
 		return nil
 	}
@@ -184,7 +198,7 @@ func refreshTestMainPackageFiles(ctx context.Context, info *proxy.TestMainInfo, 
 	}
 	refreshed := make(map[string]string)
 	for _, root := range info.ReverseRoots {
-		variants, err := resolveReversePackageFilesForTest(ctx, root, info.Target, authoritative, workDir)
+		variants, err := resolve(ctx, root, info.Target, authoritative, workDir)
 		if err != nil {
 			return fmt.Errorf("reconstructing cached reverse test variant %q for %q: %w", root, info.Target, err)
 		}

--- a/internal/toolexec/aspect/onlink_test.go
+++ b/internal/toolexec/aspect/onlink_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package aspect
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
+	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshTestMainPackageFiles(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		require.NoError(t, refreshTestMainPackageFiles(
+			context.Background(),
+			&proxy.TestMainInfo{},
+			&importcfg.ImportConfig{},
+			t.TempDir(),
+		))
+	})
+
+	t.Run("fresh", func(t *testing.T) {
+		archive := writeLinkDepsArchive(t, "root.a", "", 0)
+		info := proxy.TestMainInfo{
+			Target:              "example.com/subject",
+			PackageFiles:        map[string]string{"example.com/root": archive},
+			PackageFingerprints: map[string]string{"example.com/root": "none"},
+		}
+		require.NoError(t, refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{},
+			t.TempDir(),
+		))
+		assert.Equal(t, archive, info.PackageFiles["example.com/root"])
+	})
+
+	t.Run("stale without roots", func(t *testing.T) {
+		info := proxy.TestMainInfo{
+			Target:              "example.com/subject",
+			PackageFiles:        map[string]string{"example.com/root": filepath.Join(t.TempDir(), "missing.a")},
+			PackageFingerprints: map[string]string{"example.com/root": "fingerprint"},
+		}
+		err := refreshTestMainPackageFiles(context.Background(), &info, &importcfg.ImportConfig{}, t.TempDir())
+		require.ErrorContains(t, err, "has no reconstruction roots")
+	})
+
+	t.Run("missing authoritative target", func(t *testing.T) {
+		info := proxy.TestMainInfo{
+			Target:              "example.com/subject",
+			PackageFiles:        map[string]string{"example.com/root": filepath.Join(t.TempDir(), "missing.a")},
+			PackageFingerprints: map[string]string{"example.com/root": "fingerprint"},
+			ReverseRoots:        []string{"example.com/root"},
+		}
+		err := refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{PackageFile: make(map[string]string)},
+			t.TempDir(),
+		)
+		require.ErrorContains(t, err, "missing the authoritative package-under-test archive")
+	})
+}

--- a/internal/toolexec/aspect/onlink_test.go
+++ b/internal/toolexec/aspect/onlink_test.go
@@ -7,11 +7,14 @@ package aspect
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
 	"github.com/DataDog/orchestrion/internal/toolexec/importcfg"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
+	"github.com/blakesmith/ar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +26,7 @@ func TestRefreshTestMainPackageFiles(t *testing.T) {
 			&proxy.TestMainInfo{},
 			&importcfg.ImportConfig{},
 			t.TempDir(),
+			unexpectedReversePackageFilesResolver(t),
 		))
 	})
 
@@ -38,6 +42,7 @@ func TestRefreshTestMainPackageFiles(t *testing.T) {
 			&info,
 			&importcfg.ImportConfig{},
 			t.TempDir(),
+			unexpectedReversePackageFilesResolver(t),
 		))
 		assert.Equal(t, archive, info.PackageFiles["example.com/root"])
 	})
@@ -48,7 +53,13 @@ func TestRefreshTestMainPackageFiles(t *testing.T) {
 			PackageFiles:        map[string]string{"example.com/root": filepath.Join(t.TempDir(), "missing.a")},
 			PackageFingerprints: map[string]string{"example.com/root": "fingerprint"},
 		}
-		err := refreshTestMainPackageFiles(context.Background(), &info, &importcfg.ImportConfig{}, t.TempDir())
+		err := refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{},
+			t.TempDir(),
+			unexpectedReversePackageFilesResolver(t),
+		)
 		require.ErrorContains(t, err, "has no reconstruction roots")
 	})
 
@@ -64,7 +75,195 @@ func TestRefreshTestMainPackageFiles(t *testing.T) {
 			&info,
 			&importcfg.ImportConfig{PackageFile: make(map[string]string)},
 			t.TempDir(),
+			unexpectedReversePackageFilesResolver(t),
 		)
 		require.ErrorContains(t, err, "missing the authoritative package-under-test archive")
 	})
+
+	t.Run("reconstructs stale metadata", func(t *testing.T) {
+		const (
+			target = "example.com/subject"
+			root   = "example.com/root"
+		)
+		authoritative := writeLinkDepsArchive(t, "subject.a", "", 0)
+		rebuilt := writeFingerprintedArchive(t, "rebuilt-root.a", []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef})
+		workDir := t.TempDir()
+		info := proxy.TestMainInfo{
+			Target:              target,
+			PackageFiles:        map[string]string{root: filepath.Join(t.TempDir(), "missing.a")},
+			PackageFingerprints: map[string]string{root: "0123456789abcdef"},
+			ReverseRoots:        []string{root},
+		}
+		calls := 0
+		resolve := func(
+			_ context.Context,
+			importPath string,
+			testVariantFor string,
+			authoritativeTarget string,
+			gotWorkDir string,
+		) (pkgs.ResolveResponse, error) {
+			calls++
+			assert.Equal(t, root, importPath)
+			assert.Equal(t, target, testVariantFor)
+			assert.Equal(t, authoritative, authoritativeTarget)
+			assert.Equal(t, workDir, gotWorkDir)
+			return pkgs.ResolveResponse{
+				root: {ExportFile: rebuilt, ForTest: target},
+			}, nil
+		}
+
+		require.NoError(t, refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{PackageFile: map[string]string{target: authoritative}},
+			workDir,
+			resolve,
+		))
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, map[string]string{root: rebuilt}, info.PackageFiles)
+	})
+
+	t.Run("rejects mismatched reconstruction", func(t *testing.T) {
+		const (
+			target = "example.com/subject"
+			root   = "example.com/root"
+		)
+		authoritative := writeLinkDepsArchive(t, "subject.a", "", 0)
+		rebuilt := writeFingerprintedArchive(t, "rebuilt-root.a", []byte{0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10})
+		missing := filepath.Join(t.TempDir(), "missing.a")
+		info := proxy.TestMainInfo{
+			Target:              target,
+			PackageFiles:        map[string]string{root: missing},
+			PackageFingerprints: map[string]string{root: "0123456789abcdef"},
+			ReverseRoots:        []string{root},
+		}
+		resolve := func(context.Context, string, string, string, string) (pkgs.ResolveResponse, error) {
+			return pkgs.ResolveResponse{
+				root: {ExportFile: rebuilt, ForTest: target},
+			}, nil
+		}
+
+		err := refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{PackageFile: map[string]string{target: authoritative}},
+			t.TempDir(),
+			resolve,
+		)
+		require.ErrorContains(t, err, "has fingerprint fedcba9876543210, cached test main expects 0123456789abcdef")
+		assert.Equal(t, map[string]string{root: missing}, info.PackageFiles)
+	})
+
+	t.Run("reports reconstruction errors", func(t *testing.T) {
+		const (
+			target = "example.com/subject"
+			root   = "example.com/root"
+		)
+		authoritative := writeLinkDepsArchive(t, "subject.a", "", 0)
+		missing := filepath.Join(t.TempDir(), "missing.a")
+		info := proxy.TestMainInfo{
+			Target:              target,
+			PackageFiles:        map[string]string{root: missing},
+			PackageFingerprints: map[string]string{root: "none"},
+			ReverseRoots:        []string{root},
+		}
+		resolve := func(context.Context, string, string, string, string) (pkgs.ResolveResponse, error) {
+			return nil, assert.AnError
+		}
+
+		err := refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{PackageFile: map[string]string{target: authoritative}},
+			t.TempDir(),
+			resolve,
+		)
+		require.ErrorIs(t, err, assert.AnError)
+		require.ErrorContains(t, err, "reconstructing cached reverse test variant")
+		assert.Equal(t, map[string]string{root: missing}, info.PackageFiles)
+	})
+
+	t.Run("rejects omitted reconstruction", func(t *testing.T) {
+		const (
+			target = "example.com/subject"
+			root   = "example.com/root"
+		)
+		authoritative := writeLinkDepsArchive(t, "subject.a", "", 0)
+		missing := filepath.Join(t.TempDir(), "missing.a")
+		info := proxy.TestMainInfo{
+			Target:              target,
+			PackageFiles:        map[string]string{root: missing},
+			PackageFingerprints: map[string]string{root: "none"},
+			ReverseRoots:        []string{root},
+		}
+		resolve := func(context.Context, string, string, string, string) (pkgs.ResolveResponse, error) {
+			return make(pkgs.ResolveResponse), nil
+		}
+
+		err := refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{PackageFile: map[string]string{target: authoritative}},
+			t.TempDir(),
+			resolve,
+		)
+		require.ErrorContains(t, err, "omitted \"example.com/root\"")
+		assert.Equal(t, map[string]string{root: missing}, info.PackageFiles)
+	})
+
+	t.Run("rejects unreadable reconstruction", func(t *testing.T) {
+		const (
+			target = "example.com/subject"
+			root   = "example.com/root"
+		)
+		authoritative := writeLinkDepsArchive(t, "subject.a", "", 0)
+		missing := filepath.Join(t.TempDir(), "missing.a")
+		info := proxy.TestMainInfo{
+			Target:              target,
+			PackageFiles:        map[string]string{root: missing},
+			PackageFingerprints: map[string]string{root: "none"},
+			ReverseRoots:        []string{root},
+		}
+		resolve := func(context.Context, string, string, string, string) (pkgs.ResolveResponse, error) {
+			return pkgs.ResolveResponse{
+				root: {ExportFile: filepath.Join(t.TempDir(), "missing-rebuilt.a"), ForTest: target},
+			}, nil
+		}
+
+		err := refreshTestMainPackageFiles(
+			context.Background(),
+			&info,
+			&importcfg.ImportConfig{PackageFile: map[string]string{target: authoritative}},
+			t.TempDir(),
+			resolve,
+		)
+		require.ErrorContains(t, err, "fingerprinting reconstructed reverse test variant \"example.com/root\"")
+		assert.Equal(t, map[string]string{root: missing}, info.PackageFiles)
+	})
+}
+
+func unexpectedReversePackageFilesResolver(t *testing.T) reversePackageFilesResolver {
+	t.Helper()
+	return func(context.Context, string, string, string, string) (pkgs.ResolveResponse, error) {
+		t.Helper()
+		assert.Fail(t, "reverse package-files resolver was called unexpectedly")
+		return nil, assert.AnError
+	}
+}
+
+func writeFingerprintedArchive(t *testing.T, name string, fingerprint []byte) string {
+	t.Helper()
+	require.Len(t, fingerprint, 8)
+
+	path := filepath.Join(t.TempDir(), name)
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteGlobalHeader())
+	object := append([]byte("go object header\n!\n\x00go120ld"), fingerprint...)
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(object))}))
+	_, err = writer.Write(object)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	return path
 }

--- a/internal/toolexec/aspect/resolve.go
+++ b/internal/toolexec/aspect/resolve.go
@@ -128,7 +128,7 @@ func rejectSyntheticVariantDependency(parent string, dependency string, testVari
 	if parent == "" || !requiresRebuild || testVariantFor == "" || selected.ForTest != testVariantFor {
 		return nil
 	}
-	return fmt.Errorf("synthetic dependency %q discovered through archive %q requires a test variant for %q; an archive in that synthetic dependency closure was compiled without this edge in Go's package graph and cannot safely use the variant", dependency, parent, testVariantFor)
+	return fmt.Errorf("synthetic dependency %q discovered through archive %q requires a test variant for %q; an archive in that synthetic dependency closure was compiled without this edge in Go's package graph and cannot safely use the variant. This can be fixed by moving the tests into a separate '*_test' package", dependency, parent, testVariantFor)
 }
 
 func mergeResolvedArchives(reg *importcfg.ImportConfig, archives pkgs.ResolveResponse, testVariantFor string) (map[string]string, error) {

--- a/internal/toolexec/aspect/resolve.go
+++ b/internal/toolexec/aspect/resolve.go
@@ -26,6 +26,26 @@ func resolvePackageFiles(ctx context.Context, importPath string, workDir string)
 }
 
 func resolvePackageFilesForTest(ctx context.Context, importPath string, testVariantFor string, workDir string) (_ pkgs.ResolveResponse, err error) {
+	return resolvePackageFilesRequest(ctx, importPath, packageResolveOptions{testVariantFor: testVariantFor, workDir: workDir})
+}
+
+func resolveReversePackageFilesForTest(ctx context.Context, importPath string, testVariantFor string, authoritativeTarget string, workDir string) (_ pkgs.ResolveResponse, err error) {
+	return resolvePackageFilesRequest(ctx, importPath, packageResolveOptions{
+		testVariantFor:      testVariantFor,
+		authoritativeTarget: authoritativeTarget,
+		reverse:             true,
+		workDir:             workDir,
+	})
+}
+
+type packageResolveOptions struct {
+	testVariantFor      string
+	authoritativeTarget string
+	reverse             bool
+	workDir             string
+}
+
+func resolvePackageFilesRequest(ctx context.Context, importPath string, options packageResolveOptions) (_ pkgs.ResolveResponse, err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "aspect.resolvePackageFiles",
 		tracer.ResourceName(importPath),
 	)
@@ -36,17 +56,19 @@ func resolvePackageFilesForTest(ctx context.Context, importPath string, testVari
 		return nil, err
 	}
 
-	conn, err := client.FromEnvironment(ctx, workDir)
+	conn, err := client.FromEnvironment(ctx, options.workDir)
 	if err != nil {
 		return nil, err
 	}
 
 	req := pkgs.NewResolveRequest(cwd, importPath)
-	req.TestVariantFor = testVariantFor
-	if workDir != "" {
+	req.TestVariantFor = options.testVariantFor
+	req.ReverseTestVariant = options.reverse
+	req.AuthoritativeTarget = options.authoritativeTarget
+	if options.workDir != "" {
 		// Nest the future GOTMPDIR under this $WORK directory, so that builds with `-work` are nested,
 		// and the root work tree contains all child work trees involved in resolutions.
-		req.TempDir = filepath.Join(workDir, "__tmp__")
+		req.TempDir = filepath.Join(options.workDir, "__tmp__")
 	}
 	archives, err := client.Request(
 		ctx,

--- a/internal/toolexec/proxy/compile.go
+++ b/internal/toolexec/proxy/compile.go
@@ -56,6 +56,12 @@ type CompileCommand struct {
 	testMain bool
 	// testVariantFor is set when this command produces Go's generated test-main archive.
 	testVariantFor string
+	// testMainPackageFiles records reverse test variants selected before the
+	// generated test main is compiled so the linker can replay the same closure.
+	testMainPackageFiles map[string]string
+	// testMainReverseRoots identifies the package roots needed to reconstruct the
+	// reverse closure if cached metadata outlives one of its referenced archives.
+	testMainReverseRoots map[string]struct{}
 	// finishToken is the token returned by the job server in response to the
 	// [nbt.StartRequest] when the operation needs to continue, and that is then
 	// forwarded to the [nbt.FinishRequest].

--- a/internal/toolexec/proxy/testmain.go
+++ b/internal/toolexec/proxy/testmain.go
@@ -9,23 +9,52 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
+	goarchive "github.com/DataDog/orchestrion/internal/toolexec/archive"
 	"github.com/blakesmith/ar"
 )
 
 const (
 	testMainFilename = "testmain.info"
-	testMainHeader   = "#orchestrion.testmain@v1"
+	testMainHeaderV1 = "#orchestrion.testmain@v1"
+	testMainHeaderV2 = "#orchestrion.testmain@v2"
 )
+
+// TestMainInfo describes the package under test and any reverse test-variant
+// archives selected before compiling the generated test main.
+type TestMainInfo struct {
+	Target              string            `json:"target"`
+	PackageFiles        map[string]string `json:"packageFiles,omitempty"`
+	PackageFingerprints map[string]string `json:"packageFingerprints,omitempty"`
+	ReverseRoots        []string          `json:"reverseRoots,omitempty"`
+}
 
 // MarkTestMain records that this compile command produces a generated test-main archive.
 func (cmd *CompileCommand) MarkTestMain(packageUnderTest string) {
 	cmd.testVariantFor = packageUnderTest
+}
+
+// SetTestMainPackageFiles records package archives that must replace the outer
+// linker's ordinary closure for this test binary.
+func (cmd *CompileCommand) SetTestMainPackageFiles(packageFiles map[string]string) {
+	cmd.testMainPackageFiles = packageFiles
+}
+
+// AddTestMainReverseRoot records a root package used to reconstruct reverse
+// test variants when their cached archive paths are no longer available.
+func (cmd *CompileCommand) AddTestMainReverseRoot(importPath string) {
+	if cmd.testMainReverseRoots == nil {
+		cmd.testMainReverseRoots = make(map[string]struct{})
+	}
+	cmd.testMainReverseRoots[importPath] = struct{}{}
 }
 
 func (cmd *CompileCommand) attachTestMain() (err error) {
@@ -43,7 +72,29 @@ func (cmd *CompileCommand) attachTestMain() (err error) {
 	}
 	defer func() { err = errors.Join(err, file.Close()) }()
 
-	contents := testMainHeader + "\n" + cmd.testVariantFor + "\n"
+	fingerprints := make(map[string]string, len(cmd.testMainPackageFiles))
+	for importPath, archive := range cmd.testMainPackageFiles {
+		fingerprint, err := goarchive.CompatibilityFingerprint(archive)
+		if err != nil {
+			return fmt.Errorf("fingerprinting reverse test variant %q: %w", importPath, err)
+		}
+		fingerprints[importPath] = fingerprint
+	}
+	roots := make([]string, 0, len(cmd.testMainReverseRoots))
+	for root := range cmd.testMainReverseRoots {
+		roots = append(roots, root)
+	}
+	slices.Sort(roots)
+	payload, err := json.Marshal(TestMainInfo{
+		Target:              cmd.testVariantFor,
+		PackageFiles:        cmd.testMainPackageFiles,
+		PackageFingerprints: fingerprints,
+		ReverseRoots:        roots,
+	})
+	if err != nil {
+		return fmt.Errorf("encoding test-main metadata: %w", err)
+	}
+	contents := testMainHeaderV2 + "\n" + string(payload) + "\n"
 	wr := ar.NewWriter(file)
 	if err := wr.WriteHeader(&ar.Header{Name: testMainFilename, Mode: 0o644, Size: int64(len(contents))}); err != nil {
 		return fmt.Errorf("writing test-main header: %w", err)
@@ -54,67 +105,93 @@ func (cmd *CompileCommand) attachTestMain() (err error) {
 	return nil
 }
 
-// TestVariantFor reports the package-under-test recorded in the linker's input archive.
-func (cmd *LinkCommand) TestVariantFor(_ context.Context) (string, bool, error) {
-	var found string
+// TestMainInfo reports metadata recorded in the linker's test-main input archive.
+func (cmd *LinkCommand) TestMainInfo(_ context.Context) (TestMainInfo, bool, error) {
+	var found TestMainInfo
 	for _, input := range cmd.Inputs {
 		value, ok, err := readTestMain(input)
 		if err != nil {
-			return "", false, err
+			return TestMainInfo{}, false, err
 		}
 		if !ok {
 			continue
 		}
-		if found != "" && found != value {
-			return "", false, fmt.Errorf("conflicting test-main targets %q and %q", found, value)
+		if found.Target != "" {
+			if found.Target != value.Target {
+				return TestMainInfo{}, false, fmt.Errorf("conflicting test-main targets %q and %q", found.Target, value.Target)
+			}
+			if !maps.Equal(found.PackageFiles, value.PackageFiles) ||
+				!maps.Equal(found.PackageFingerprints, value.PackageFingerprints) ||
+				!slices.Equal(found.ReverseRoots, value.ReverseRoots) {
+				return TestMainInfo{}, false, fmt.Errorf("conflicting test-main metadata for %q", found.Target)
+			}
 		}
 		found = value
 	}
-	return found, found != "", nil
+	return found, found.Target != "", nil
 }
 
-func readTestMain(filename string) (string, bool, error) {
+// TestVariantFor reports the package-under-test recorded in the linker's input archive.
+func (cmd *LinkCommand) TestVariantFor(ctx context.Context) (string, bool, error) {
+	info, ok, err := cmd.TestMainInfo(ctx)
+	return info.Target, ok, err
+}
+
+func readTestMain(filename string) (TestMainInfo, bool, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return "", false, fmt.Errorf("opening link input %q: %w", filename, err)
+		return TestMainInfo{}, false, fmt.Errorf("opening link input %q: %w", filename, err)
 	}
 	defer file.Close()
 
 	magic := make([]byte, len("!<arch>\n"))
 	if _, err := io.ReadFull(file, magic); errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		return "", false, nil
+		return TestMainInfo{}, false, nil
 	} else if err != nil {
-		return "", false, fmt.Errorf("reading link input %q: %w", filename, err)
+		return TestMainInfo{}, false, fmt.Errorf("reading link input %q: %w", filename, err)
 	}
 	if !bytes.Equal(magic, []byte("!<arch>\n")) {
-		return "", false, nil
+		return TestMainInfo{}, false, nil
 	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return "", false, fmt.Errorf("rewinding link input %q: %w", filename, err)
+		return TestMainInfo{}, false, fmt.Errorf("rewinding link input %q: %w", filename, err)
 	}
 
 	rd := ar.NewReader(file)
 	for {
 		hdr, err := rd.Next()
 		if errors.Is(err, io.EOF) {
-			return "", false, nil
+			return TestMainInfo{}, false, nil
 		}
 		if err != nil {
-			return "", false, fmt.Errorf("reading link input %q: %w", filename, err)
+			return TestMainInfo{}, false, fmt.Errorf("reading link input %q: %w", filename, err)
 		}
 		if hdr.Name != testMainFilename {
 			continue
 		}
 		scanner := bufio.NewScanner(rd)
-		if !scanner.Scan() || scanner.Text() != testMainHeader {
-			return "", false, fmt.Errorf("invalid test-main metadata in %q", filename)
+		scanner.Buffer(nil, 16<<20)
+		if !scanner.Scan() {
+			return TestMainInfo{}, false, fmt.Errorf("invalid test-main metadata in %q", filename)
 		}
+		header := scanner.Text()
 		if !scanner.Scan() || strings.TrimSpace(scanner.Text()) == "" {
-			return "", false, fmt.Errorf("missing test-main target in %q", filename)
+			return TestMainInfo{}, false, fmt.Errorf("missing test-main target in %q", filename)
 		}
-		value := strings.TrimSpace(scanner.Text())
+		line := strings.TrimSpace(scanner.Text())
+		var value TestMainInfo
+		switch header {
+		case testMainHeaderV1:
+			value.Target = line
+		case testMainHeaderV2:
+			if err := json.Unmarshal([]byte(line), &value); err != nil || value.Target == "" {
+				return TestMainInfo{}, false, fmt.Errorf("invalid test-main metadata in %q", filename)
+			}
+		default:
+			return TestMainInfo{}, false, fmt.Errorf("invalid test-main metadata in %q", filename)
+		}
 		if scanner.Scan() || scanner.Err() != nil {
-			return "", false, fmt.Errorf("invalid test-main metadata in %q", filename)
+			return TestMainInfo{}, false, fmt.Errorf("invalid test-main metadata in %q", filename)
 		}
 		return value, true, nil
 	}

--- a/internal/toolexec/proxy/testmain_test.go
+++ b/internal/toolexec/proxy/testmain_test.go
@@ -7,6 +7,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -63,4 +64,84 @@ func TestTestMainMetadataIgnoresImportPathSuffix(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 	assert.Empty(t, target)
+}
+
+func TestTestMainMetadataV1(t *testing.T) {
+	archive := writeTestMainMetadataArchive(t, testMainHeaderV1+"\nexample.com/subject\n")
+	info, ok, err := (&LinkCommand{Inputs: []string{archive}}).TestMainInfo(context.Background())
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, TestMainInfo{Target: "example.com/subject"}, info)
+}
+
+func TestTestMainMetadataConflicts(t *testing.T) {
+	t.Run("target", func(t *testing.T) {
+		first := writeTestMainMetadataArchive(t, testMainHeaderV1+"\nexample.com/first\n")
+		second := writeTestMainMetadataArchive(t, testMainHeaderV1+"\nexample.com/second\n")
+		_, _, err := (&LinkCommand{Inputs: []string{first, second}}).TestMainInfo(context.Background())
+		require.ErrorContains(t, err, "conflicting test-main targets")
+	})
+
+	t.Run("metadata", func(t *testing.T) {
+		first := writeTestMainInfoArchive(t, TestMainInfo{
+			Target:       "example.com/subject",
+			PackageFiles: map[string]string{"example.com/root": "/first.a"},
+		})
+		second := writeTestMainInfoArchive(t, TestMainInfo{
+			Target:       "example.com/subject",
+			PackageFiles: map[string]string{"example.com/root": "/second.a"},
+		})
+		_, _, err := (&LinkCommand{Inputs: []string{first, second}}).TestMainInfo(context.Background())
+		require.ErrorContains(t, err, "conflicting test-main metadata")
+	})
+}
+
+func TestReadTestMainRejectsMalformedMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     string
+	}{
+		{name: "empty", want: "invalid test-main metadata"},
+		{name: "missing target", contents: testMainHeaderV1 + "\n", want: "missing test-main target"},
+		{name: "invalid JSON", contents: testMainHeaderV2 + "\n{\n", want: "invalid test-main metadata"},
+		{name: "unknown header", contents: "#unknown\nexample.com/subject\n", want: "invalid test-main metadata"},
+		{name: "trailing data", contents: testMainHeaderV1 + "\nexample.com/subject\nextra\n", want: "invalid test-main metadata"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := readTestMain(writeTestMainMetadataArchive(t, tt.contents))
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestAttachTestMainRejectsMissingReverseArchive(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "main.a")
+	require.NoError(t, os.WriteFile(archive, []byte("!<arch>\n"), 0o644))
+	compile := &CompileCommand{Flags: compileFlagSet{Output: archive}}
+	compile.MarkTestMain("example.com/subject")
+	compile.SetTestMainPackageFiles(map[string]string{"example.com/importer": filepath.Join(t.TempDir(), "missing.a")})
+	require.ErrorContains(t, compile.attachTestMain(), "fingerprinting reverse test variant")
+}
+
+func writeTestMainInfoArchive(t *testing.T, info TestMainInfo) string {
+	t.Helper()
+	payload, err := json.Marshal(info)
+	require.NoError(t, err)
+	return writeTestMainMetadataArchive(t, testMainHeaderV2+"\n"+string(payload)+"\n")
+}
+
+func writeTestMainMetadataArchive(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "main.a")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteGlobalHeader())
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: testMainFilename, Mode: 0o644, Size: int64(len(contents))}))
+	_, err = writer.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	return path
 }

--- a/internal/toolexec/proxy/testmain_test.go
+++ b/internal/toolexec/proxy/testmain_test.go
@@ -23,7 +23,7 @@ func TestTestMainMetadata(t *testing.T) {
 	require.NoError(t, err)
 	contents := []byte("\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xef")
 	writer := ar.NewWriter(file)
-	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "__.PKGDEF", Mode: 0o644, Size: int64(len(contents))}))
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(contents))}))
 	_, err = writer.Write(contents)
 	require.NoError(t, err)
 	require.NoError(t, file.Close())

--- a/internal/toolexec/proxy/testmain_test.go
+++ b/internal/toolexec/proxy/testmain_test.go
@@ -22,7 +22,7 @@ func TestTestMainMetadata(t *testing.T) {
 	require.NoError(t, os.WriteFile(archive, []byte("!<arch>\n"), 0o644))
 	file, err := os.OpenFile(archive, os.O_APPEND|os.O_WRONLY, 0o644)
 	require.NoError(t, err)
-	contents := []byte("\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xef")
+	contents := []byte("go object header\n!\n\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xef")
 	writer := ar.NewWriter(file)
 	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "_go_.o", Mode: 0o644, Size: int64(len(contents))}))
 	_, err = writer.Write(contents)

--- a/internal/toolexec/proxy/testmain_test.go
+++ b/internal/toolexec/proxy/testmain_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blakesmith/ar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,12 +19,32 @@ import (
 func TestTestMainMetadata(t *testing.T) {
 	archive := filepath.Join(t.TempDir(), "main.a")
 	require.NoError(t, os.WriteFile(archive, []byte("!<arch>\n"), 0o644))
+	file, err := os.OpenFile(archive, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	contents := []byte("\x00go120ld\x01\x23\x45\x67\x89\xab\xcd\xef")
+	writer := ar.NewWriter(file)
+	require.NoError(t, writer.WriteHeader(&ar.Header{Name: "__.PKGDEF", Mode: 0o644, Size: int64(len(contents))}))
+	_, err = writer.Write(contents)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
 
 	compile := &CompileCommand{Flags: compileFlagSet{Output: archive}}
 	compile.MarkTestMain("example.com/subject")
+	compile.SetTestMainPackageFiles(map[string]string{"example.com/importer": archive})
+	compile.AddTestMainReverseRoot("example.com/importer")
 	require.NoError(t, compile.attachTestMain())
 
 	link := &LinkCommand{Inputs: []string{archive}}
+	info, ok, err := link.TestMainInfo(context.Background())
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, TestMainInfo{
+		Target:              "example.com/subject",
+		PackageFiles:        map[string]string{"example.com/importer": archive},
+		PackageFingerprints: map[string]string{"example.com/importer": "0123456789abcdef"},
+		ReverseRoots:        []string{"example.com/importer"},
+	}, info)
+
 	target, ok, err := link.TestVariantFor(context.Background())
 	require.NoError(t, err)
 	assert.True(t, ok)

--- a/internal/toolexec/version.go
+++ b/internal/toolexec/version.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/orchestrion/internal/jobserver"
 	"github.com/DataDog/orchestrion/internal/jobserver/buildid"
 	"github.com/DataDog/orchestrion/internal/jobserver/client"
+	"github.com/DataDog/orchestrion/internal/jobserver/pkgs"
 	"github.com/DataDog/orchestrion/internal/toolexec/proxy"
 	"github.com/rs/zerolog"
 )
@@ -57,6 +58,18 @@ func ComputeVersion(ctx context.Context, cmd proxy.Command) (string, error) {
 		return "", err
 	}
 
+	// Flavor reverse test-variant builds at the tool identity level. cmd/go
+	// includes this complete version in every action ID, which keeps these
+	// archives separate from ordinary build-cache entries.
+	flavor, _, active, err := pkgs.ReverseVariantEnvironment()
+	if err != nil {
+		return "", err
+	}
+	suffix := string(res)
+	if active {
+		suffix = fmt.Sprintf("%s:reverse-test-variant=%s", suffix, flavor)
+	}
+
 	// Produce the complete version string
-	return fmt.Sprintf("%s:%s", strings.TrimSpace(stdout.String()), res), nil
+	return fmt.Sprintf("%s:%s", strings.TrimSpace(stdout.String()), suffix), nil
 }

--- a/internal/toolexec/version_test.go
+++ b/internal/toolexec/version_test.go
@@ -110,6 +110,18 @@ func Test(t *testing.T) {
 		require.NotEmpty(t, final)
 		require.NotEqual(t, initial, final)
 		require.NotEqual(t, updated, final)
+
+		reverseEnvironment := filepath.Join(tmp, "reverse-environment.json")
+		require.NoError(t, os.WriteFile(reverseEnvironment, []byte(`{"flavor":"coverage-test","packageFiles":{"example.com/root":"/root.a"}}`), 0o644))
+		t.Setenv("ORCHESTRION_REVERSE_VARIANT", reverseEnvironment)
+		t.Setenv("ORCHESTRION_REVERSE_VARIANT_FLAVOR", "coverage-test")
+		reverseVariant := inDir(t, tmp, func() string {
+			v, err := ComputeVersion(ctx, cmd)
+			require.NoError(t, err)
+			return v
+		})
+		require.NotEqual(t, final, reverseVariant)
+		require.Contains(t, reverseVariant, ":reverse-test-variant=coverage-test")
 	})
 
 	t.Run("workspace", func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -253,6 +253,128 @@ func Value() int { return middle.Value() }
 	run.exec(t, orchestrion, "go", "test", "-a", "-cover", "-coverpkg=./...", "./subject")
 }
 
+func TestSyntheticImportDependencyWithExternalTests(t *testing.T) {
+	run := runner{dir: t.TempDir()}
+	writeFile := func(name, contents string) {
+		t.Helper()
+		path := filepath.Join(run.dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	}
+
+	writeFile("go.mod", `module example.com/reversetestvariant
+
+go 1.25
+
+require github.com/DataDog/orchestrion v0.0.0
+
+replace github.com/DataDog/orchestrion => `+rootDir+"\n")
+	writeFile("orchestrion.tool.go", `//go:build tools
+
+package tools
+
+import (
+	_ "example.com/reversetestvariant/instrumentation"
+	_ "github.com/DataDog/orchestrion"
+)
+`)
+	writeFile("instrumentation/instrumentation.go", "package instrumentation\n")
+	writeFile("instrumentation/orchestrion.yml", `meta:
+  name: Reversed external test variant import
+  description: Injects an import of the covered package under test.
+aspects:
+  - id: reversed-external-test-variant
+    join-point:
+      all-of:
+        - import-path: example.com/reversetestvariant/importer
+        - function-body:
+            function:
+              - name: Value
+    advice:
+      - inject-declarations:
+          imports:
+            subject: example.com/reversetestvariant/subject
+          template: |-
+            func init() {
+              subject.Instrumented++
+            }
+`)
+	writeFile("subject/subject.go", `package subject
+
+var Instrumented int
+
+func Value() int { return 42 }
+`)
+	writeFile("subject/subject_test.go", `package subject_test
+
+import (
+	"testing"
+
+	"example.com/reversetestvariant/helper"
+	"example.com/reversetestvariant/subject"
+)
+
+func TestValue(t *testing.T) {
+	if got := helper.Value(); got != 42 {
+		t.Fatalf("helper.Value() = %d, want 42", got)
+	}
+	if got := subject.Instrumented; got != 1 {
+		t.Fatalf("subject.Instrumented = %d, want 1", got)
+	}
+}
+`)
+	writeFile("helper/helper.go", `package helper
+
+import "example.com/reversetestvariant/importer"
+
+func Value() int { return importer.Value() }
+`)
+	writeFile("importer/importer.go", `package importer
+
+import "fmt"
+
+func Value() int {
+	if fmt.Sprint(42) == "42" {
+		return 42
+	}
+	return 0
+}
+`)
+	orchestrion := buildOrchestrion(t)
+	sharedCache := t.TempDir()
+	run.execWithCache(t, sharedCache, orchestrion, "go", "test", "./subject")
+	run.execWithCache(t, sharedCache, orchestrion, "go", "test", "-coverprofile="+filepath.Join(run.dir, "coverage.out"), "./...")
+	// Reverse variants must not poison ordinary action IDs, and their flavored
+	// action IDs must remain reusable by subsequent covered builds.
+	run.execWithCache(t, sharedCache, orchestrion, "go", "test", "./subject")
+	run.execWithCache(t, sharedCache, orchestrion, "go", "test", "-coverprofile="+filepath.Join(run.dir, "coverage-cached.out"), "./...")
+	run.exec(t, orchestrion, "go", "test", "-cover", "-coverpkg=./...", "./subject")
+
+	// In-package tests make the package under test part of the importer up-set.
+	// Rebuilding that cycle is unsafe, so preserve the existing explicit failure
+	// instead of allowing a linker fingerprint mismatch.
+	writeFile("subject/subject_test.go", `package subject
+
+import (
+	"testing"
+
+	"example.com/reversetestvariant/helper"
+)
+
+func TestValue(t *testing.T) {
+	if got := helper.Value(); got != 42 {
+		t.Fatalf("helper.Value() = %d, want 42", got)
+	}
+	if got := Instrumented; got != 1 {
+		t.Fatalf("Instrumented = %d, want 1", got)
+	}
+}
+`)
+	output := run.execError(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "same-package-coverage.out"), "./...")
+	require.Contains(t, output, "cannot safely use the variant")
+	require.NotContains(t, output, "fingerprint mismatch")
+}
+
 func TestAspectsApplyToTestVariants(t *testing.T) {
 	run := runner{dir: t.TempDir()}
 	writeFile := func(name, contents string) {
@@ -574,6 +696,21 @@ func (h *harness) instrumented(b *testing.B) {
 }
 
 func (r *runner) exec(tb testing.TB, name string, args ...string) {
+	r.execWithCache(tb, tb.TempDir(), name, args...)
+}
+
+func (r *runner) execWithCache(tb testing.TB, cache string, name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = r.dir
+	cmd.Env = append(os.Environ(), "GOCACHE="+cache)
+	output := bytes.NewBuffer(make([]byte, 0, 4_096))
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	require.NoError(tb, cmd.Run(), "command failed: %s\n%s", cmd, output)
+}
+
+func (r *runner) execError(tb testing.TB, name string, args ...string) string {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = r.dir
 	cmd.Env = append(os.Environ(), "GOCACHE="+tb.TempDir())
@@ -581,7 +718,8 @@ func (r *runner) exec(tb testing.TB, name string, args ...string) {
 	cmd.Stdout = output
 	cmd.Stderr = output
 
-	require.NoError(tb, cmd.Run(), "command failed: %s\n%s", cmd, output)
+	require.Error(tb, cmd.Run(), "command succeeded unexpectedly: %s\n%s", cmd, output)
+	return output.String()
 }
 
 func (*harness) findLatestGithubReleaseTag(b *testing.B, owner string, repo string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -234,6 +234,18 @@ func TestValue(t *testing.T) {
 	}
 }
 `)
+	writeFile("testonly/testonly_test.go", `package testonly
+
+import "testing"
+
+func TestOnly(t *testing.T) {}
+`)
+	writeFile("externaltestonly/external_test.go", `package externaltestonly_test
+
+import "testing"
+
+func TestOnly(t *testing.T) {}
+`)
 	writeFile("middle/middle.go", `package middle
 
 import "example.com/externaltestvariant/subject"
@@ -249,6 +261,10 @@ func Value() int { return middle.Value() }
 
 	orchestrion := buildOrchestrion(t)
 	run.exec(t, orchestrion, "go", "test", "-a", "./subject")
+	// Packages with only test files have no ordinary export archive. An
+	// external-test-only package also has no package-under-test importcfg entry.
+	// Do not resolve provenance or require that entry without a synthetic importer.
+	run.exec(t, orchestrion, "go", "test", "-a", "./testonly", "./externaltestonly")
 	run.exec(t, orchestrion, "go", "test", "-a", "-coverprofile="+filepath.Join(run.dir, "coverage.out"), "./subject")
 	run.exec(t, orchestrion, "go", "test", "-a", "-cover", "-coverpkg=./...", "./subject")
 }


### PR DESCRIPTION
Implicit test coverage gives the package under test a binary-local archive. Instrumentation-added compiler imports are absent from the Go package graph, so ordinary importer archives can retain a conflicting fingerprint and fail at link time.

Preserve satisfied import provenance and rebuild affected importer closures in a target-specific tool flavor. Carry authoritative archives through nested compilation, record validated closure metadata on the test main, and replay or reconstruct it at link time without polluting ordinary build cache entries.

Keep same-package cycles rejected and add regression coverage for external tests, cache reuse, explicit coverage, and stale metadata.

Fixes #875 (to the extent of what's possible)