### PR TITLE
fix(tools): make license generation independent of host architecture

### DIFF
--- a/_tools/make-licenses.sh
+++ b/_tools/make-licenses.sh
@@ -11,21 +11,25 @@ go -C $(dirname "${BASH_SOURCE[0]}") build -o "${TMPDIR}/bin/go-licenses" github
 # This package somehow breaks the license detection...
 IGNORE_LIST="github.com/DataDog/sketches-go/ddsketch"
 
-# We run for linux, darwin and windows to get all the licenses, including platform-conditional ones.
+# We run for linux, darwin and windows, each on amd64 and arm64, to get all the licenses, including
+# platform- and architecture-conditional ones. GOARCH is set explicitly (never inherited from the host)
+# so the generated CSV is identical regardless of which architecture ran this script.
 SOURCES="${TMPDIR}/sources"
 mkdir -p "${SOURCES}"
 declare -a LICENSE_FILES
 for GOOS in linux darwin windows; do
-  SOURCE_DIR="${TMPDIR}/sources-${GOOS}"
-  echo "Aggregating source files in $(basename "${SOURCE_DIR}") so we can scrape copyright statements later..."
-  GOOS="${GOOS}" "${TMPDIR}/bin/go-licenses" save --ignore "${IGNORE_LIST}" --save_path "${SOURCE_DIR}" ./... 2> "${TMPDIR}/errors" || (cat "${TMPDIR}/errors" >&2 && exit -1)
-  chmod -R a+rw "${SOURCE_DIR}"
-  cp -r "${SOURCE_DIR}"/* "${SOURCES}/"
+  for GOARCH in amd64 arm64; do
+    SOURCE_DIR="${TMPDIR}/sources-${GOOS}-${GOARCH}"
+    echo "Aggregating source files in $(basename "${SOURCE_DIR}") so we can scrape copyright statements later..."
+    GOOS="${GOOS}" GOARCH="${GOARCH}" "${TMPDIR}/bin/go-licenses" save --ignore "${IGNORE_LIST}" --save_path "${SOURCE_DIR}" ./... 2> "${TMPDIR}/errors" || (cat "${TMPDIR}/errors" >&2 && exit -1)
+    chmod -R a+rw "${SOURCE_DIR}"
+    cp -r "${SOURCE_DIR}"/* "${SOURCES}/"
 
-  OUTFILE="${TMPDIR}/LICENSE-3rdparty.${GOOS}.csv"
-  echo "Building $(basename "${OUTFILE}")"
-  GOOS="${GOOS}" "${TMPDIR}/bin/go-licenses" report ./... --ignore "${IGNORE_LIST}" --template ./_tools/licenses.tpl > "${OUTFILE}" 2> "${TMPDIR}/errors" || (cat "${TMPDIR}/errors" >&2 && exit -1)
-  LICENSE_FILES+=("${OUTFILE}")
+    OUTFILE="${TMPDIR}/LICENSE-3rdparty.${GOOS}-${GOARCH}.csv"
+    echo "Building $(basename "${OUTFILE}")"
+    GOOS="${GOOS}" GOARCH="${GOARCH}" "${TMPDIR}/bin/go-licenses" report ./... --ignore "${IGNORE_LIST}" --template ./_tools/licenses.tpl > "${OUTFILE}" 2> "${TMPDIR}/errors" || (cat "${TMPDIR}/errors" >&2 && exit -1)
+    LICENSE_FILES+=("${OUTFILE}")
+  done
 done
 
 go run ./_tools/copyrights/merge.go -licenses "${SOURCES}" -output LICENSE-3rdparty.csv "${LICENSE_FILES[@]}"


### PR DESCRIPTION
## Summary
- `_tools/make-licenses.sh` iterated `GOOS` (linux/darwin/windows) but never set `GOARCH`, so it always built for the host's native architecture.
- Running it on an arm64 machine silently drops architecture-conditional dependencies that only appear in the amd64 build graph (e.g. `github.com/klauspost/cpuid/v2`, a conditional dependency of `klauspost/compress`).
- Now iterates `GOOS x GOARCH` (amd64, arm64) for each of linux/darwin/windows, so the generated `LICENSE-3rdparty.csv` is a union across architectures and doesn't depend on which machine regenerated it.

## Test plan
- [x] Ran the updated script on an arm64 host; the regenerated `LICENSE-3rdparty.csv` is byte-identical to the committed one (previously generated on amd64), including the `klauspost/cpuid/v2` row.
- [x] `git diff LICENSE-3rdparty.csv` is empty after running the script.