### PR TITLE
feat(join): match typed operator expressions

### DIFF
--- a/internal/injector/aspect/advice/code/dot_concat.go
+++ b/internal/injector/aspect/advice/code/dot_concat.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package code
+
+import (
+	"errors"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect/concat"
+)
+
+// errNotStringConcat is returned by [dot.StringConcatOperands] when the current
+// node is not part of a non-constant `string` concatenation chain.
+var errNotStringConcat = errors.New("the node in this context is not part of a string concatenation chain")
+
+// StringConcatOperands returns the operands of the maximal `string`
+// concatenation chain the current node belongs to, in source order.
+//
+// Parentheses do not split a concatenation chain, so `(a + b) + c` yields three
+// operands. A subexpression the compiler folds into a constant is retained as a
+// single operand, so `a + ("x" + "y")` yields two operands: `a` and `("x" + "y")`.
+//
+// Each returned value renders as a placeholder replaced by the original operand
+// expression and keeps its original type. A template using this helper MUST emit
+// every operand exactly once and in source order. Omitting an operand drops its
+// side effects; copying or rendering one more than once repeats its evaluation.
+//
+// This fails if the current node is not part of a non-constant `string`
+// concatenation chain, which normally means the advice was not attached to a
+// `string-concat` join point.
+func (d *dot) StringConcatOperands() ([]any, error) {
+	_, operands := concat.RootOperands(d.context)
+	if operands == nil {
+		return nil, errNotStringConcat
+	}
+
+	res := make([]any, len(operands))
+	for i, operand := range operands {
+		res[i] = newProxy[any](operand, &d.placeholders)
+	}
+
+	return res, nil
+}

--- a/internal/injector/aspect/advice/code/dot_slice.go
+++ b/internal/injector/aspect/advice/code/dot_slice.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package code
+
+import "github.com/dave/dst"
+
+// SliceHasLow reports whether the current slice expression has a low bound.
+func (d *dot) SliceHasLow() bool {
+	expression, ok := d.context.Node().(*dst.SliceExpr)
+	return ok && expression.Low != nil
+}
+
+// SliceHasHigh reports whether the current slice expression has a high bound.
+func (d *dot) SliceHasHigh() bool {
+	expression, ok := d.context.Node().(*dst.SliceExpr)
+	return ok && expression.High != nil
+}
+
+// SliceHasMax reports whether the current slice expression has a capacity bound.
+func (d *dot) SliceHasMax() bool {
+	expression, ok := d.context.Node().(*dst.SliceExpr)
+	return ok && expression.Max != nil
+}

