### PR TITLE
fix(samples): set Content-Type before writing error bodies

### DIFF
--- a/samples/server/main.go
+++ b/samples/server/main.go
@@ -25,6 +25,7 @@ func myHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := io.ReadAll(r.Body)
 	// test comment in function
 	if err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
 		return
@@ -38,6 +39,7 @@ func instrumentedHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := io.ReadAll(r.Body)
 	// test comment in function
 	if err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
 		return

--- a/samples/testdata/server/main.go.snap
+++ b/samples/testdata/server/main.go.snap
@@ -39,6 +39,7 @@ func myHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := io.ReadAll(r.Body)
 	// test comment in function
 	if err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
 		return
@@ -52,6 +53,7 @@ func instrumentedHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := io.ReadAll(r.Body)
 	// test comment in function
 	if err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
 		return


### PR DESCRIPTION
## Summary
- CodeQL flagged two high-severity reflected-XSS alerts in `samples/server/main.go` (lines 29, 42): `myHandler` and `instrumentedHandler` write `err.Error()` to the response body without a `Content-Type`, so taint analysis treats the request-influenced error text as an XSS sink.
- Sets `Content-Type: text/plain; charset=utf-8` before writing the error body in both handlers.

## Test plan
- [x] `go build ./...` in `samples/server`
- [ ] Confirm the CodeQL alerts close on the next scan