### PR TITLE
fix(pin): surface pkg.Errors as prune reason instead of a misleading message

### DIFF
--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -308,6 +308,11 @@ func pruneImports(ctx context.Context, importSet *importSet, opts Options) (bool
 
 	var pruned bool
 	for _, pkg := range pkgs {
+		if len(pkg.Errors) > 0 {
+			pruned = pruneImport(importSet, pkg.PkgPath, joinPackageErrors(pkg.Errors), opts) || pruned
+			continue
+		}
+
 		hasConfig, err := config.HasConfig(ctx, nil, pkg, opts.Validate)
 		if err != nil {
 			pruned = pruneImport(importSet, pkg.PkgPath, err.Error(), opts) || pruned
@@ -345,6 +350,16 @@ func pruneImport(importSet *importSet, path string, reason string, opts Options)
 		_, _ = fmt.Fprintf(opts.Writer, "removing unnecessary import of %q: %v\n", path, reason)
 	}
 	return true
+}
+
+// joinPackageErrors joins the messages of the supplied [packages.Error]
+// values into a single, single-line reason string.
+func joinPackageErrors(errs []packages.Error) string {
+	msgs := make([]string, len(errs))
+	for i, err := range errs {
+		msgs[i] = err.Error()
+	}
+	return strings.Join(msgs, "; ")
 }
 
 // writeUpdated writes the updated AST to the given file, using a temporary file

--- a/internal/pin/pin.go
+++ b/internal/pin/pin.go
@@ -308,18 +308,22 @@ func pruneImports(ctx context.Context, importSet *importSet, opts Options) (bool
 
 	var pruned bool
 	for _, pkg := range pkgs {
-		if len(pkg.Errors) > 0 {
-			pruned = pruneImport(importSet, pkg.PkgPath, joinPackageErrors(pkg.Errors), opts) || pruned
-			continue
-		}
-
 		hasConfig, err := config.HasConfig(ctx, nil, pkg, opts.Validate)
 		if err != nil {
 			pruned = pruneImport(importSet, pkg.PkgPath, err.Error(), opts) || pruned
 			continue
 		}
 		if !hasConfig {
-			pruned = pruneImport(importSet, pkg.PkgPath, "there is no "+config.FilenameOrchestrionYML+" nor "+config.FilenameOrchestrionToolGo+" file in this package", opts) || pruned
+			// A package can have pkg.Errors set while still carrying a valid
+			// configuration, e.g. when GOOS/GOARCH or build tags exclude all its
+			// Go files: config.HasConfig locates the config via pkg.IgnoredFiles
+			// in that case. Only fall back to the load error here, once
+			// config.HasConfig has confirmed there really is no configuration.
+			reason := "there is no " + config.FilenameOrchestrionYML + " nor " + config.FilenameOrchestrionToolGo + " file in this package"
+			if len(pkg.Errors) > 0 {
+				reason = joinPackageErrors(pkg.Errors)
+			}
+			pruned = pruneImport(importSet, pkg.PkgPath, reason, opts) || pruned
 			continue
 		}
 		decl := importSet.Find(pkg.PkgPath)

--- a/internal/pin/pin_test.go
+++ b/internal/pin/pin_test.go
@@ -6,6 +6,7 @@
 package pin
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -155,6 +156,45 @@ func main() {}
 
 		require.ErrorContains(t, PinOrchestrion(ctx, Options{Writer: io.Discard, ErrWriter: io.Discard}), "expected 'package', found 'EOF'")
 	})
+}
+
+// TestPruneImportsLoadError verifies that an import that fails to load (as
+// opposed to one that loads fine but lacks orchestrion configuration) is
+// pruned using the actual load error as the reason, rather than being
+// misreported as "there is no orchestrion.yml/tool.go file in this package".
+//
+// This is exercised by calling pruneImports directly instead of going
+// through PinOrchestrion: PinOrchestrion runs `go mod tidy` before
+// pruneImports ever runs, and `go mod tidy` already fails hard on an
+// unresolvable import, so the pkg.Errors branch inside pruneImports is not
+// reachable from that entry point in this scenario.
+func TestPruneImportsLoadError(t *testing.T) {
+	ctx := context.Background()
+
+	tmp := scaffold(t, make(map[string]string))
+	chdir(t, tmp)
+
+	toolDotGo := filepath.Join(tmp, config.FilenameOrchestrionToolGo)
+	require.NoError(t, os.WriteFile(toolDotGo, []byte(`//go:build tools
+package tools
+
+import (
+	_ "github.com/DataDog/orchestrion"
+	_ "github.com/DataDog/orchestrion/this-package-does-not-exist-zzz"
+)
+`), 0o644))
+
+	dstFile, err := parseOrchestrionToolGo(toolDotGo)
+	require.NoError(t, err)
+	importSet := importSetFrom(dstFile)
+
+	var out bytes.Buffer
+	pruned, err := pruneImports(ctx, importSet, Options{Writer: &out, ErrWriter: io.Discard})
+	require.NoError(t, err)
+
+	assert.True(t, pruned)
+	assert.Contains(t, out.String(), "removing unnecessary import")
+	assert.NotContains(t, out.String(), "there is no "+config.FilenameOrchestrionYML)
 }
 
 var goModTemplate = template.Must(template.New("go-mod").Parse(`module github.com/DataDog/orchestrion/pin-test

--- a/internal/pin/pin_test.go
+++ b/internal/pin/pin_test.go
@@ -232,6 +232,54 @@ import (
 	assert.NotNil(t, importSet.Find("github.com/DataDog/orchestrion/this-package-does-not-exist-zzz"))
 }
 
+// TestPruneImportsBuildTagExcluded verifies that an import whose only Go file
+// is excluded by build tags (so packages.Load reports pkg.Errors alongside
+// pkg.IgnoredFiles) is not pruned when it has an adjacent orchestrion.tool.go,
+// since config.HasConfig locates configuration via pkg.IgnoredFiles in that
+// case. Reported by Codex during review of PR #891.
+func TestPruneImportsBuildTagExcluded(t *testing.T) {
+	ctx := context.Background()
+
+	tmp := scaffold(t, make(map[string]string))
+	chdir(t, tmp)
+
+	pkgDir := filepath.Join(tmp, "buildtagpkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "only_tag.go"), []byte(`//go:build orchestrion_never_defined
+
+package buildtagpkg
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, config.FilenameOrchestrionToolGo), []byte(`//go:build tools
+package tools
+
+import (
+	_ "github.com/DataDog/orchestrion"
+)
+`), 0o644))
+
+	toolDotGo := filepath.Join(tmp, config.FilenameOrchestrionToolGo)
+	require.NoError(t, os.WriteFile(toolDotGo, []byte(`//go:build tools
+package tools
+
+import (
+	_ "github.com/DataDog/orchestrion"
+	_ "github.com/DataDog/orchestrion/pin-test/buildtagpkg"
+)
+`), 0o644))
+
+	dstFile, err := parseOrchestrionToolGo(toolDotGo)
+	require.NoError(t, err)
+	importSet := importSetFrom(dstFile)
+
+	var out bytes.Buffer
+	pruned, err := pruneImports(ctx, importSet, Options{Writer: &out, ErrWriter: io.Discard})
+	require.NoError(t, err)
+
+	assert.False(t, pruned)
+	assert.NotNil(t, importSet.Find("github.com/DataDog/orchestrion/pin-test/buildtagpkg"))
+	assert.Empty(t, out.String())
+}
+
 var goModTemplate = template.Must(template.New("go-mod").Parse(`module github.com/DataDog/orchestrion/pin-test
 
 go {{ .GoVersion }}

--- a/internal/pin/pin_test.go
+++ b/internal/pin/pin_test.go
@@ -197,6 +197,41 @@ import (
 	assert.NotContains(t, out.String(), "there is no "+config.FilenameOrchestrionYML)
 }
 
+// TestPruneImportsLoadErrorNoPrune verifies that, when [Options.NoPrune] is
+// set, an import that fails to load is not removed from the [*importSet].
+// Instead, a warning is printed using the actual load error as the reason
+// (not the misleading "there is no orchestrion.yml/tool.go file in this
+// package" message), and the import is left in place.
+func TestPruneImportsLoadErrorNoPrune(t *testing.T) {
+	ctx := context.Background()
+
+	tmp := scaffold(t, make(map[string]string))
+	chdir(t, tmp)
+
+	toolDotGo := filepath.Join(tmp, config.FilenameOrchestrionToolGo)
+	require.NoError(t, os.WriteFile(toolDotGo, []byte(`//go:build tools
+package tools
+
+import (
+	_ "github.com/DataDog/orchestrion"
+	_ "github.com/DataDog/orchestrion/this-package-does-not-exist-zzz"
+)
+`), 0o644))
+
+	dstFile, err := parseOrchestrionToolGo(toolDotGo)
+	require.NoError(t, err)
+	importSet := importSetFrom(dstFile)
+
+	var out bytes.Buffer
+	pruned, err := pruneImports(ctx, importSet, Options{Writer: &out, ErrWriter: io.Discard, NoPrune: true})
+	require.NoError(t, err)
+
+	assert.False(t, pruned)
+	assert.Contains(t, out.String(), "unnecessary import")
+	assert.NotContains(t, out.String(), "there is no "+config.FilenameOrchestrionYML)
+	assert.NotNil(t, importSet.Find("github.com/DataDog/orchestrion/this-package-does-not-exist-zzz"))
+}
+
 var goModTemplate = template.Must(template.New("go-mod").Parse(`module github.com/DataDog/orchestrion/pin-test
 
 go {{ .GoVersion }}


### PR DESCRIPTION
## Summary
- `pruneImports` (`internal/pin/pin.go`) now checks `pkg.Errors` before calling `config.HasConfig`, so a package that failed to load (malformed import path, or a missing/unresolvable package or module) is pruned using the real load error as the reason, instead of the misleading "there is no orchestrion.yml nor tool.go file in this package" message it produced today (since `HasConfig` silently returns `(false, nil)` for a package with no `GoFiles`).
- Added `joinPackageErrors` to join `[]packages.Error` into one compact reason string.
- Network/proxy failures and unresolvable module versions (e.g. GOPROXY unreachable, DNS failure, "unknown revision") are a separate, pre-existing code path and are **not** improved by this change: `cmd/go` does not suppress errors from module-graph construction even under `-e`, so `packages.Load` returns `(nil, err)` with zero packages instead of a per-package error. `pruneImports` hits its existing early return (pin.go:305-307) and aborts the whole batch with a generic wrapped error rather than pruning the individual import with a better reason.
- Flagged during review of #890 as a separate, pre-existing gap (not introduced by that PR).

## Test plan
- [x] `go build ./internal/pin/...` / `go vet ./internal/pin/...`
- [x] `go test ./internal/pin/... -run 'TestPin$|TestPruneImportsLoadError' -v` — all pass, including the new `TestPruneImportsLoadError`, which calls `pruneImports` directly (bypassing `PinOrchestrion`, since `go mod tidy` runs before `pruneImports` and already fails hard on a fully unresolvable import, so that path can't reach this code from the CLI entry point in this scenario)
- [x] `gofmt -l` clean on changed files