--- a/internal/injector/aspect/advice/code/template_test.go
+++ b/internal/injector/aspect/advice/code/template_test.go
@@ -6,6 +6,7 @@
 package code_test
 
 import (
+	"go/constant"
 	"go/types"
 	"testing"
 
@@ -40,6 +41,11 @@ func (mockAdviceContext) ParseSource(src []byte) (*dst.File, error) {
 // The rest is not used by the tests as of now...
 
 func (m mockAdviceContext) ResolveType(dst.Expr) types.Type {
+	assert.FailNow(m.t, "unexpected method call")
+	return nil
+}
+
+func (m mockAdviceContext) ResolveConstant(dst.Expr) constant.Value {
 	assert.FailNow(m.t, "unexpected method call")
 	return nil
 }

--- a/internal/injector/aspect/concat/concat.go
+++ b/internal/injector/aspect/concat/concat.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package concat provides the shared analysis of Go string concatenation
+// expressions (`+` applied to `string` operands) that is used both to select
+// join points and to expose the resulting operands to code templates.
+//
+// The Go compiler lowers a whole chain of `string` additions into a single
+// concatenation operation. This package therefore identifies the *maximal*
+// chain: the outermost [*dst.BinaryExpr] that is part of one such chain. The
+// chain is then flattened into its operands, in source order.
+package concat
+
+import (
+	"go/constant"
+	"go/token"
+	"go/types"
+
+	"github.com/dave/dst"
+
+	"github.com/DataDog/orchestrion/internal/injector/typed"
+)
+
+// maxFlattenDepth bounds the recursion performed while flattening a
+// concatenation chain. A chain deeper than this is not flattened any further,
+// and the too-deep subtree is retained as a single operand. This can only occur
+// for chains far larger than any supported operand count, which are rejected
+// anyway.
+const maxFlattenDepth = 64
+
+// Resolver provides the type information needed to analyze a concatenation
+// chain. It is satisfied by [context.AspectContext].
+type Resolver interface {
+	// ResolveType resolves an expression to its type, or nil if unknown.
+	ResolveType(dst.Expr) types.Type
+	// ResolveConstant resolves an expression to its compile-time constant value,
+	// or nil if it is not a constant expression.
+	ResolveConstant(dst.Expr) constant.Value
+}
+
+// IsStringConcat reports whether expr is a non-constant string concatenation
+// expression, that is a `+` binary expression whose core type is `string` and
+// which the type-checker did not fold into a constant.
+//
+// Constant concatenations are excluded because the compiler folds them at
+// compile time: there is no run-time operation to advise.
+func IsStringConcat(res Resolver, expr dst.Expr) bool {
+	bin, ok := expr.(*dst.BinaryExpr)
+	if !ok {
+		return false
+	}
+	return IsStringConcatBinary(res, bin)
+}
+
+// IsStringConcatBinary is [IsStringConcat] for an already-known
+// [*dst.BinaryExpr].
+func IsStringConcatBinary(res Resolver, bin *dst.BinaryExpr) bool {
+	if bin.Op != token.ADD {
+		return false
+	}
+	if !typed.IsStringCore(res.ResolveType(bin)) {
+		return false
+	}
+	// A constant-folded concatenation is performed by the compiler, not at
+	// run-time; it is never part of a run-time concatenation chain.
+	return res.ResolveConstant(bin) == nil
+}
+
+// Unparen returns expr with all enclosing [*dst.ParenExpr] removed. Parentheses
+// are not concatenation boundaries for the compiler, so they are transparent to
+// this analysis.
+func Unparen(expr dst.Expr) dst.Expr {
+	for {
+		paren, ok := expr.(*dst.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}
+
+// Flatten returns the operands of the maximal string concatenation chain rooted
+// at root, in source order.
+//
+// A subexpression that the type-checker folded into a constant is retained as a
+// single, atomic operand, matching what the compiler actually concatenates at
+// run time. Parentheses are crossed when they enclose a non-constant string
+// concatenation, and retained as part of the operand otherwise.
+func Flatten(res Resolver, root *dst.BinaryExpr) []dst.Expr {
+	// A chain of n operands has n-1 operators; pre-size for a small chain.
+	operands := make([]dst.Expr, 0, 4)
+	return flatten(res, root, operands, maxFlattenDepth)
+}
+
+// flatten appends the operands of the chain rooted at bin to operands, in source
+// order, and returns the result.
+func flatten(res Resolver, bin *dst.BinaryExpr, operands []dst.Expr, depth int) []dst.Expr {
+	for _, operand := range [...]dst.Expr{bin.X, bin.Y} {
+		// Cross parentheses only to determine whether the operand continues the
+		// chain; the original (possibly parenthesized) expression is retained when
+		// it does not.
+		if inner, ok := Unparen(operand).(*dst.BinaryExpr); ok &&
+			depth > 0 &&
+			IsStringConcatBinary(res, inner) {
+			operands = flatten(res, inner, operands, depth-1)
+			continue
+		}
+		operands = append(operands, operand)
+	}
+	return operands
+}

--- a/internal/injector/aspect/concat/root.go
+++ b/internal/injector/aspect/concat/root.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package concat
+
+import (
+	"github.com/dave/dst"
+
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
+)
+
+// Root returns the root of the maximal string concatenation chain the context's
+// current node belongs to, or nil if that node is not part of a non-constant
+// string concatenation chain.
+//
+// The search crosses [*dst.ParenExpr] ancestors, as parentheses do not split a
+// concatenation chain as far as the compiler is concerned. The returned node is
+// the outermost [*dst.BinaryExpr] of the chain.
+func Root(ctx context.AspectContext) *dst.BinaryExpr {
+	node := ctx.Node()
+
+	// The starting point must itself be part of a concatenation chain. Parentheses
+	// around it are transparent.
+	expr, ok := node.(dst.Expr)
+	if !ok {
+		return nil
+	}
+	root, ok := Unparen(expr).(*dst.BinaryExpr)
+	if !ok || !IsStringConcatBinary(ctx, root) {
+		return nil
+	}
+
+	// Walk outwards for as long as ancestors keep extending the same chain.
+	for curr := ctx.Chain(); curr != nil; curr = curr.Parent() {
+		if curr.Node() == node {
+			// This is the level of the starting node itself.
+			continue
+		}
+
+		switch parent := curr.Node().(type) {
+		case *dst.ParenExpr:
+			// Parentheses are transparent; keep looking outwards.
+			continue
+		case *dst.BinaryExpr:
+			if !IsStringConcatBinary(ctx, parent) {
+				// A different operation (such as a comparison): the chain ends here.
+				return root
+			}
+			root = parent
+		default:
+			// Any other node type ends the chain.
+			return root
+		}
+	}
+
+	return root
+}
+
+// IsRoot reports whether the context's current node is the root of a maximal
+// non-constant string concatenation chain.
+func IsRoot(ctx context.AspectContext) bool {
+	root := Root(ctx)
+	return root != nil && root == ctx.Node()
+}
+
+// RootOperands returns the root of the maximal string concatenation chain the
+// context's current node belongs to, together with that chain's operands in
+// source order. The root is nil if the current node is not part of a
+// non-constant string concatenation chain.
+func RootOperands(ctx context.AspectContext) (*dst.BinaryExpr, []dst.Expr) {
+	root := Root(ctx)
+	if root == nil {
+		return nil, nil
+	}
+	return root, Flatten(ctx, root)
+}

--- a/internal/injector/aspect/context/context.go
+++ b/internal/injector/aspect/context/context.go
@@ -8,6 +8,7 @@ package context
 import (
 	gocontext "context"
 	"go/ast"
+	"go/constant"
 	"go/types"
 	"sync"
 
@@ -53,6 +54,11 @@ type AspectContext interface {
 
 	// ResolveType resolves a dst.Expr to its corresponding types.Type.
 	ResolveType(dst.Expr) types.Type
+
+	// ResolveConstant returns the compile-time constant value of the provided
+	// dst.Expr, or nil if the expression is not a constant expression (or its
+	// value could not be determined).
+	ResolveConstant(dst.Expr) constant.Value
 }
 
 type AdviceContext interface {
@@ -265,6 +271,30 @@ func (c *context) AddLink(path string) bool {
 
 func (c *context) EnsureMinGoLang(lang GoLangVersion) {
 	c.minGoLang.SetAtLeast(lang)
+}
+
+// ResolveConstant returns the compile-time constant value the type-checker
+// determined for the provided expression, or nil if that expression is not a
+// constant expression.
+func (c *context) ResolveConstant(expr dst.Expr) constant.Value {
+	astExpr, ok := c.astExpr(expr)
+	if !ok {
+		return nil
+	}
+
+	return c.typeInfo.Types[astExpr].Value
+}
+
+// astExpr returns the [ast.Expr] that corresponds to the provided [dst.Expr],
+// if one is known to this context.
+func (c *context) astExpr(expr dst.Expr) (ast.Expr, bool) {
+	astNode, ok := c.nodeMap[expr]
+	if !ok {
+		return nil, false
+	}
+
+	astExpr, ok := astNode.(ast.Expr)
+	return astExpr, ok
 }
 
 // ResolveType resolves a dst.Expr to its corresponding types.Type within the

--- a/internal/injector/aspect/join/function_test.go
+++ b/internal/injector/aspect/join/function_test.go
@@ -6,6 +6,7 @@
 package join
 
 import (
+	"go/constant"
 	"go/types"
 	"testing"
 
@@ -336,6 +337,9 @@ func (functionTestContext) Package() string                     { return "test" 
 func (functionTestContext) TestMain() bool                      { return false }
 func (functionTestContext) Release()                            {}
 func (functionTestContext) ResolveType(dst.Expr) types.Type     { return nil }
+func (functionTestContext) ResolveConstant(dst.Expr) constant.Value {
+	return nil
+}
 
 func TestUnmarshalYAMLSignatureContains(t *testing.T) {
 	yamlStr := `

--- a/internal/injector/aspect/join/operator_test.go
+++ b/internal/injector/aspect/join/operator_test.go
@@ -57,6 +57,28 @@ func TestStringConcatYAML(t *testing.T) {
 	}
 }
 
+func TestTypeConversionValidationYAMLAndHash(t *testing.T) {
+	_, err := TypeConversion(ConversionString, ConversionString)
+	require.Error(t, err)
+	unmarshal := unmarshalers["type-conversion"]
+	require.NotNil(t, unmarshal)
+	var value any
+	require.NoError(t, yaml.Unmarshal([]byte(`{from: bytes, to: string}`), &value))
+	node, err := yaml.ValueToNode(value)
+	require.NoError(t, err)
+	point, err := unmarshal(gocontext.Background(), node)
+	require.NoError(t, err)
+	conversion := point.(*typeConversion)
+	require.Equal(t, ConversionBytes, conversion.From)
+	require.Equal(t, ConversionString, conversion.To)
+	first, second := fingerprint.New(), fingerprint.New()
+	require.NoError(t, conversion.Hash(first))
+	reverse, err := TypeConversion(ConversionString, ConversionBytes)
+	require.NoError(t, err)
+	require.NoError(t, reverse.Hash(second))
+	require.NotEqual(t, first.Finish(), second.Finish())
+}
+
 func TestSliceExpressionYAMLAndHash(t *testing.T) {
 	unmarshal := unmarshalers["slice-expression"]
 	require.NotNil(t, unmarshal)

--- a/internal/injector/aspect/join/operator_test.go
+++ b/internal/injector/aspect/join/operator_test.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package join
+
+import (
+	gocontext "context"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
+)
+
+func TestStringConcatBoundsAndHash(t *testing.T) {
+	first, err := StringConcat(2, 16)
+	require.NoError(t, err)
+	same, err := StringConcat(2, 16)
+	require.NoError(t, err)
+	different, err := StringConcat(3, 8)
+	require.NoError(t, err)
+	for _, bounds := range [][2]int{{1, 2}, {2, 17}, {8, 4}} {
+		_, err := StringConcat(bounds[0], bounds[1])
+		require.Error(t, err)
+	}
+	hash := func(point *stringConcat) string {
+		hasher := fingerprint.New()
+		require.NoError(t, point.Hash(hasher))
+		return hasher.Finish()
+	}
+	require.Equal(t, hash(first), hash(same))
+	require.NotEqual(t, hash(first), hash(different))
+}
+
+func TestStringConcatYAML(t *testing.T) {
+	unmarshal := unmarshalers["string-concat"]
+	require.NotNil(t, unmarshal)
+	for _, test := range []struct {
+		source   string
+		min, max int
+	}{
+		{source: `{}`, min: 2, max: 16},
+		{source: `{min-operands: 4, max-operands: 8}`, min: 4, max: 8},
+	} {
+		var value any
+		require.NoError(t, yaml.Unmarshal([]byte(test.source), &value))
+		node, err := yaml.ValueToNode(value)
+		require.NoError(t, err)
+		point, err := unmarshal(gocontext.Background(), node)
+		require.NoError(t, err)
+		concat := point.(*stringConcat)
+		require.Equal(t, test.min, concat.MinOperands)
+		require.Equal(t, test.max, concat.MaxOperands)
+	}
+}
+
+func TestSliceExpressionYAMLAndHash(t *testing.T) {
+	unmarshal := unmarshalers["slice-expression"]
+	require.NotNil(t, unmarshal)
+	for source, expected := range map[string]SliceExpressionOperand{
+		`{operand: string}`: SliceExpressionOperandString,
+		`{operand: bytes}`:  SliceExpressionOperandBytes,
+	} {
+		var value any
+		require.NoError(t, yaml.Unmarshal([]byte(source), &value))
+		node, err := yaml.ValueToNode(value)
+		require.NoError(t, err)
+		point, err := unmarshal(gocontext.Background(), node)
+		require.NoError(t, err)
+		require.Equal(t, expected, point.(*sliceExpression).Operand)
+	}
+	for _, source := range []string{`{}`, `{operand: words}`} {
+		var value any
+		require.NoError(t, yaml.Unmarshal([]byte(source), &value))
+		node, err := yaml.ValueToNode(value)
+		require.NoError(t, err)
+		_, err = unmarshal(gocontext.Background(), node)
+		require.Error(t, err)
+	}
+	stringHasher, bytesHasher := fingerprint.New(), fingerprint.New()
+	require.NoError(t, SliceExpression(SliceExpressionOperandString).Hash(stringHasher))
+	require.NoError(t, SliceExpression(SliceExpressionOperandBytes).Hash(bytesHasher))
+	require.NotEqual(t, stringHasher.Finish(), bytesHasher.Finish())
+}

--- a/internal/injector/aspect/join/package_test.go
+++ b/internal/injector/aspect/join/package_test.go
@@ -7,6 +7,7 @@ package join
 
 import (
 	gocontext "context"
+	"go/constant"
 	"go/types"
 	"testing"
 
@@ -481,3 +482,6 @@ func (*mockAspectContext) Package() string                 { return "" }
 func (*mockAspectContext) TestMain() bool                  { return false }
 func (*mockAspectContext) Release()                        {}
 func (*mockAspectContext) ResolveType(dst.Expr) types.Type { return nil }
+func (*mockAspectContext) ResolveConstant(dst.Expr) constant.Value {
+	return nil
+}

--- a/internal/injector/aspect/join/slice_expression.go
+++ b/internal/injector/aspect/join/slice_expression.go
@@ -9,6 +9,7 @@ import (
 	gocontext "context"
 	"errors"
 	"fmt"
+	"go/types"
 
 	"github.com/dave/dst"
 	"github.com/goccy/go-yaml/ast"
@@ -65,6 +66,15 @@ func (s *sliceExpression) Matches(ctx context.AspectContext) bool {
 		return false
 	}
 
+	for _, bound := range []dst.Expr{expr.Low, expr.High, expr.Max} {
+		if bound == nil {
+			continue
+		}
+		basic, ok := ctx.ResolveType(bound).(*types.Basic)
+		if ok && (basic.Kind() == types.UntypedFloat || basic.Kind() == types.UntypedComplex) {
+			return false
+		}
+	}
 	operandType := ctx.ResolveType(expr.X)
 	switch s.Operand {
 	case SliceExpressionOperandString:

--- a/internal/injector/aspect/join/slice_expression.go
+++ b/internal/injector/aspect/join/slice_expression.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package join
+
+import (
+	gocontext "context"
+	"errors"
+	"fmt"
+
+	"github.com/dave/dst"
+	"github.com/goccy/go-yaml/ast"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
+	"github.com/DataDog/orchestrion/internal/injector/typed"
+	"github.com/DataDog/orchestrion/internal/yaml"
+)
+
+type (
+	// SliceExpressionOperand identifies the kind of operand a `slice-expression`
+	// join point matches.
+	SliceExpressionOperand int
+
+	sliceExpression struct {
+		Operand SliceExpressionOperand
+	}
+)
+
+const (
+	// SliceExpressionOperandString matches slice expressions applied to an operand
+	// whose core type is exactly `string`.
+	SliceExpressionOperandString SliceExpressionOperand = iota
+	// SliceExpressionOperandBytes matches slice expressions applied to an operand
+	// whose core type is exactly `[]byte`.
+	SliceExpressionOperandBytes
+)
+
+// SliceExpression matches slice expressions (`x[low:high]` and, for `bytes`,
+// `x[low:high:max]`) applied to an operand of the designated kind.
+func SliceExpression(operand SliceExpressionOperand) *sliceExpression {
+	return &sliceExpression{Operand: operand}
+}
+
+func (*sliceExpression) ImpliesImported() []string {
+	return nil
+}
+
+func (*sliceExpression) PackageMayMatch(*may.PackageContext) may.MatchType {
+	// A slice expression does not imply any import.
+	return may.Unknown
+}
+
+func (*sliceExpression) FileMayMatch(ctx *may.FileContext) may.MatchType {
+	// A slice expression necessarily involves the `[` token.
+	return ctx.FileContains("[")
+}
+
+func (s *sliceExpression) Matches(ctx context.AspectContext) bool {
+	expr, ok := ctx.Node().(*dst.SliceExpr)
+	if !ok {
+		return false
+	}
+
+	operandType := ctx.ResolveType(expr.X)
+	switch s.Operand {
+	case SliceExpressionOperandString:
+		// A full slice expression (`x[low:high:max]`) is not valid on a string, so
+		// this is rejected defensively.
+		if expr.Max != nil {
+			return false
+		}
+		return typed.IsStringCore(operandType)
+	case SliceExpressionOperandBytes:
+		// Full slice expressions are supported on `[]byte` operands.
+		return typed.IsByteSliceCore(operandType)
+	default:
+		return false
+	}
+}
+
+func (s *sliceExpression) Hash(h *fingerprint.Hasher) error {
+	return h.Named("slice-expression", s.Operand)
+}
+
+func init() {
+	unmarshalers["slice-expression"] = func(ctx gocontext.Context, node ast.Node) (Point, error) {
+		spec := struct {
+			Operand *SliceExpressionOperand `yaml:"operand"`
+		}{}
+		if err := yaml.NodeToValueContext(ctx, node, &spec); err != nil {
+			return nil, err
+		}
+
+		if spec.Operand == nil {
+			return nil, errors.New("slice-expression: missing required field 'operand'")
+		}
+
+		return SliceExpression(*spec.Operand), nil
+	}
+}
+
+var _ yaml.NodeUnmarshalerContext = (*SliceExpressionOperand)(nil)
+
+func (s *SliceExpressionOperand) UnmarshalYAML(ctx gocontext.Context, node ast.Node) error {
+	var name string
+	if err := yaml.NodeToValueContext(ctx, node, &name); err != nil {
+		return err
+	}
+
+	switch name {
+	case "string":
+		*s = SliceExpressionOperandString
+	case "bytes":
+		*s = SliceExpressionOperandBytes
+	default:
+		return fmt.Errorf("invalid slice-expression.operand value: %q", name)
+	}
+
+	return nil
+}
+
+func (s SliceExpressionOperand) String() string {
+	switch s {
+	case SliceExpressionOperandString:
+		return "string"
+	case SliceExpressionOperandBytes:
+		return "bytes"
+	default:
+		return fmt.Sprintf("invalid(%d)", int(s))
+	}
+}
+
+func (s SliceExpressionOperand) Hash(h *fingerprint.Hasher) error {
+	return h.Named("slice-expression-operand", fingerprint.Int(s))
+}

--- a/internal/injector/aspect/join/string_concat.go
+++ b/internal/injector/aspect/join/string_concat.go
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package join
+
+import (
+	gocontext "context"
+	"fmt"
+
+	"github.com/dave/dst"
+	"github.com/goccy/go-yaml/ast"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/concat"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/context"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
+	"github.com/DataDog/orchestrion/internal/yaml"
+)
+
+const (
+	// MinStringConcatOperands is the smallest operand count a `string-concat` join
+	// point may be configured with. A concatenation always has at least two
+	// operands.
+	MinStringConcatOperands = 2
+	// MaxStringConcatOperands is the largest operand count a `string-concat` join
+	// point may be configured with.
+	MaxStringConcatOperands = 16
+)
+
+type stringConcat struct {
+	// MinOperands is the smallest number of operands a chain must have to match.
+	MinOperands int
+	// MaxOperands is the largest number of operands a chain may have to match.
+	MaxOperands int
+}
+
+// StringConcat matches the root of a maximal, non-constant `string`
+// concatenation chain having between minOperands and maxOperands operands
+// (inclusive).
+//
+// Both bounds must be between [MinStringConcatOperands] and
+// [MaxStringConcatOperands], and minOperands must not be greater than
+// maxOperands.
+func StringConcat(minOperands int, maxOperands int) (*stringConcat, error) {
+	if minOperands < MinStringConcatOperands || minOperands > MaxStringConcatOperands {
+		return nil, fmt.Errorf(
+			"string-concat: min-operands must be between %d and %d (got %d)",
+			MinStringConcatOperands, MaxStringConcatOperands, minOperands,
+		)
+	}
+	if maxOperands < MinStringConcatOperands || maxOperands > MaxStringConcatOperands {
+		return nil, fmt.Errorf(
+			"string-concat: max-operands must be between %d and %d (got %d)",
+			MinStringConcatOperands, MaxStringConcatOperands, maxOperands,
+		)
+	}
+	if minOperands > maxOperands {
+		return nil, fmt.Errorf(
+			"string-concat: min-operands (%d) must not be greater than max-operands (%d)",
+			minOperands, maxOperands,
+		)
+	}
+
+	return &stringConcat{MinOperands: minOperands, MaxOperands: maxOperands}, nil
+}
+
+func (*stringConcat) ImpliesImported() []string {
+	return nil
+}
+
+func (*stringConcat) PackageMayMatch(*may.PackageContext) may.MatchType {
+	// A string concatenation does not imply any import.
+	return may.Unknown
+}
+
+func (*stringConcat) FileMayMatch(ctx *may.FileContext) may.MatchType {
+	// A concatenation expression necessarily involves the `+` token.
+	return ctx.FileContains("+")
+}
+
+func (s *stringConcat) Matches(ctx context.AspectContext) bool {
+	// Only ever match the root of a maximal chain, so that the whole
+	// concatenation is advised as the single operation the compiler performs.
+	if _, ok := ctx.Node().(*dst.BinaryExpr); !ok {
+		return false
+	}
+	root := concat.Root(ctx)
+	if root == nil || root != ctx.Node() {
+		return false
+	}
+
+	operands := len(concat.Flatten(ctx, root))
+	return operands >= s.MinOperands && operands <= s.MaxOperands
+}
+
+func (s *stringConcat) Hash(h *fingerprint.Hasher) error {
+	return h.Named("string-concat", fingerprint.Int(s.MinOperands), fingerprint.Int(s.MaxOperands))
+}
+
+func init() {
+	unmarshalers["string-concat"] = func(ctx gocontext.Context, node ast.Node) (Point, error) {
+		spec := struct {
+			MinOperands *int `yaml:"min-operands"`
+			MaxOperands *int `yaml:"max-operands"`
+		}{}
+		if err := yaml.NodeToValueContext(ctx, node, &spec); err != nil {
+			return nil, err
+		}
+
+		minOperands := MinStringConcatOperands
+		if spec.MinOperands != nil {
+			minOperands = *spec.MinOperands
+		}
+		maxOperands := MaxStringConcatOperands
+		if spec.MaxOperands != nil {
+			maxOperands = *spec.MaxOperands
+		}
+
+		return StringConcat(minOperands, maxOperands)
+	}
+}

--- a/internal/injector/aspect/join/type_conversion.go
+++ b/internal/injector/aspect/join/type_conversion.go
@@ -1,0 +1,146 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package join
+
+import (
+	gocontext "context"
+	"errors"
+	"fmt"
+	"go/types"
+
+	"github.com/dave/dst"
+	"github.com/goccy/go-yaml/ast"
+
+	"github.com/DataDog/orchestrion/internal/fingerprint"
+	aspectcontext "github.com/DataDog/orchestrion/internal/injector/aspect/context"
+	"github.com/DataDog/orchestrion/internal/injector/aspect/may"
+	"github.com/DataDog/orchestrion/internal/injector/typed"
+	"github.com/DataDog/orchestrion/internal/yaml"
+)
+
+// ConversionType identifies a string or byte-slice conversion endpoint.
+type ConversionType int
+
+const (
+	ConversionString ConversionType = iota
+	ConversionBytes
+)
+
+type typeConversion struct{ From, To ConversionType }
+
+// TypeConversion creates a matcher for assignment- or return-context conversions.
+func TypeConversion(from, to ConversionType) (*typeConversion, error) {
+	if from == to || from < ConversionString || from > ConversionBytes || to < ConversionString || to > ConversionBytes {
+		return nil, errors.New("type-conversion requires distinct string and bytes types")
+	}
+	return &typeConversion{From: from, To: to}, nil
+}
+func (*typeConversion) ImpliesImported() []string                         { return nil }
+func (*typeConversion) PackageMayMatch(*may.PackageContext) may.MatchType { return may.Unknown }
+func (*typeConversion) FileMayMatch(*may.FileContext) may.MatchType       { return may.Unknown }
+func (conversion *typeConversion) Matches(ctx aspectcontext.AspectContext) bool {
+	call, ok := ctx.Node().(*dst.CallExpr)
+	if !ok || len(call.Args) != 1 || call.Ellipsis {
+		return false
+	}
+	if !conversion.matches(ctx.ResolveType(call.Args[0]), conversion.From) || !conversion.matches(ctx.ResolveType(call.Fun), conversion.To) {
+		return false
+	}
+	chain := ctx.Chain()
+	if chain != nil {
+		chain = chain.Parent()
+	}
+	for chain != nil {
+		switch parent := chain.Node().(type) {
+		case *dst.ParenExpr:
+			chain = chain.Parent()
+			continue
+		case *dst.ReturnStmt:
+			return true
+		case *dst.AssignStmt:
+			if conversion.To == ConversionBytes {
+				return false
+			}
+			return !assignmentDiscards(parent, call)
+		case *dst.ValueSpec:
+			if conversion.To == ConversionBytes {
+				return false
+			}
+			return !valueSpecDiscards(parent, call)
+		default:
+			return false
+		}
+	}
+	return false
+}
+func assignmentDiscards(assignment *dst.AssignStmt, call *dst.CallExpr) bool {
+	for index, expression := range assignment.Rhs {
+		if unparenExpression(expression) != call || index >= len(assignment.Lhs) {
+			continue
+		}
+		identifier, ok := assignment.Lhs[index].(*dst.Ident)
+		return ok && identifier.Name == "_"
+	}
+	return false
+}
+
+func valueSpecDiscards(spec *dst.ValueSpec, call *dst.CallExpr) bool {
+	for index, expression := range spec.Values {
+		if unparenExpression(expression) != call || index >= len(spec.Names) {
+			continue
+		}
+		return spec.Names[index].Name == "_"
+	}
+	return false
+}
+
+func unparenExpression(expression dst.Expr) dst.Expr {
+	for {
+		parenthesized, ok := expression.(*dst.ParenExpr)
+		if !ok {
+			return expression
+		}
+		expression = parenthesized.X
+	}
+}
+
+func (*typeConversion) matches(resolved types.Type, kind ConversionType) bool {
+	if kind == ConversionString {
+		return typed.IsStringCore(resolved)
+	}
+	return typed.IsByteSliceCore(resolved)
+}
+func (conversion *typeConversion) Hash(hasher *fingerprint.Hasher) error {
+	return hasher.Named("type-conversion", fingerprint.Int(conversion.From), fingerprint.Int(conversion.To))
+}
+
+func init() {
+	unmarshalers["type-conversion"] = func(ctx gocontext.Context, node ast.Node) (Point, error) {
+		var spec struct{ From, To string }
+		if err := yaml.NodeToValueContext(ctx, node, &spec); err != nil {
+			return nil, err
+		}
+		parse := func(value string) (ConversionType, error) {
+			switch value {
+			case "string":
+				return ConversionString, nil
+			case "bytes":
+				return ConversionBytes, nil
+			default:
+				return 0, fmt.Errorf("invalid conversion type %q", value)
+			}
+		}
+		from, err := parse(spec.From)
+		if err != nil {
+			return nil, err
+		}
+		to, err := parse(spec.To)
+		if err != nil {
+			return nil, err
+		}
+		return TypeConversion(from, to)
+	}
+}

--- a/internal/injector/config/schema.json
+++ b/internal/injector/config/schema.json
@@ -373,6 +373,8 @@
         { "$ref": "#/$defs/join-point/function-call" },
         { "$ref": "#/$defs/join-point/import-path" },
         { "$ref": "#/$defs/join-point/method-call" },
+        { "$ref": "#/$defs/join-point/slice-expression" },
+        { "$ref": "#/$defs/join-point/string-concat" },
         { "$ref": "#/$defs/join-point/not" },
         { "$ref": "#/$defs/join-point/one-of" },
         { "$ref": "#/$defs/join-point/package-name" },
@@ -632,6 +634,60 @@
         "examples": [
           { "import-path": "net/http" },
           { "import-path": "github.com/gorilla/mux" }
+        ]
+      },
+      "slice-expression": {
+        "required": ["slice-expression"],
+        "unevaluatedProperties": false,
+        "properties": {
+          "slice-expression": {
+            "title": "Target typed slice expressions",
+            "markdownDescription": "The `slice-expression` join point matches slice expressions whose operand has the selected core type.",
+            "type": "object",
+            "required": ["operand"],
+            "properties": {
+              "operand": {
+                "description": "The operand core type to match.",
+                "type": "string",
+                "enum": ["string", "bytes"]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "examples": [
+          { "slice-expression": { "operand": "string" } },
+          { "slice-expression": { "operand": "bytes" } }
+        ]
+      },
+      "string-concat": {
+        "required": ["string-concat"],
+        "unevaluatedProperties": false,
+        "properties": {
+          "string-concat": {
+            "title": "Target maximal string concatenations",
+            "markdownDescription": "The `string-concat` join point matches one maximal non-constant string addition chain within the configured operand bounds.",
+            "type": "object",
+            "properties": {
+              "min-operands": {
+                "type": "integer",
+                "minimum": 2,
+                "maximum": 16,
+                "default": 2
+              },
+              "max-operands": {
+                "type": "integer",
+                "minimum": 2,
+                "maximum": 16,
+                "default": 16
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "examples": [
+          { "string-concat": {} },
+          { "string-concat": { "min-operands": 2, "max-operands": 8 } }
         ]
       },
       "method-call": {

--- a/internal/injector/config/schema.json
+++ b/internal/injector/config/schema.json
@@ -382,6 +382,7 @@
         { "$ref": "#/$defs/join-point/struct-definition" },
         { "$ref": "#/$defs/join-point/struct-literal" },
         { "$ref": "#/$defs/join-point/test-main" },
+        { "$ref": "#/$defs/join-point/type-conversion" },
         { "$ref": "#/$defs/join-point/value-declaration" }
       ]
     },
@@ -920,6 +921,27 @@
             "type": "boolean"
           }
         }
+      },
+      "type-conversion": {
+        "required": ["type-conversion"],
+        "unevaluatedProperties": false,
+        "properties": {
+          "type-conversion": {
+            "title": "Target string and byte conversions",
+            "markdownDescription": "Matches explicit byte-to-string conversions in non-discarded assignment, value declaration, and return contexts. String-to-byte conversions match only direct return contexts, where the result necessarily escapes. Optimized calls, comparisons, ranges, map keys, concatenations, and other parent contexts are excluded.",
+            "type": "object",
+            "required": ["from", "to"],
+            "properties": {
+              "from": { "type": "string", "enum": ["string", "bytes"] },
+              "to": { "type": "string", "enum": ["string", "bytes"] }
+            },
+            "additionalProperties": false
+          }
+        },
+        "examples": [
+          { "type-conversion": { "from": "bytes", "to": "string" } },
+          { "type-conversion": { "from": "string", "to": "bytes" } }
+        ]
       },
       "value-declaration": {
         "required": ["value-declaration"],

--- a/internal/injector/testdata/injector/operator-join-points/config.yml
+++ b/internal/injector/testdata/injector/operator-join-points/config.yml
@@ -21,6 +21,22 @@ aspects:
     advice:
       - wrap-expression:
           template: markString({{ .AST }})
+  - id: bytes-to-string
+    join-point:
+      type-conversion:
+        from: bytes
+        to: string
+    advice:
+      - wrap-expression:
+          template: markString({{ .AST }})
+  - id: string-to-bytes
+    join-point:
+      type-conversion:
+        from: string
+        to: bytes
+    advice:
+      - wrap-expression:
+          template: markBytes({{ .AST }})
   - id: byte-slice
     join-point:
       slice-expression:
@@ -46,4 +62,16 @@ code: |-
     _ = s[low:high]
     _ = data[low:high]
     _ = data[low:high:cap(data)]
+    convertedString := string(data)
+    convertedBytes := []byte(s)
+    _, _ = convertedString, convertedBytes
+    _ = len(string(data))
+  }
+
+  func returned(data []byte) string {
+    return string(data)
+  }
+
+  func returnedBytes(value string) []byte {
+    return []byte(value)
   }

--- a/internal/injector/testdata/injector/operator-join-points/config.yml
+++ b/internal/injector/testdata/injector/operator-join-points/config.yml
@@ -60,6 +60,7 @@ code: |-
     _ = a + ("x" + "y")
     _ = "x" + "y"
     _ = s[low:high]
+    _ = s[1.0:]
     _ = data[low:high]
     _ = data[low:high:cap(data)]
     convertedString := string(data)

--- a/internal/injector/testdata/injector/operator-join-points/config.yml
+++ b/internal/injector/testdata/injector/operator-join-points/config.yml
@@ -1,0 +1,49 @@
+%YAML 1.1
+---
+aspects:
+  - id: maximal-string-concat
+    join-point:
+      string-concat:
+        min-operands: 2
+        max-operands: 4
+    advice:
+      - wrap-expression:
+          template: |-
+            markConcat(
+              {{- range .StringConcatOperands }}
+              {{ . }},
+              {{- end }}
+            )
+  - id: string-slice
+    join-point:
+      slice-expression:
+        operand: string
+    advice:
+      - wrap-expression:
+          template: markString({{ .AST }})
+  - id: byte-slice
+    join-point:
+      slice-expression:
+        operand: bytes
+    advice:
+      - wrap-expression:
+          template: markBytes({{ .AST }})
+
+code: |-
+  package test
+
+  type namedString string
+  type namedBytes []byte
+
+  func markConcat(values ...string) string { return "" }
+  func markString[T ~string](value T) T { return value }
+  func markBytes[T ~[]byte](value T) T { return value }
+
+  func operators(a, b, c string, s namedString, data namedBytes, low, high int) {
+    _ = a + b + c
+    _ = a + ("x" + "y")
+    _ = "x" + "y"
+    _ = s[low:high]
+    _ = data[low:high]
+    _ = data[low:high:cap(data)]
+  }

--- a/internal/injector/testdata/injector/operator-join-points/modified.go.snap
+++ b/internal/injector/testdata/injector/operator-join-points/modified.go.snap
@@ -35,4 +35,26 @@ func operators(a, b, c string, s namedString, data namedBytes, low, high int) {
     markBytes(
 //line input.go:16
       data[low:high:cap(data)])
+  convertedString :=
+//line <generated>:1
+    markString(
+//line input.go:17
+      string(data))
+  convertedBytes := []byte(s)
+  _, _ = convertedString, convertedBytes
+  _ = len(string(data))
+}
+
+func returned(data []byte) string {
+  return markString(//line <generated>:1
+
+//line input.go:24
+    string(data))
+}
+
+func returnedBytes(value string) []byte {
+  return markBytes(//line <generated>:1
+
+//line input.go:28
+    []byte(value))
 }

--- a/internal/injector/testdata/injector/operator-join-points/modified.go.snap
+++ b/internal/injector/testdata/injector/operator-join-points/modified.go.snap
@@ -27,18 +27,23 @@ func operators(a, b, c string, s namedString, data namedBytes, low, high int) {
       s[low:high])
   _ =
 //line <generated>:1
-    markBytes(
+    markString(
 //line input.go:15
-      data[low:high])
+      s[1.0:])
   _ =
 //line <generated>:1
     markBytes(
 //line input.go:16
+      data[low:high])
+  _ =
+//line <generated>:1
+    markBytes(
+//line input.go:17
       data[low:high:cap(data)])
   convertedString :=
 //line <generated>:1
     markString(
-//line input.go:17
+//line input.go:18
       string(data))
   convertedBytes := []byte(s)
   _, _ = convertedString, convertedBytes
@@ -48,13 +53,13 @@ func operators(a, b, c string, s namedString, data namedBytes, low, high int) {
 func returned(data []byte) string {
   return markString(//line <generated>:1
 
-//line input.go:24
+//line input.go:25
     string(data))
 }
 
 func returnedBytes(value string) []byte {
   return markBytes(//line <generated>:1
 
-//line input.go:28
+//line input.go:29
     []byte(value))
 }

--- a/internal/injector/testdata/injector/operator-join-points/modified.go.snap
+++ b/internal/injector/testdata/injector/operator-join-points/modified.go.snap
@@ -1,0 +1,38 @@
+//line input.go:1:1
+package test
+
+type namedString string
+type namedBytes []byte
+
+func markConcat(values ...string) string { return "" }
+func markString[T ~string](value T) T    { return value }
+func markBytes[T ~[]byte](value T) T     { return value }
+
+func operators(a, b, c string, s namedString, data namedBytes, low, high int) {
+  _ =
+//line <generated>:1
+    markConcat(
+//line input.go:11
+      a, b, c)
+  _ =
+//line <generated>:1
+    markConcat(
+//line input.go:12
+      a, ("x" + "y"))
+  _ = "x" + "y"
+  _ =
+//line <generated>:1
+    markString(
+//line input.go:14
+      s[low:high])
+  _ =
+//line <generated>:1
+    markBytes(
+//line input.go:15
+      data[low:high])
+  _ =
+//line <generated>:1
+    markBytes(
+//line input.go:16
+      data[low:high:cap(data)])
+}

--- a/internal/injector/typed/coretype.go
+++ b/internal/injector/typed/coretype.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package typed
+
+import "go/types"
+
+// maxCoreTypeDepth bounds the recursion performed while computing the core type
+// of a type parameter, so that pathological (or cyclic) constraint hierarchies
+// can never cause unbounded recursion.
+const maxCoreTypeDepth = 16
+
+// CoreType returns the core type of t as defined by the Go language
+// specification, or nil if t has no core type (for example an interface with
+// more than one distinct underlying type in its type set).
+//
+// For ordinary (non type-parameter) types, the core type is simply the
+// underlying type. For a type parameter, it is the single underlying type shared
+// by every term of its constraint's type set.
+func CoreType(t types.Type) types.Type {
+	if t == nil {
+		return nil
+	}
+
+	t = types.Unalias(t)
+	if tp, ok := t.(*types.TypeParam); ok {
+		return typeParamCoreType(tp, maxCoreTypeDepth)
+	}
+
+	return t.Underlying()
+}
+
+// typeParamCoreType computes the core type of a type parameter by intersecting
+// the underlying types of all the terms in its constraint's type set. It returns
+// nil when the type set is empty, unbounded, or contains terms with differing
+// underlying types.
+func typeParamCoreType(tp *types.TypeParam, depth int) types.Type {
+	iface, ok := types.Unalias(tp.Constraint()).Underlying().(*types.Interface)
+	if !ok {
+		return nil
+	}
+
+	core, found := interfaceCoreType(iface, depth)
+	if !found {
+		return nil
+	}
+	return core
+}
+
+// interfaceCoreType returns the single underlying type shared by every term of
+// the given interface's type set. The boolean result reports whether such a type
+// was found; it is false when the interface constrains no types at all (only
+// methods), or when its terms do not all share the same underlying type.
+func interfaceCoreType(iface *types.Interface, depth int) (types.Type, bool) {
+	if depth <= 0 {
+		return nil, false
+	}
+
+	var core types.Type
+	for i := range iface.NumEmbeddeds() {
+		embedded := types.Unalias(iface.EmbeddedType(i))
+		if named, ok := embedded.(*types.Named); ok {
+			embedded = named.Underlying()
+		}
+
+		var terms []types.Type
+		switch embedded := embedded.(type) {
+		case *types.Union:
+			for j := range embedded.Len() {
+				terms = append(terms, types.Unalias(embedded.Term(j).Type()))
+			}
+		case *types.Interface:
+			// Method-only and comparable interfaces do not widen an intersection,
+			// so they contribute no core term. A nested type restriction contributes
+			// its own core type.
+			nested, found := interfaceCoreType(embedded, depth-1)
+			if !found {
+				continue
+			}
+			terms = []types.Type{nested}
+		default:
+			terms = []types.Type{embedded}
+		}
+
+		for _, term := range terms {
+			underlying := term.Underlying()
+			if core == nil {
+				core = underlying
+				continue
+			}
+			if !types.Identical(core, underlying) {
+				// More than one distinct underlying type: there is no core type.
+				return nil, false
+			}
+		}
+	}
+
+	return core, core != nil
+}
+
+// IsStringCore reports whether the core type of t is exactly the predeclared
+// `string` type. This is true of `string` itself, of defined types whose
+// underlying type is `string`, and of type parameters constrained to a single
+// `string`-based type set (such as `~string`).
+//
+// Untyped string constants are not matched, as their type is
+// [types.UntypedString].
+func IsStringCore(t types.Type) bool {
+	basic, ok := CoreType(t).(*types.Basic)
+	return ok && basic.Kind() == types.String
+}
+
+// IsByteSliceCore reports whether the core type of t is exactly `[]byte`. Slices
+// of a defined type whose underlying type is `byte` (such as
+// `type myByte byte`) are deliberately not matched, as they are not `[]byte`.
+func IsByteSliceCore(t types.Type) bool {
+	slice, ok := CoreType(t).(*types.Slice)
+	return ok && types.Identical(slice.Elem(), types.Typ[types.Byte])
+}

--- a/internal/injector/typed/coretype_test.go
+++ b/internal/injector/typed/coretype_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package typed
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoreTypePredicates(t *testing.T) {
+	pkg := types.NewPackage("example.com/types", "types")
+	namedString := types.NewNamed(types.NewTypeName(token.NoPos, pkg, "String", nil), types.Typ[types.String], nil)
+	namedByte := types.NewNamed(types.NewTypeName(token.NoPos, pkg, "Byte", nil), types.Typ[types.Byte], nil)
+	require.True(t, IsStringCore(types.Typ[types.String]))
+	require.True(t, IsStringCore(namedString))
+	require.False(t, IsStringCore(types.Typ[types.UntypedString]))
+	require.False(t, IsStringCore(nil))
+	require.True(t, IsByteSliceCore(types.NewSlice(types.Typ[types.Byte])))
+	require.False(t, IsByteSliceCore(types.NewSlice(namedByte)))
+	require.False(t, IsByteSliceCore(types.NewArray(types.Typ[types.Byte], 2)))
+}
+
+func TestTypeParameterCoreType(t *testing.T) {
+	stringTerm := types.NewTerm(true, types.Typ[types.String])
+	constraint := types.NewInterfaceType(nil, []types.Type{types.NewUnion([]*types.Term{stringTerm})})
+	constraint.Complete()
+	parameter := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "T", nil), constraint)
+	require.True(t, IsStringCore(parameter))
+
+	comparableConstraint := types.NewInterfaceType(nil, []types.Type{
+		types.NewUnion([]*types.Term{stringTerm}),
+		types.Universe.Lookup("comparable").Type(),
+	})
+	comparableConstraint.Complete()
+	comparableParameter := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "C", nil), comparableConstraint)
+	require.True(t, IsStringCore(comparableParameter))
+
+	mixed := types.NewInterfaceType(nil, []types.Type{types.NewUnion([]*types.Term{
+		types.NewTerm(true, types.Typ[types.String]),
+		types.NewTerm(true, types.Typ[types.Int]),
+	})})
+	mixed.Complete()
+	mixedParameter := types.NewTypeParam(types.NewTypeName(token.NoPos, nil, "M", nil), mixed)
+	require.Nil(t, CoreType(mixedParameter))
+}

--- a/internal/toolexec/proxy/compile.flags.go
+++ b/internal/toolexec/proxy/compile.flags.go
@@ -10,7 +10,7 @@ package proxy
 import "flag"
 
 func (f *compileFlagSet) parse(args []string) ([]string, error) {
-	flagSet := flag.NewFlagSet("compile version go1.25", flag.ContinueOnError)
+	flagSet := flag.NewFlagSet("compile version go1.26", flag.ContinueOnError)
 	flagSet.Bool("%", false, "debug non-static initializers")
 	flagSet.Bool("+", false, "compiling runtime")
 	flagSet.Bool("B", false, "disable bounds checking")

--- a/internal/toolexec/proxy/link.flags.go
+++ b/internal/toolexec/proxy/link.flags.go
@@ -10,8 +10,9 @@ package proxy
 import "flag"
 
 func (f *linkFlagSet) parse(args []string) ([]string, error) {
-	flagSet := flag.NewFlagSet("link version go1.25", flag.ContinueOnError)
+	flagSet := flag.NewFlagSet("link version go1.26", flag.ContinueOnError)
 	flagSet.String("B", "", "set ELF NT_GNU_BUILD_ID note or Mach-O UUID; use \"gobuildid\" to generate it from the Go build ID; \"none\" to disable")
+	flagSet.Int("D", 0, "set the start address of data symbols")
 	flagSet.String("E", "", "set entry symbol name")
 	flagSet.String("H", "", "set header type")
 	flagSet.String("I", "", "use linker as ELF dynamic linker")


### PR DESCRIPTION
## Why

IAST taint propagation needs to advise compiler operator expressions without matching arithmetic, unrelated slices, nested concat subexpressions, or folded constant-only chains. Existing call-oriented join points cannot identify these shapes.

## What

- Add `string-concat` for bounded maximal non-constant string addition chains.
- Add `slice-expression` for typed `string` and `[]byte` operands.
- Expose source-ordered, constant-aware concat operands and safe slice-bound presence helpers to advice templates.
- Add bounded core-type resolution for defined and constrained types.
- Add schema validation, unit tests, and a compiled injector golden covering maximal selection, parentheses, constant folding, and two-/three-index slices.

The change intentionally does not add mutation-oriented `append`/`copy` support or conversion matching.