### PR TITLE
fix(pin): resolve dependency imports from the consuming module, not their own directory

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,7 +54,7 @@ jobs:
         if: github.event_name != 'push'
         run: |-
           currentTag=$(go run . version -static | cut -d' ' -f 2)
-          find . -iname go.mod -not -path './_docs/themes/**' -print0 | while IFS= read -r -d '' gomod; do
+          find . -iname go.mod -not -path './_docs/themes/**' -not -path '*/testdata/*' -print0 | while IFS= read -r -d '' gomod; do
             dir="$(dirname "${gomod}")"
             if [[ -n $(go -C="${dir}" mod edit --json | jq '(.Replace // []).[] | select(.Old.Path == "github.com/DataDog/orchestrion")') ]]; then
               echo "Aligning orchestrion version in ${dir} to ${currentTag} if necessary..."

--- a/internal/injector/config/config-go.go
+++ b/internal/injector/config/config-go.go
@@ -26,6 +26,33 @@ const FilenameOrchestrionToolGo = "orchestrion.tool.go"
 
 var ErrInvalidGoPackage = errors.New("no .go files in package")
 
+// isNoGoFilesError reports whether e is the (poorly-typed) error emitted by
+// [packages.Load] when a package's directory has no Go files at all -- as
+// opposed to the package failing to resolve in the first place.
+func isNoGoFilesError(e packages.Error) bool {
+	return e.Kind == packages.ListError && strings.Contains(e.Msg, "no Go files in")
+}
+
+// unresolvedError returns a non-nil error if pkg.Errors indicates the package
+// could not be resolved at all (module not found, a `replace` directive
+// pointing at a missing directory, an unreachable proxy, inconsistent
+// vendoring, ...), as opposed to resolving to an empty, Go-file-less
+// directory. A resolution failure must never be mistaken for evidence that the
+// package lacks configuration.
+func unresolvedError(pkg *packages.Package) error {
+	var errs []error
+	for _, e := range pkg.Errors {
+		if isNoGoFilesError(e) {
+			continue
+		}
+		errs = append(errs, e)
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("resolving %q: %w", pkg.PkgPath, errors.Join(errs...))
+}
+
 // loadGoPackage loads configuration from the specified go package.
 func (l *Loader) loadGoPackage(ctx context.Context, pkg *packages.Package) (_ *configGo, err error) {
 	// Special-case the `github.com/DataDog/orchestrion` package, we need not
@@ -48,7 +75,7 @@ func (l *Loader) loadGoPackage(ctx context.Context, pkg *packages.Package) (_ *c
 			var err error
 			for _, e := range pkg.Errors {
 				var innerErr error = e
-				if e.Kind == packages.ListError && strings.Contains(e.Msg, "no Go files in") { // Workaround poor error typing in packages.Load
+				if isNoGoFilesError(e) {
 					innerErr = fmt.Errorf("no Go files found, was expecting at least orchestrion.tool.go: %w", e)
 				}
 				err = errors.Join(err, innerErr)

--- a/internal/injector/config/config.go
+++ b/internal/injector/config/config.go
@@ -26,19 +26,32 @@ type Config interface {
 	visit(Visitor, string) error
 }
 
+// PackageLoader resolves package patterns. The string argument is the
+// directory the patterns are resolved from: it selects which module is
+// "main" for the resolution, and therefore which `replace` directives and
+// which `go.sum` apply. It must always be the consuming module's directory,
+// never the directory of the package the patterns were found in.
 type PackageLoader = func(context.Context, string, ...string) ([]*packages.Package, error)
 
 // HasConfig determines whether the specified package contains injector
-// configuration, and optionally validates it. If the [PackageLoader] is nil,
-// a default implementation is used.
-func HasConfig(ctx context.Context, pkgLoader PackageLoader, pkg *packages.Package, validate bool) (bool, error) {
-	root := packageRoot(pkg)
-	if root == "" {
-		// It contains no .go file, so it can't contain configuration.
+// configuration, and optionally validates it. Configuration files are read
+// from pkg's own directory, but import paths found in them are resolved from
+// dir, which must be the directory of the module consuming pkg (the main
+// module) -- never pkg's own directory, which for a module-cache dependency
+// would apply that dependency's `replace` directives. If the [PackageLoader]
+// is nil, a default implementation is used.
+func HasConfig(ctx context.Context, pkgLoader PackageLoader, dir string, pkg *packages.Package, validate bool) (bool, error) {
+	if packageRoot(pkg) == "" {
+		if err := unresolvedError(pkg); err != nil {
+			// The package failed to resolve entirely; we cannot tell whether it
+			// provides configuration, so this must not be reported as "no config".
+			return false, err
+		}
+		// Directory resolved and provably holds no Go source: no configuration.
 		return false, nil
 	}
 
-	l := NewLoader(pkgLoader, root, validate)
+	l := NewLoader(pkgLoader, dir, validate)
 	cfg, err := l.loadGoPackage(ctx, pkg)
 	if err != nil {
 		return false, err
@@ -66,6 +79,9 @@ func defaultPackageLoader(ctx context.Context, dir string, patterns ...string) (
 		Context: ctx,
 		Dir:     dir,
 		Mode:    packages.NeedName | packages.NeedFiles,
+		// Neutralize any `-toolexec` inherited from GOFLAGS: resolving
+		// configuration must never recurse into orchestrion itself.
+		BuildFlags: []string{"-toolexec="},
 	}
 	return packages.Load(cfg, patterns...)
 }

--- a/internal/injector/config/config_test.go
+++ b/internal/injector/config/config_test.go
@@ -29,7 +29,7 @@ func TestHasConfig(t *testing.T) {
 		t.Run("no source files at all", func(t *testing.T) {
 			t.Parallel()
 
-			hasCfg, err := HasConfig(context.Background(), nil, &packages.Package{}, true)
+			hasCfg, err := HasConfig(context.Background(), nil, t.TempDir(), &packages.Package{}, true)
 			require.NoError(t, err)
 			require.False(t, hasCfg)
 		})
@@ -37,7 +37,7 @@ func TestHasConfig(t *testing.T) {
 		t.Run("ignored files", func(t *testing.T) {
 			t.Parallel()
 
-			hasCfg, err := HasConfig(context.Background(), nil, &packages.Package{IgnoredFiles: []string{filepath.Join(t.TempDir(), "test.go")}}, true)
+			hasCfg, err := HasConfig(context.Background(), nil, t.TempDir(), &packages.Package{IgnoredFiles: []string{filepath.Join(t.TempDir(), "test.go")}}, true)
 			require.NoError(t, err)
 			require.False(t, hasCfg)
 		})
@@ -45,7 +45,7 @@ func TestHasConfig(t *testing.T) {
 		t.Run("regular files", func(t *testing.T) {
 			t.Parallel()
 
-			hasCfg, err := HasConfig(context.Background(), nil, &packages.Package{GoFiles: []string{filepath.Join(t.TempDir(), "test.go")}}, true)
+			hasCfg, err := HasConfig(context.Background(), nil, t.TempDir(), &packages.Package{GoFiles: []string{filepath.Join(t.TempDir(), "test.go")}}, true)
 			require.NoError(t, err)
 			require.False(t, hasCfg)
 		})
@@ -74,7 +74,7 @@ func TestHasConfig(t *testing.T) {
 				PkgPath: "github.com/DataDog/orchestrion/config_test",
 				GoFiles: []string{filepath.Join(pkgRoot, FilenameOrchestrionToolGo)},
 			}
-			hasCfg, err := HasConfig(context.Background(), nil, pkg, true)
+			hasCfg, err := HasConfig(context.Background(), nil, pkgRoot, pkg, true)
 			require.NoError(t, err)
 			require.True(t, hasCfg)
 		})
@@ -90,7 +90,7 @@ func TestHasConfig(t *testing.T) {
 				PkgPath: "github.com/DataDog/orchestrion/config_test",
 				GoFiles: []string{filepath.Join(pkgRoot, "main.go")},
 			}
-			hasCfg, err := HasConfig(context.Background(), nil, pkg, true)
+			hasCfg, err := HasConfig(context.Background(), nil, pkgRoot, pkg, true)
 			require.NoError(t, err)
 			require.True(t, hasCfg)
 		})
@@ -114,7 +114,7 @@ func TestHasConfig(t *testing.T) {
 				PkgPath: "github.com/DataDog/orchestrion/config_test",
 				GoFiles: []string{filepath.Join(pkgRoot, FilenameOrchestrionToolGo)},
 			}
-			hasCfg, err := HasConfig(context.Background(), nil, pkg, true)
+			hasCfg, err := HasConfig(context.Background(), nil, pkgRoot, pkg, true)
 			require.NoError(t, err)
 			require.True(t, hasCfg)
 		})
@@ -139,7 +139,7 @@ func TestHasConfig(t *testing.T) {
 				PkgPath: "github.com/DataDog/orchestrion/config_test",
 				GoFiles: []string{filepath.Join(pkgRoot, FilenameOrchestrionToolGo)},
 			}
-			hasCfg, err := HasConfig(context.Background(), nil, pkg, false)
+			hasCfg, err := HasConfig(context.Background(), nil, pkgRoot, pkg, false)
 			require.NoError(t, err)
 			require.True(t, hasCfg)
 		})
@@ -164,9 +164,118 @@ func TestHasConfig(t *testing.T) {
 				PkgPath: "github.com/DataDog/orchestrion/config_test",
 				GoFiles: []string{filepath.Join(pkgRoot, FilenameOrchestrionToolGo)},
 			}
-			_, err := HasConfig(context.Background(), nil, pkg, true)
+			_, err := HasConfig(context.Background(), nil, pkgRoot, pkg, true)
 			require.ErrorContains(t, err, "meta is required")
 		})
+	})
+}
+
+// TestHasConfigErrorClassification pins the invariant that pruning code
+// relies on: HasConfig must only ever report "no configuration" when it
+// positively established that, never merely because something failed to
+// resolve.
+func TestHasConfigErrorClassification(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no Go files in the package directory is not an error", func(t *testing.T) {
+		t.Parallel()
+
+		pkg := &packages.Package{
+			PkgPath: "example.com/x",
+			Errors:  []packages.Error{{Kind: packages.ListError, Msg: "no Go files in /x"}},
+		}
+		hasCfg, err := HasConfig(context.Background(), nil, t.TempDir(), pkg, false)
+		require.NoError(t, err)
+		require.False(t, hasCfg)
+	})
+
+	t.Run("a module that could not be found is an error, not \"no config\"", func(t *testing.T) {
+		t.Parallel()
+
+		pkg := &packages.Package{
+			PkgPath: "example.com/x",
+			Errors:  []packages.Error{{Kind: packages.ListError, Msg: "no required module provides package example.com/x; to add it:\n\tgo get example.com/x"}},
+		}
+		_, err := HasConfig(context.Background(), nil, t.TempDir(), pkg, false)
+		require.Error(t, err)
+	})
+
+	t.Run("a broken replace directive is an error, not \"no config\"", func(t *testing.T) {
+		t.Parallel()
+
+		// Issue #760: this is the exact shape of the error dd-trace-go's own
+		// checkout-relative `replace` directives produce when resolved outside
+		// of a dd-trace-go checkout.
+		pkg := &packages.Package{
+			PkgPath: "example.com/x",
+			Errors:  []packages.Error{{Msg: "example.com/x@v1.0.0: replacement directory ../does-not-exist does not exist"}},
+		}
+		_, err := HasConfig(context.Background(), nil, t.TempDir(), pkg, false)
+		require.Error(t, err)
+	})
+}
+
+// TestHasConfigResolvesFromConsumerModule is a regression test for issue #760:
+// a dependency's own go.mod may carry `replace` directives whose paths are
+// only valid inside its own checkout (dd-trace-go's `orchestrion/all/v2`
+// carries several such directives, e.g. `=> ../../contrib/...`). Import paths
+// found in that dependency's orchestrion.tool.go file must be resolved from
+// the module that *consumes* the dependency, never from the dependency's own
+// directory -- otherwise those checkout-relative replace directives get
+// applied and fail to resolve.
+func TestHasConfigResolvesFromConsumerModule(t *testing.T) {
+	t.Parallel()
+
+	thingDir := t.TempDir()
+	runGo(t, thingDir, "mod", "init", "example.com/thing")
+	require.NoError(t, os.WriteFile(filepath.Join(thingDir, "thing.go"), []byte(`package thing`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(thingDir, FilenameOrchestrionYML), []byte("meta: {name: name, description: description}\naspects: [{ id: ID, join-point: { package-name: thing }, advice: [add-blank-import: unsafe] }]"), 0o644))
+
+	// dep requires "thing" through a replace directive that is only valid
+	// inside dep's own checkout -- mirroring dd-trace-go/orchestrion/all/v2's
+	// `replace ... => ../../contrib/...` directives.
+	depDir := t.TempDir()
+	runGo(t, depDir, "mod", "init", "example.com/dep")
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "dep.go"), []byte(`package dep`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, FilenameOrchestrionToolGo), []byte(`
+		//go:build tools
+		package tools
+		import _ "example.com/thing"
+	`), 0o644))
+	runGo(t, depDir, "mod", "edit",
+		"-require=example.com/thing@v1.0.0",
+		"-replace=example.com/thing@v1.0.0=../does-not-exist",
+	)
+
+	// consumer requires "thing" through a valid replace directive, as a real
+	// consumer of dep would (via `go mod tidy`, which records a valid
+	// resolution for every transitive import reachable through dep's
+	// orchestrion.tool.go).
+	consumerDir := t.TempDir()
+	runGo(t, consumerDir, "mod", "init", "example.com/consumer")
+	runGo(t, consumerDir, "mod", "edit",
+		"-require=example.com/thing@v1.0.0",
+		"-replace=example.com/thing@v1.0.0="+thingDir,
+	)
+
+	pkg := &packages.Package{
+		PkgPath: "example.com/dep",
+		GoFiles: []string{filepath.Join(depDir, "dep.go")},
+	}
+
+	t.Run("resolving from the dependency's own directory fails", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := HasConfig(context.Background(), nil, depDir, pkg, false)
+		require.ErrorContains(t, err, "replacement directory")
+	})
+
+	t.Run("resolving from the consuming module succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		hasCfg, err := HasConfig(context.Background(), nil, consumerDir, pkg, false)
+		require.NoError(t, err)
+		require.True(t, hasCfg)
 	})
 }
 

--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -90,7 +90,8 @@ func PinOrchestrion(ctx context.Context, opts Options) error {
 		}
 	}()
 
-	toolFile := filepath.Join(goMod, "..", config.FilenameOrchestrionToolGo)
+	moduleDir := filepath.Dir(goMod)
+	toolFile := filepath.Join(moduleDir, config.FilenameOrchestrionToolGo)
 	dstFile, err := parseOrchestrionToolGo(toolFile)
 	if errors.Is(err, os.ErrNotExist) {
 		log.Debug().Msg("no " + config.FilenameOrchestrionToolGo + " file found, creating a new one")
@@ -138,13 +139,25 @@ func PinOrchestrion(ctx context.Context, opts Options) error {
 		edits = append(edits, gomod.Require{Path: orchestrionImportPath, Version: version})
 	}
 
+	// gomod.RunEdit only runs `go mod tidy` when it has at least one edit to
+	// apply.
+	tidied := len(edits) > 0
 	if err := gomod.RunEdit(ctx, goMod, edits...); err != nil {
 		return fmt.Errorf("editing %q: %w", goMod, err)
 	}
+	if !tidied {
+		// pruneImports resolves the whole orchestrion.tool.go import closure from
+		// this module, which needs go.sum entries for modules only reachable
+		// through build-constrained files (the contribs behind
+		// orchestrion/all/v2). Only `go mod tidy` records those.
+		if err := gomod.Run(ctx, "tidy", goMod, nil); err != nil {
+			return fmt.Errorf("running `go mod tidy`: %w", err)
+		}
+	}
 
-	pruned, err := pruneImports(ctx, importSet, opts)
+	pruned, err := pruneImports(ctx, moduleDir, importSet, opts)
 	if err != nil {
-		return fmt.Errorf("pruning imports from %q: %w", toolFile, err)
+		return fmt.Errorf("checking imports of %q: %w", toolFile, err)
 	}
 
 	if pruned {
@@ -283,10 +296,18 @@ func updateGoGenerateDirective(opts Options, file *dst.File) {
 	file.Decs.Start.Append("\n", newDirective, "\n")
 }
 
-// pruneImports removes unnecessary or invalid imports from the provided
-// [*importSet]; unless the [*Options.NoPrune] field is true, in which case it
-// only outputs a message informing the user about uncalled-for imports.
-func pruneImports(ctx context.Context, importSet *importSet, opts Options) (bool, error) {
+// pruneImports removes unnecessary imports from the provided [*importSet];
+// unless the [*Options.NoPrune] field is true, in which case it only outputs
+// a message informing the user about uncalled-for imports. An import is only
+// ever pruned once we have positively established that it provides no
+// orchestrion integrations; a failure to determine this (e.g. because a
+// transitive import could not be resolved) is reported as a warning and the
+// import is left untouched. moduleDir must be the root directory of the
+// module being pinned: it is used to resolve every import, including
+// transitive imports found in a dependency's own [config.FilenameOrchestrionToolGo]
+// file, so that the dependency's own `replace` directives are never
+// mistakenly applied.
+func pruneImports(ctx context.Context, moduleDir string, importSet *importSet, opts Options) (bool, error) {
 	importPaths := importSet.Except(orchestrionImportPath)
 	if len(importPaths) == 0 {
 		// Nothing to do!
@@ -296,6 +317,7 @@ func pruneImports(ctx context.Context, importSet *importSet, opts Options) (bool
 	log := zerolog.Ctx(ctx)
 	pkgs, err := packages.Load(
 		&packages.Config{
+			Dir:        moduleDir,
 			BuildFlags: []string{"-toolexec="},
 			Logf:       func(format string, args ...any) { log.Trace().Str("operation", "packages.Load").Msgf(format, args...) },
 			Mode:       packages.NeedName | packages.NeedFiles,
@@ -308,12 +330,16 @@ func pruneImports(ctx context.Context, importSet *importSet, opts Options) (bool
 
 	var pruned bool
 	for _, pkg := range pkgs {
-		hasConfig, err := config.HasConfig(ctx, nil, pkg, opts.Validate)
-		if err != nil {
-			pruned = pruneImport(importSet, pkg.PkgPath, err.Error(), opts) || pruned
-			continue
-		}
-		if !hasConfig {
+		hasConfig, err := config.HasConfig(ctx, nil, moduleDir, pkg, opts.Validate)
+		switch {
+		case err != nil:
+			// We failed to determine whether this package provides integrations.
+			// That is not evidence that it does not -- leave it alone.
+			if opts.Validate {
+				return pruned, fmt.Errorf("checking imports of %q: %w", pkg.PkgPath, err)
+			}
+			warnImport(ctx, pkg.PkgPath, err, opts)
+		case !hasConfig:
 			// A package can have pkg.Errors set while still carrying a valid
 			// configuration, e.g. when GOOS/GOARCH or build tags exclude all its
 			// Go files: config.HasConfig locates the config via pkg.IgnoredFiles
@@ -324,18 +350,19 @@ func pruneImports(ctx context.Context, importSet *importSet, opts Options) (bool
 				reason = joinPackageErrors(pkg.Errors)
 			}
 			pruned = pruneImport(importSet, pkg.PkgPath, reason, opts) || pruned
-			continue
+		default:
+			if decl := importSet.Find(pkg.PkgPath); decl != nil {
+				decl.Decs.End.Replace("// integration")
+			}
 		}
-		decl := importSet.Find(pkg.PkgPath)
-		decl.Decs.End.Replace("// integration")
 	}
 
 	return pruned, nil
 }
 
 // pruneImport prunes a single import from the supplied [*importSet], unless
-// [*Options.NoPrune] is set, in which case it prints a warning using the
-// provided `reason` message.
+// [*Options.NoPrune] is set, in which case it prints a message using the
+// provided `reason`.
 func pruneImport(importSet *importSet, path string, reason string, opts Options) bool {
 	if opts.NoPrune {
 		spec := importSet.Find(path)
@@ -344,14 +371,14 @@ func pruneImport(importSet *importSet, path string, reason string, opts Options)
 			return false
 		}
 
-		_, _ = fmt.Fprintf(opts.Writer, "unnecessary import of %q: %v\n", path, reason)
+		_, _ = fmt.Fprintf(opts.Writer, "%q: %s; it would be removed without -prune=false\n", path, reason)
 		spec.Decs.End.Clear() // Remove the // integration comment.
 
 		return false
 	}
 
 	if importSet.Remove(path) {
-		_, _ = fmt.Fprintf(opts.Writer, "removing unnecessary import of %q: %v\n", path, reason)
+		_, _ = fmt.Fprintf(opts.Writer, "removed %q from %s: %s\n", path, config.FilenameOrchestrionToolGo, reason)
 	}
 	return true
 }
@@ -364,6 +391,19 @@ func joinPackageErrors(errs []packages.Error) string {
 		msgs[i] = err.Error()
 	}
 	return strings.Join(msgs, "; ")
+}
+
+// warnImport reports that we could not determine whether the package at path
+// provides orchestrion integrations, so it is being left untouched. This is
+// not an error: the build is unaffected, and nothing was changed.
+func warnImport(ctx context.Context, path string, cause error, opts Options) {
+	zerolog.Ctx(ctx).Warn().Err(cause).Str("import-path", path).
+		Msg("Could not determine whether package provides orchestrion integrations; leaving it untouched")
+	_, _ = fmt.Fprintf(opts.ErrWriter,
+		"note: keeping %q in %s -- orchestrion could not check whether it provides integrations.\n"+
+			"      this is not an error: nothing was changed and your build is unaffected.\n"+
+			"      details: %v\n",
+		path, config.FilenameOrchestrionToolGo, cause)
 }
 
 // writeUpdated writes the updated AST to the given file, using a temporary file

--- a/internal/pin/pin_test.go
+++ b/internal/pin/pin_test.go
@@ -36,7 +36,8 @@ func TestPin(t *testing.T) {
 		tmp := scaffold(t, make(map[string]string))
 		chdir(t, tmp)
 
-		require.NoError(t, PinOrchestrion(ctx, Options{Writer: io.Discard, ErrWriter: io.Discard}))
+		var out, errOut bytes.Buffer
+		require.NoError(t, PinOrchestrion(ctx, Options{Writer: &out, ErrWriter: &errOut}))
 
 		assert.FileExists(t, filepath.Join(tmp, config.FilenameOrchestrionToolGo))
 		assert.FileExists(t, filepath.Join(tmp, "go.sum"))
@@ -51,6 +52,15 @@ func TestPin(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Contains(t, string(content), "//go:generate")
+
+		// Regression test for issue #760: dd-trace-go/orchestrion/all/v2 must
+		// never be reported as an unnecessary import, and its own transitive
+		// import resolution failures (which happen when its own
+		// checkout-relative `replace` directives are mistakenly applied) must
+		// never surface as a warning either.
+		assert.Contains(t, string(content), integrations.DatadogTracerV2All)
+		assert.NotContains(t, out.String(), "unnecessary import")
+		assert.NotContains(t, errOut.String(), "note: keeping")
 	})
 
 	t.Run("upgrade:dd-trace-go", func(t *testing.T) {
@@ -119,7 +129,14 @@ func main() {}
 		assert.NotContains(t, string(content), "//go:generate")
 	})
 
-	t.Run("prune", func(t *testing.T) {
+	// These two tests exercise `go mod tidy` removing an unused require, not
+	// pruneImports: the extra modules are only added to go.mod's requires, and
+	// are never imported from orchestrion.tool.go, so pruneImports never even
+	// considers them. Real prune coverage lives in
+	// "does not falsely prune an import whose transitive replace is
+	// checkout-relative" below and in internal/injector/config.
+
+	t.Run("tidy:removes-unused-require", func(t *testing.T) {
 		tmp := scaffold(t, map[string]string{"github.com/digitalocean/sample-golang": "v0.0.0-20240904143939-1e058723dcf4"})
 		chdir(t, tmp)
 
@@ -131,7 +148,7 @@ func main() {}
 		assert.NotContains(t, data.Require, gomod.Require{Path: "github.com/digitalocean/sample-golang", Version: "v0.0.0-20240904143939-1e058723dcf4"})
 	})
 
-	t.Run("prune-multiple", func(t *testing.T) {
+	t.Run("tidy:removes-multiple-unused-requires", func(t *testing.T) {
 		tmp := scaffold(t, map[string]string{
 			"github.com/digitalocean/sample-golang":  "v0.0.0-20240904143939-1e058723dcf4",
 			"github.com/skyrocknroll/go-mod-example": "v0.0.0-20190130140558-29b3c92445e5",
@@ -147,6 +164,50 @@ func main() {}
 		assert.NotContains(t, data.Require, gomod.Require{Path: "github.com/skyrocknroll/go-mod-example", Version: "v0.0.0-20190130140558-29b3c92445e5"})
 	})
 
+	t.Run("does not falsely prune an import whose transitive replace is checkout-relative", func(t *testing.T) {
+		// Regression test for issue #760: a dependency's own go.mod may carry
+		// `replace` directives whose paths are only valid inside its own
+		// checkout (dd-trace-go/orchestrion/all/v2 carries several such
+		// directives, e.g. `=> ../../contrib/...`). Import paths found in that
+		// dependency's orchestrion.tool.go file must be resolved from the
+		// module that consumes it, never from the dependency's own directory --
+		// otherwise those checkout-relative replace directives get applied and
+		// fail to resolve, and the import gets misreported as unnecessary.
+		tmp := scaffold(t, make(map[string]string))
+		chdir(t, tmp)
+
+		_, thisFile, _, _ := runtime.Caller(0)
+		fixtureRoot := filepath.Join(thisFile, "..", "testdata", "relative-replace")
+		depDir := filepath.Join(fixtureRoot, "dep")
+		thingDir := filepath.Join(fixtureRoot, "thing")
+
+		require.NoError(t, gomod.Run(ctx, "edit", filepath.Join(tmp, "go.mod"), io.Discard,
+			"-require=example.com/dep@v1.0.0",
+			"-replace=example.com/dep@v1.0.0="+depDir,
+			"-require=example.com/thing@v1.0.0",
+			"-replace=example.com/thing@v1.0.0="+thingDir,
+		))
+
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, config.FilenameOrchestrionToolGo), []byte(`//go:build tools
+package tools
+
+import (
+	_ "github.com/DataDog/orchestrion"
+	_ "example.com/dep"
+)
+`), 0o644))
+
+		var out, errOut bytes.Buffer
+		require.NoError(t, PinOrchestrion(ctx, Options{Writer: &out, ErrWriter: &errOut, NoGenerate: true}))
+
+		assert.NotContains(t, out.String(), "unnecessary import")
+		assert.NotContains(t, errOut.String(), "note: keeping")
+
+		content, err := os.ReadFile(filepath.Join(tmp, config.FilenameOrchestrionToolGo))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), `"example.com/dep"`)
+	})
+
 	t.Run("empty-tool-dot-go", func(t *testing.T) {
 		tmp := scaffold(t, make(map[string]string))
 		chdir(t, tmp)
@@ -160,8 +221,9 @@ func main() {}
 
 // TestPruneImportsLoadError verifies that an import that fails to load (as
 // opposed to one that loads fine but lacks orchestrion configuration) is
-// pruned using the actual load error as the reason, rather than being
-// misreported as "there is no orchestrion.yml/tool.go file in this package".
+// left untouched with a non-fatal warning on ErrWriter, using the actual
+// load error as the reason -- a resolution failure is not evidence that the
+// package provides no orchestrion integrations, so it must never be pruned.
 //
 // This is exercised by calling pruneImports directly instead of going
 // through PinOrchestrion: PinOrchestrion runs `go mod tidy` before
@@ -188,48 +250,14 @@ import (
 	require.NoError(t, err)
 	importSet := importSetFrom(dstFile)
 
-	var out bytes.Buffer
-	pruned, err := pruneImports(ctx, importSet, Options{Writer: &out, ErrWriter: io.Discard})
-	require.NoError(t, err)
-
-	assert.True(t, pruned)
-	assert.Contains(t, out.String(), "removing unnecessary import")
-	assert.NotContains(t, out.String(), "there is no "+config.FilenameOrchestrionYML)
-}
-
-// TestPruneImportsLoadErrorNoPrune verifies that, when [Options.NoPrune] is
-// set, an import that fails to load is not removed from the [*importSet].
-// Instead, a warning is printed using the actual load error as the reason
-// (not the misleading "there is no orchestrion.yml/tool.go file in this
-// package" message), and the import is left in place.
-func TestPruneImportsLoadErrorNoPrune(t *testing.T) {
-	ctx := context.Background()
-
-	tmp := scaffold(t, make(map[string]string))
-	chdir(t, tmp)
-
-	toolDotGo := filepath.Join(tmp, config.FilenameOrchestrionToolGo)
-	require.NoError(t, os.WriteFile(toolDotGo, []byte(`//go:build tools
-package tools
-
-import (
-	_ "github.com/DataDog/orchestrion"
-	_ "github.com/DataDog/orchestrion/this-package-does-not-exist-zzz"
-)
-`), 0o644))
-
-	dstFile, err := parseOrchestrionToolGo(toolDotGo)
-	require.NoError(t, err)
-	importSet := importSetFrom(dstFile)
-
-	var out bytes.Buffer
-	pruned, err := pruneImports(ctx, importSet, Options{Writer: &out, ErrWriter: io.Discard, NoPrune: true})
+	var out, errOut bytes.Buffer
+	pruned, err := pruneImports(ctx, tmp, importSet, Options{Writer: &out, ErrWriter: &errOut})
 	require.NoError(t, err)
 
 	assert.False(t, pruned)
-	assert.Contains(t, out.String(), "unnecessary import")
-	assert.NotContains(t, out.String(), "there is no "+config.FilenameOrchestrionYML)
 	assert.NotNil(t, importSet.Find("github.com/DataDog/orchestrion/this-package-does-not-exist-zzz"))
+	assert.Contains(t, errOut.String(), "note: keeping")
+	assert.NotContains(t, out.String(), "there is no "+config.FilenameOrchestrionYML)
 }
 
 // TestPruneImportsBuildTagExcluded verifies that an import whose only Go file
@@ -272,7 +300,7 @@ import (
 	importSet := importSetFrom(dstFile)
 
 	var out bytes.Buffer
-	pruned, err := pruneImports(ctx, importSet, Options{Writer: &out, ErrWriter: io.Discard})
+	pruned, err := pruneImports(ctx, tmp, importSet, Options{Writer: &out, ErrWriter: io.Discard})
 	require.NoError(t, err)
 
 	assert.False(t, pruned)

--- a/internal/pin/testdata/relative-replace/dep/dep.go
+++ b/internal/pin/testdata/relative-replace/dep/dep.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package dep

--- a/internal/pin/testdata/relative-replace/dep/go.mod
+++ b/internal/pin/testdata/relative-replace/dep/go.mod
@@ -1,0 +1,11 @@
+module example.com/dep
+
+go 1.23
+
+require example.com/thing v1.0.0
+
+// This mirrors github.com/DataDog/dd-trace-go/orchestrion/all/v2's own
+// checkout-relative `replace` directives (e.g. `=> ../../contrib/...`): valid
+// only when this module's own go.mod is treated as the main module, which
+// must never happen when resolving this package's imports as a dependency.
+replace example.com/thing v1.0.0 => ../does-not-exist

--- a/internal/pin/testdata/relative-replace/dep/orchestrion.tool.go
+++ b/internal/pin/testdata/relative-replace/dep/orchestrion.tool.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build tools
+
+package tools
+
+import (
+	_ "example.com/thing"
+)

--- a/internal/pin/testdata/relative-replace/thing/go.mod
+++ b/internal/pin/testdata/relative-replace/thing/go.mod
@@ -1,0 +1,3 @@
+module example.com/thing
+
+go 1.23

--- a/internal/pin/testdata/relative-replace/thing/orchestrion.yml
+++ b/internal/pin/testdata/relative-replace/thing/orchestrion.yml
@@ -1,0 +1,2 @@
+meta: {name: name, description: description}
+aspects: [{ id: ID, join-point: { package-name: thing }, advice: [add-blank-import: unsafe] }]

--- a/internal/pin/testdata/relative-replace/thing/thing.go
+++ b/internal/pin/testdata/relative-replace/thing/thing.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package thing


### PR DESCRIPTION
## Summary

Fixes #760.

`orchestrion pin` was resolving transitive imports found in a dependency's `orchestrion.tool.go` file (e.g. `github.com/DataDog/dd-trace-go/orchestrion/all/v2`) against **that dependency's own module-cache directory**, instead of the module actually consuming it. This made the dependency's own checkout-relative `replace` directives (valid only inside a `dd-trace-go` checkout, e.g. `=> ../../contrib/...`) get applied during resolution, causing `go list` to fail and the import to be misreported as "unnecessary" and pruned — even though the import was perfectly valid.

```
removing unnecessary import of "github.com/DataDog/dd-trace-go/orchestrion/all/v2": in
"github.com/DataDog/dd-trace-go/contrib/99designs/gqlgen/v2" imported from
".../orchestrion/all/v2@v2.4.0/orchestrion.tool.go": ...: replacement directory
../../contrib/99designs/gqlgen does not exist
```

- `config.HasConfig` now takes an explicit resolution directory (the consuming module's root), separate from the directory a config file is read from.
- `pin`'s package loader now forces `-toolexec=` (matching the jobserver's loader) so resolution never recurses into `orchestrion` itself if `GOFLAGS=-toolexec=...` is set.
- Closed a narrow gap where `go mod tidy` wouldn't run before pruning if `ensure.RequiredIntegrations` produced no edits, which could leave `go.sum` incomplete for the transitive contribs pruning needs to resolve.
- **Guardrail:** pruning now only removes an import once `HasConfig` positively established it provides no integrations (`err == nil && !hasConfig`). Any resolution failure (an unreachable proxy, a broken `replace`, etc.) is reported as a non-fatal `note:` warning on stderr and the import is left untouched — it is only fatal under `-validate`.

## Test plan

- [x] `go test ./internal/injector/config/... ./internal/pin/...` — new hermetic regression tests reproduce the #760 shape both at the `config.HasConfig` level and end-to-end through `PinOrchestrion` (`internal/pin/testdata/relative-replace/`).
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all clean.
- [x] Manually reproduced the bug and confirmed the fix with a built binary in a scratch module (no false-positive prune, `orchestrion.tool.go` retains `dd-trace-go/orchestrion/all/v2`, exit 0).

## Out of scope

Flagged as follow-up work, not included here:
- #687 (`orchestrion pin` fails with "inconsistent vendoring") — same function area, different root cause; currently being investigated separately.
- Pruning currently never persists to disk (`writeUpdated` runs before `pruneImports`, so removed imports never actually leave `orchestrion.tool.go` — only `go mod tidy`'s cleanup of unused `go.mod` requires is visible). Fixing this safely depends on #687 landing first, since `go mod vendor` doesn't copy `orchestrion.yml` files, and persisting prunes without vendor-awareness would silently delete valid integrations from vendored projects.
- The no-edits fallback path (`pin.go`'s `if !tidied { gomod.Run(ctx, "tidy", ...) }`) runs `go mod tidy` directly, bypassing the `go mod vendor` step that `gomod.RunEdit` performs when a `vendor/` directory is present. In a vendored project that hits this path (no `go.mod` edits needed), `go.sum` is refreshed but `vendor/` is not — the same vendor-awareness gap as #687, tracked there rather than fixed here.
- The new prune-output wording (`"removed %q from %s: %s"`) is phrased in the past tense, which overstates what happens today given the persistence gap noted above — the import is not actually removed from `orchestrion.tool.go` on disk yet. The wording should be revisited once persistence lands (tracked with #687); not fixed in this PR.
